### PR TITLE
refactor: rename project from AuthCrux to FerrisKey and update related files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AuthCrux - Keycloak Light in Rust
+# FerrisKey - Keycloak Light in Rust
 
 ## Project goals
 
-AuthCrux is a lightweight, modular identity management and authentication system designed to offer a simplified alternative to Keycloak, focusing on the essential features of user authentication, authorization and management.
+FerrisKey is a lightweight, modular identity management and authentication system designed to offer a simplified alternative to Keycloak, focusing on the essential features of user authentication, authorization and management.
 
 ### Main objectives:
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,11 +6,11 @@ authors = ["nathaelb <pro.nathaelbonnal@gmail.com>"]
 
 [[bin]]
 path = "src/bin/main.rs"
-name = "authcrux-server"
+name = "ferriskey-server"
 
 [lib]
 path = "src/lib/lib.rs"
-name = "authcrux"
+name = "ferriskey"
 
 [dependencies]
 anyhow = "1.0.97"

--- a/api/env.example
+++ b/api/env.example
@@ -1,2 +1,3 @@
 PORT=3333
 ENV=development
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/ferriskey

--- a/api/src/bin/main.rs
+++ b/api/src/bin/main.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use authcrux::{
+use ferriskey::{
     application::http::{HttpServer, HttpServerConfig},
     domain::{client::service::ClientServiceImpl, realm::service::RealmServiceImpl},
     env::{AppEnv, Env},


### PR DESCRIPTION
- Updated README.md to reflect the new project name, FerrisKey.
- Renamed server and library names in Cargo.toml to match the new project name.
- Modified main.rs to use the new FerrisKey module.
- Added DATABASE_URL to env.example for local development setup.