### PR TITLE
refactor: update authentication service and token handling

### DIFF
--- a/api/src/bin/main.rs
+++ b/api/src/bin/main.rs
@@ -50,9 +50,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let realm_repository = PostgresRealmRepository::new(Arc::clone(&postgres));
     let client_repository = PostgresClientRepository::new(Arc::clone(&postgres));
     let hasher_repository = Arc::new(Argon2HasherRepository::new());
-    let authentication_repository = Arc::new(AuthenticationServiceImpl::new(
-        AuthenticationRepositoryImpl::new(Arc::clone(&postgres)),
-    ));
+    let authentication_repository = AuthenticationRepositoryImpl::new(Arc::clone(&postgres));
+    
 
     let realm_service = Arc::new(RealmServiceImpl::new(realm_repository));
 
@@ -60,6 +59,8 @@ async fn main() -> Result<(), anyhow::Error> {
         client_repository,
         Arc::clone(&realm_service),
     ));
+
+    let authentication_service = Arc::new(AuthenticationServiceImpl::new(authentication_repository, Arc::clone(&realm_service)));
 
     let credential_repository = PostgresCredentialRepository::new(Arc::clone(&postgres));
 
@@ -85,7 +86,7 @@ async fn main() -> Result<(), anyhow::Error> {
         realm_service,
         client_service,
         credential_service,
-        authentication_repository,
+        authentication_service,
     )
     .await?;
 

--- a/api/src/lib/application/http/authentication/handlers/token.rs
+++ b/api/src/lib/application/http/authentication/handlers/token.rs
@@ -10,14 +10,14 @@ use crate::domain::authentication::entities::model::JwtToken;
 use crate::domain::authentication::ports::AuthenticationService;
 
 #[derive(TypedPath, Deserialize)]
-#[typed_path("/realms/{name}/oauth2/token")]
+#[typed_path("/realms/{realm_name}/protocol/openid-connect/token")]
 pub struct TokenRoute {
-    name: String,
+    realm_name: String,
 }
 
 #[utoipa::path(
     post,
-    path = "/oauth2/token",
+    path = "/protocol/openid-connect/token",
     tag = "auth",
     request_body = TokenRequestValidator,
     responses(
@@ -25,12 +25,13 @@ pub struct TokenRoute {
     )
 )]
 pub async fn exchange_token<A: AuthenticationService>(
-    _: TokenRoute,
+    TokenRoute { realm_name }: TokenRoute,
     Extension(token_service): Extension<Arc<A>>,
     ValidateJson(payload): ValidateJson<TokenRequestValidator>,
 ) -> Result<Response<JwtToken>, ApiError> {
     token_service
         .authentificate(
+            realm_name,
             payload.grant_type,
             payload.client_id,
             payload.code,

--- a/api/src/lib/application/http/server/http_server.rs
+++ b/api/src/lib/application/http/server/http_server.rs
@@ -1,8 +1,5 @@
-<<<<<<< HEAD
 use crate::application::http::auth::router::auth_router;
-=======
 use crate::application::http::authentication::router::authentication_routes;
->>>>>>> 8890145 (feat: implement exchange_token route)
 use crate::application::http::client::router::client_routes;
 use crate::application::http::realm::router::realm_routes;
 use crate::application::http::server::app_state::AppState;
@@ -16,7 +13,6 @@ use anyhow::Context;
 use axum::http::header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE};
 use axum::http::{HeaderValue, Method};
 use axum::{Extension, Router};
-use axum_extra::headers::Origin;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 use tracing::info_span;

--- a/api/src/lib/domain/authentication/ports.rs
+++ b/api/src/lib/domain/authentication/ports.rs
@@ -1,3 +1,5 @@
+use uuid::Uuid;
+
 use super::entities::{
     error::AuthenticationError,
     model::{GrantType, JwtToken},
@@ -13,7 +15,7 @@ pub trait AuthenticationRepository: Clone + Send + Sync + 'static {
 
     async fn using_password(
         &self,
-        client_id: String,
+        user_id: Uuid,
         username: String,
         password: String,
     ) -> Result<JwtToken, AuthenticationError>;
@@ -35,6 +37,7 @@ pub trait AuthenticationService: Clone + Send + Sync + 'static {
 
     async fn using_password(
         &self,
+        realm_id: Uuid,
         username: String,
         password: String,
     ) -> Result<JwtToken, AuthenticationError>;
@@ -47,6 +50,7 @@ pub trait AuthenticationService: Clone + Send + Sync + 'static {
 
     async fn authentificate(
         &self,
+        realm_name: String,
         grant_type: GrantType,
         client_id: String,
         code: Option<String>,

--- a/api/src/lib/domain/authentication/service.rs
+++ b/api/src/lib/domain/authentication/service.rs
@@ -1,31 +1,41 @@
+use std::sync::Arc;
+
+use crate::domain::realm::ports::RealmService;
+
 use super::entities::error::AuthenticationError;
 use super::entities::model::{GrantType, JwtToken};
 use super::ports::{AuthenticationRepository, AuthenticationService};
 use async_trait::async_trait;
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
-pub struct AuthenticationServiceImpl<A: Clone + Send + Sync + 'static>
+pub struct AuthenticationServiceImpl<A: Clone + Send + Sync + 'static, R>
 where
     A: AuthenticationRepository,
+    R: RealmService,
 {
     pub authentication_repository: A,
+    pub realm_service: Arc<R>
 }
 
-impl<A> AuthenticationServiceImpl<A>
+impl<A, R> AuthenticationServiceImpl<A, R>
 where
     A: AuthenticationRepository,
+    R: RealmService,
 {
-    pub fn new(authentication_repository: A) -> Self {
+    pub fn new(authentication_repository: A, realm_service: Arc<R>) -> Self {
         Self {
             authentication_repository,
+            realm_service,
         }
     }
 }
 
 #[async_trait]
-impl<A> AuthenticationService for AuthenticationServiceImpl<A>
+impl<A, R> AuthenticationService for AuthenticationServiceImpl<A, R>
 where
     A: AuthenticationRepository,
+    R: RealmService,
 {
     async fn using_code(
         &self,
@@ -39,11 +49,12 @@ where
 
     async fn using_password(
         &self,
+        user_id: Uuid,
         username: String,
         password: String,
     ) -> Result<JwtToken, AuthenticationError> {
         self.authentication_repository
-            .using_password(username, password)
+            .using_password(user_id, username, password)
             .await
     }
 
@@ -59,16 +70,18 @@ where
 
     async fn authentificate(
         &self,
+        realm_name: String,
         grant_type: GrantType,
         client_id: String,
         code: Option<String>,
         username: Option<String>,
         password: Option<String>,
     ) -> Result<JwtToken, AuthenticationError> {
+        let realm = self.realm_service.get_by_name(realm_name).await.map_err(|_| AuthenticationError::InternalServerError)?;
         match grant_type {
             GrantType::Code => self.using_code(client_id, code.unwrap()).await,
             GrantType::Password => {
-                self.using_password(username.unwrap(), password.unwrap())
+                self.using_password(realm.id, username.unwrap(), password.unwrap())
                     .await
             }
             GrantType::Credentials => {

--- a/api/src/lib/infrastructure/repositories/authentication_repository.rs
+++ b/api/src/lib/infrastructure/repositories/authentication_repository.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use uuid::Uuid;
 use std::sync::Arc;
 
 use crate::domain::authentication::{
@@ -36,7 +37,7 @@ impl AuthenticationRepository for AuthenticationRepositoryImpl {
 
     async fn using_password(
         &self,
-        client_id: String,
+        user_id: Uuid,
         username: String,
         password: String,
     ) -> Result<JwtToken, AuthenticationError> {


### PR DESCRIPTION
- Simplified the instantiation of the `AuthenticationServiceImpl` by directly passing the `AuthenticationRepositoryImpl` and `RealmService`.
- Updated the `TokenRoute` struct to use `realm_name` instead of `name` for clarity in the token exchange endpoint.
- Modified the `exchange_token` function to accept the new `realm_name` parameter and adjusted the authentication logic accordingly.
- Enhanced method signatures in the `AuthenticationService` and `AuthenticationRepository` to include `user_id` and `realm_name` for improved functionality.