### PR TITLE
feat: add Docker Compose configuration for PostgreSQL and Keycloak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=authcrux
+      - POSTGRES_DB=ferriskey
     volumes:
       - postgres_data:/var/lib/postgresql/data
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:17
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=authcrux
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  keycloak-db-init:
+    image: postgres:17
+    depends_on:
+      - postgres
+    environment:
+      - PGPASSWORD=postgres
+    command: >
+      bash -c "
+        echo 'Creating keycloak database...' &&
+        psql -h postgres -U postgres -c 'CREATE DATABASE keycloak;' &&
+        echo 'Keycloak database created successfully!'
+      "
+    restart: on-failure
+
+
+  keycloak:
+    image: bitnami/keycloak:26.0.0
+    environment:
+      KEYCLOAK_ADMIN: super
+      KEYCLOAK_ADMIN_PASSWORD: super
+      KEYCLOAK_DATABASE_HOST: postgres
+      KEYCLOAK_DATABASE_PORT: 5432
+      KEYCLOAK_DATABASE_USER: postgres
+      KEYCLOAK_DATABASE_PASSWORD: postgres
+      KEYCLOAK_DATABASE_NAME: keycloak
+    depends_on:
+      - postgres
+    ports:
+      - 8080:8080
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
- Introduced a new docker-compose.yml file to set up PostgreSQL and Keycloak services.
- Configured PostgreSQL with environment variables for user, password, and database.
- Added a service to initialize the Keycloak database after PostgreSQL is ready.
- Set up Keycloak with necessary environment variables for admin credentials and database connection.