### PR TITLE
feat: enhance OpenAPI documentation for realm management

### DIFF
--- a/api/src/lib/application/http.rs
+++ b/api/src/lib/application/http.rs
@@ -3,18 +3,17 @@ use std::sync::Arc;
 use anyhow::Context;
 use axum::Extension;
 use handlers::realm::realm_routes;
+use openapi::ApiDoc;
 use tracing::{info, info_span};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::domain::{client::ports::ClientService, realm::ports::RealmService};
-
-use crate::application::http::handlers::realm::create_realm::__path_create_realm;
-
 use super::state::AppState;
+use crate::domain::{client::ports::ClientService, realm::ports::RealmService};
 
 pub mod errors;
 pub mod handlers;
+pub mod openapi;
 pub mod responses;
 pub mod validation;
 
@@ -28,10 +27,6 @@ impl HttpServerConfig {
         Self { port }
     }
 }
-
-#[derive(OpenApi)]
-#[openapi(paths(create_realm))]
-struct ApiDoc;
 
 pub struct HttpServer {
     router: axum::Router,

--- a/api/src/lib/application/http/handlers/realm.rs
+++ b/api/src/lib/application/http/handlers/realm.rs
@@ -3,12 +3,24 @@ use axum_extra::routing::RouterExt;
 use create_realm::create_realm;
 use delete_realm::delete_realm;
 use get_realm::get_realm;
+use utoipa::OpenApi;
 
 use crate::domain::realm::ports::RealmService;
+
+use create_realm::__path_create_realm;
 
 pub mod create_realm;
 pub mod delete_realm;
 pub mod get_realm;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(create_realm),
+    tags(
+        (name = "realm", description = "Realm management")
+    )
+)]
+pub struct RealmApiDoc;
 
 pub fn realm_routes<R: RealmService>() -> Router {
     Router::new()

--- a/api/src/lib/application/http/handlers/realm/create_realm.rs
+++ b/api/src/lib/application/http/handlers/realm/create_realm.rs
@@ -18,7 +18,8 @@ pub struct CreateRealmRoute;
 
 #[utoipa::path(
     post, 
-    path = "/realms",
+    path = "",
+    tag = "realm",
     responses(
         (status = 201, body = Realm)
     ),

--- a/api/src/lib/application/http/openapi.rs
+++ b/api/src/lib/application/http/openapi.rs
@@ -1,0 +1,15 @@
+use utoipa::OpenApi;
+
+use crate::application::http::handlers::realm::RealmApiDoc;
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "FerrisKey API"
+    ),
+    nest(
+        (path = "/realms", api = RealmApiDoc)
+    )
+
+)]
+pub struct ApiDoc;


### PR DESCRIPTION
- Introduced a new `openapi.rs` file to define API documentation for the FerrisKey API.
- Updated `realm.rs` to include `RealmApiDoc` for realm management endpoints.
- Modified `create_realm.rs` to adjust the OpenAPI path and tag for better documentation clarity.
- Refactored existing code to improve organization and maintainability of API documentation.