### PR TITLE
feat: add release drafter configuration and workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,43 @@
+name-template: 'v$RESOLVED_VERSION 🦀'
+tag-template: 'v$RESOLVED_VERSION'
+tag-prefix: v
+
+categories:
+  - title: 🚀 Features
+    labels:
+      - "type:feature"
+  - title: 🐛 Fixes
+    labels:
+      - "type:bug"
+  - title: 📄 Documentation
+    labels:
+      - "type:docs"
+  - title: 🔄 CI
+    labels:
+      - "type:ci"
+  - title: 🧩 Dependency Updates
+    labels:
+      - "type:build"
+  - title: 🔨 Refactor
+    labels:
+      - "type:refactor"
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - "semver:major"
+  minor:
+    labels:
+      - "semver:minor"
+  patch:
+    labels:
+      - "semver:patch"
+  default: patch
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  frontend:
+    name: "Draft release frontend"
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Introduced a new release drafter configuration file to automate release notes generation based on labels.
- Created a GitHub Actions workflow to draft releases on pushes to the main branch, utilizing the release drafter configuration.