### PR TITLE
fix: Update JWT service to use claims for generating refresh tokens

### DIFF
--- a/api/src/lib/domain/authentication/grant_type_strategies/authorization_code_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/authorization_code_strategy.rs
@@ -73,13 +73,13 @@ impl GrantTypeStrategy for AuthorizationCodeStrategy {
 
         let jwt = self
             .jwt_service
-            .generate_token(claims)
+            .generate_token(claims.clone())
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 
         let refresh_token = self
             .jwt_service
-            .generate_refresh_token(user.id)
+            .generate_refresh_token(claims.clone())
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 

--- a/api/src/lib/domain/authentication/grant_type_strategies/authorization_code_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/authorization_code_strategy.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use chrono::{TimeZone, Utc};
+
 use crate::domain::{
     authentication::{
         entities::{error::AuthenticationError, jwt_token::JwtToken},
@@ -13,7 +15,7 @@ use crate::domain::{
     credential::services::credential_service::DefaultCredentialService,
     jwt::{
         entities::jwt_claim::{ClaimsTyp, JwtClaim},
-        ports::jwt_service::JwtService,
+        ports::{jwt_repository::RefreshTokenRepository, jwt_service::JwtService},
         services::jwt_service::DefaultJwtService,
     },
     user::{ports::user_service::UserService, services::user_service::DefaultUserService},
@@ -48,9 +50,11 @@ impl AuthorizationCodeStrategy {
 
 impl GrantTypeStrategy for AuthorizationCodeStrategy {
     async fn execute(&self, params: GrantTypeParams) -> Result<JwtToken, AuthenticationError> {
+        let code = params.code.ok_or(AuthenticationError::Invalid)?;
+
         let auth_session = self
             .auth_session_service
-            .get_by_code(params.code.unwrap())
+            .get_by_code(code)
             .await
             .map_err(|_| AuthenticationError::Invalid)?;
 
@@ -77,9 +81,26 @@ impl GrantTypeStrategy for AuthorizationCodeStrategy {
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 
+        let refresh_claims = JwtClaim::new_refresh_token(
+            claims.sub.clone(),
+            claims.iss.clone(),
+            claims.aud.clone(),
+            claims.azp.clone(),
+        );
+
         let refresh_token = self
             .jwt_service
-            .generate_refresh_token(claims.clone())
+            .generate_refresh_token(refresh_claims.clone())
+            .await
+            .map_err(|_| AuthenticationError::InternalServerError)?;
+
+        self.jwt_service
+            .refresh_token_repository
+            .create(
+                refresh_claims.jti,
+                user.id,
+                Some(Utc.timestamp_opt(refresh_token.expires_at, 0).unwrap()),
+            )
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 

--- a/api/src/lib/domain/authentication/grant_type_strategies/client_credentials_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/client_credentials_strategy.rs
@@ -72,13 +72,13 @@ impl GrantTypeStrategy for ClientCredentialsStrategy {
 
                 let jwt = self
                     .jwt_service
-                    .generate_token(claims)
+                    .generate_token(claims.clone())
                     .await
                     .map_err(|_| AuthenticationError::InternalServerError)?;
 
                 let refresh_token = self
                     .jwt_service
-                    .generate_refresh_token(user.id)
+                    .generate_refresh_token(claims.clone())
                     .await
                     .map_err(|_| AuthenticationError::InternalServerError)?;
 

--- a/api/src/lib/domain/authentication/grant_type_strategies/client_credentials_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/client_credentials_strategy.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use chrono::{TimeZone, Utc};
 use tracing::info;
 
 use crate::domain::{
@@ -12,7 +13,7 @@ use crate::domain::{
     },
     jwt::{
         entities::jwt_claim::{ClaimsTyp, JwtClaim},
-        ports::jwt_service::JwtService,
+        ports::{jwt_repository::RefreshTokenRepository, jwt_service::JwtService},
         services::jwt_service::DefaultJwtService,
     },
     user::{ports::user_service::UserService, services::user_service::DefaultUserService},
@@ -76,9 +77,26 @@ impl GrantTypeStrategy for ClientCredentialsStrategy {
                     .await
                     .map_err(|_| AuthenticationError::InternalServerError)?;
 
+                let refresh_claims = JwtClaim::new_refresh_token(
+                    claims.sub.clone(),
+                    claims.iss.clone(),
+                    claims.aud.clone(),
+                    claims.azp.clone(),
+                );
+
                 let refresh_token = self
                     .jwt_service
-                    .generate_refresh_token(claims.clone())
+                    .generate_refresh_token(refresh_claims.clone())
+                    .await
+                    .map_err(|_| AuthenticationError::InternalServerError)?;
+
+                self.jwt_service
+                    .refresh_token_repository
+                    .create(
+                        refresh_claims.jti,
+                        user.id,
+                        Some(Utc.timestamp_opt(refresh_token.expires_at, 0).unwrap()),
+                    )
                     .await
                     .map_err(|_| AuthenticationError::InternalServerError)?;
 

--- a/api/src/lib/domain/authentication/grant_type_strategies/password_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/password_strategy.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use chrono::{TimeZone, Utc};
 use tracing::info;
 
 use crate::domain::{
@@ -13,7 +14,7 @@ use crate::domain::{
     },
     jwt::{
         entities::jwt_claim::{ClaimsTyp, JwtClaim},
-        ports::jwt_service::JwtService,
+        ports::{jwt_repository::RefreshTokenRepository, jwt_service::JwtService},
         services::jwt_service::DefaultJwtService,
     },
     user::{ports::user_service::UserService, services::user_service::DefaultUserService},
@@ -80,9 +81,26 @@ impl GrantTypeStrategy for PasswordStrategy {
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 
+        let refresh_claims = JwtClaim::new_refresh_token(
+            claims.sub.clone(),
+            claims.iss.clone(),
+            claims.aud.clone(),
+            claims.azp.clone(),
+        );
+
         let refresh_token = self
             .jwt_service
-            .generate_refresh_token(claims.clone())
+            .generate_refresh_token(refresh_claims.clone())
+            .await
+            .map_err(|_| AuthenticationError::InternalServerError)?;
+
+        self.jwt_service
+            .refresh_token_repository
+            .create(
+                refresh_claims.jti,
+                user.id,
+                Some(Utc.timestamp_opt(refresh_token.expires_at, 0).unwrap()),
+            )
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 

--- a/api/src/lib/domain/authentication/grant_type_strategies/password_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/password_strategy.rs
@@ -76,13 +76,13 @@ impl GrantTypeStrategy for PasswordStrategy {
 
         let jwt = self
             .jwt_service
-            .generate_token(claims)
+            .generate_token(claims.clone())
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 
         let refresh_token = self
             .jwt_service
-            .generate_refresh_token(user.id)
+            .generate_refresh_token(claims.clone())
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 

--- a/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
 use tracing::{info, warn};
-use utoipa::openapi::info;
 
 use crate::domain::{
     authentication::{
@@ -45,16 +44,13 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
 
         let claims = self
             .jwt_service
-            .verify_token(refresh_token)
+            .verify_refresh_token(refresh_token)
             .await
             .map_err(|_| AuthenticationError::InvalidRefreshToken)?;
 
         if claims.typ != ClaimsTyp::Refresh {
             return Err(AuthenticationError::InvalidRefreshToken);
         }
-
-        warn!("claims: {:?}", claims);
-        warn!("params: {:?}", params.client_id);
 
         if claims.azp != params.client_id {
             info!("Invalid client_id: {:?}", claims.azp);

--- a/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::domain::{
     authentication::{
@@ -49,6 +49,7 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
             .map_err(|_| AuthenticationError::InvalidRefreshToken)?;
 
         if claims.typ != ClaimsTyp::Refresh {
+            info!("Invalid token type: {:?}", claims.typ);
             return Err(AuthenticationError::InvalidRefreshToken);
         }
 
@@ -56,6 +57,7 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
         warn!("params: {:?}", params.client_id);
 
         if claims.azp != params.client_id {
+            info!("Invalid client_id: {:?}", claims.azp);
             return Err(AuthenticationError::InvalidRefreshToken);
         }
 
@@ -65,7 +67,7 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
             .await
             .map_err(|_| AuthenticationError::InvalidRefreshToken)?;
 
-        let claims = JwtClaim::new(
+        let new_claims = JwtClaim::new(
             user.id,
             user.username,
             "http://localhost:3333/realms/master".to_string(),
@@ -80,9 +82,16 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 
+        let refresh_claims = JwtClaim::new_refresh_token(
+            new_claims.sub.clone(),
+            new_claims.iss.clone(),
+            new_claims.aud.clone(),
+            new_claims.azp.clone(),
+        );
+
         let refresh_token = self
             .jwt_service
-            .generate_refresh_token(claims.clone())
+            .generate_refresh_token(refresh_claims.clone())
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 
@@ -95,7 +104,7 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
         self.jwt_service
             .refresh_token_repository
             .create(
-                claims.jti,
+                refresh_claims.jti.clone(),
                 user.id,
                 Some(Utc.timestamp_opt(refresh_token.expires_at, 0).unwrap()),
             )

--- a/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
 use tracing::{info, warn};
+use utoipa::openapi::info;
 
 use crate::domain::{
     authentication::{
@@ -49,7 +50,6 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
             .map_err(|_| AuthenticationError::InvalidRefreshToken)?;
 
         if claims.typ != ClaimsTyp::Refresh {
-            info!("Invalid token type: {:?}", claims.typ);
             return Err(AuthenticationError::InvalidRefreshToken);
         }
 

--- a/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
@@ -82,7 +82,7 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
 
         let refresh_token = self
             .jwt_service
-            .generate_refresh_token(user.id)
+            .generate_refresh_token(claims.clone())
             .await
             .map_err(|_| AuthenticationError::InternalServerError)?;
 

--- a/api/src/lib/domain/jwt/entities/jwt_claim.rs
+++ b/api/src/lib/domain/jwt/entities/jwt_claim.rs
@@ -41,7 +41,7 @@ impl JwtClaim {
             preferred_username: Some(preferred_username),
             iat: chrono::Utc::now().timestamp(),
             jti: Uuid::new_v4(),
-            exp: Some(chrono::Utc::now().timestamp() + 3600),
+            exp: Some(chrono::Utc::now().timestamp() + 3600), // 1 hour
             iss,
             aud,
             typ,
@@ -60,7 +60,7 @@ impl JwtClaim {
             typ: ClaimsTyp::Refresh,
             azp,
             preferred_username: None,
-            exp: None,
+            exp: Some(chrono::Utc::now().timestamp() + 86400), // 24 hours
             client_id: None,
         }
     }

--- a/api/src/lib/domain/jwt/ports/jwt_repository.rs
+++ b/api/src/lib/domain/jwt/ports/jwt_repository.rs
@@ -25,6 +25,6 @@ pub trait RefreshTokenRepository: Clone + Send + Sync + 'static {
         user_id: Uuid,
         expires_at: Option<DateTime<Utc>>,
     ) -> impl Future<Output = Result<RefreshToken, JwtError>> + Send;
-    fn is_valid(&self, jti: Uuid) -> impl Future<Output = Result<bool, JwtError>> + Send;
+    fn get_by_jti(&self, jti: Uuid) -> impl Future<Output = Result<RefreshToken, JwtError>> + Send;
     fn delete(&self, jti: Uuid) -> impl Future<Output = Result<(), JwtError>> + Send;
 }

--- a/api/src/lib/domain/jwt/ports/jwt_repository.rs
+++ b/api/src/lib/domain/jwt/ports/jwt_repository.rs
@@ -25,5 +25,6 @@ pub trait RefreshTokenRepository: Clone + Send + Sync + 'static {
         user_id: Uuid,
         expires_at: Option<DateTime<Utc>>,
     ) -> impl Future<Output = Result<RefreshToken, JwtError>> + Send;
+    fn is_valid(&self, jti: Uuid) -> impl Future<Output = Result<bool, JwtError>> + Send;
     fn delete(&self, jti: Uuid) -> impl Future<Output = Result<(), JwtError>> + Send;
 }

--- a/api/src/lib/domain/jwt/ports/jwt_service.rs
+++ b/api/src/lib/domain/jwt/ports/jwt_service.rs
@@ -15,6 +15,6 @@ pub trait JwtService: Clone + Send + Sync + 'static {
 
     fn generate_refresh_token(
         &self,
-        user_id: Uuid,
+        claims: JwtClaim,
     ) -> impl Future<Output = Result<Jwt, JwtError>> + Send;
 }

--- a/api/src/lib/domain/jwt/ports/jwt_service.rs
+++ b/api/src/lib/domain/jwt/ports/jwt_service.rs
@@ -13,6 +13,11 @@ pub trait JwtService: Clone + Send + Sync + 'static {
         token: String,
     ) -> impl Future<Output = Result<JwtClaim, JwtError>> + Send;
 
+    fn verify_refresh_token(
+        &self,
+        token: String,
+    ) -> impl Future<Output = Result<JwtClaim, JwtError>> + Send;
+
     fn generate_refresh_token(
         &self,
         claims: JwtClaim,

--- a/api/src/lib/domain/jwt/services/jwt_service.rs
+++ b/api/src/lib/domain/jwt/services/jwt_service.rs
@@ -36,14 +36,12 @@ impl<JR: JwtRepository, RR: RefreshTokenRepository> JwtService for JwtServiceImp
         self.jwt_repository.verify_token(token).await
     }
 
-    async fn generate_refresh_token(&self, user_id: Uuid) -> Result<Jwt, JwtError> {
-        let claims = JwtClaim::new_refresh_token(
-            user_id,
-            "http://localhost:3333/realms/master".to_string(),
-            vec!["master-realm".to_string(), "account".to_string()],
-            "master-realm".to_string(),
-        );
+    async fn generate_refresh_token(&self, claims: JwtClaim) -> Result<Jwt, JwtError> {
+        let refresh_claims =
+            JwtClaim::new_refresh_token(claims.sub, claims.iss, claims.aud, claims.azp);
 
-        self.jwt_repository.generate_jwt_token(&claims).await
+        self.jwt_repository
+            .generate_jwt_token(&refresh_claims)
+            .await
     }
 }

--- a/api/src/lib/domain/jwt/services/jwt_service.rs
+++ b/api/src/lib/domain/jwt/services/jwt_service.rs
@@ -36,10 +36,7 @@ impl<JR: JwtRepository, RR: RefreshTokenRepository> JwtService for JwtServiceImp
         self.jwt_repository.verify_token(token).await
     }
 
-    async fn generate_refresh_token(&self, claims: JwtClaim) -> Result<Jwt, JwtError> {
-        let refresh_claims =
-            JwtClaim::new_refresh_token(claims.sub, claims.iss, claims.aud, claims.azp);
-
+    async fn generate_refresh_token(&self, refresh_claims: JwtClaim) -> Result<Jwt, JwtError> {
         self.jwt_repository
             .generate_jwt_token(&refresh_claims)
             .await

--- a/api/src/lib/infrastructure/repositories/jwt_repository.rs
+++ b/api/src/lib/infrastructure/repositories/jwt_repository.rs
@@ -45,6 +45,7 @@ impl JwtRepository for StaticJwtRepository {
             .map_err(|e| JwtError::GenerationError(e.to_string()))?;
 
         let exp = claims.exp.unwrap_or(0);
+
         Ok(Jwt {
             token,
             expires_at: exp,


### PR DESCRIPTION
This pull request introduces several key updates to the authentication system, primarily focused on enhancing refresh token management and improving token verification. The changes include adding support for refresh token claims, implementing stricter validation for refresh tokens, and extending repository and service interfaces to handle refresh tokens more effectively.

### Refresh Token Enhancements:

* Added a `get_by_jti` method to the `RefreshTokenRepository` trait, enabling retrieval of refresh tokens by their unique identifier (`jti`). This is implemented in the `PostgresRefreshTokenRepository` class. [[1]](diffhunk://#diff-72d755641f56072532e65d42725a0c3adce638c7aa2e7a32c3ac9ad76298d831R28) [[2]](diffhunk://#diff-c7f82d93862d2c337e479f2a2f5666d55101efff04ab38225997b7b6f8b65bebR67-R77)
* Modified `JwtService` to include a `verify_refresh_token` method for validating refresh tokens, ensuring they are not revoked and have not expired. [[1]](diffhunk://#diff-26b45b601fad761919ee08b552f259f73aee9f4a95e58840747a233dbaef1268R16-R23) [[2]](diffhunk://#diff-55a653f5f701d6c1cd91dc43afee49c69c34b145fb07690e92f57ea2ba1ef08fL39-R60)
* Updated refresh token creation logic across grant type strategies (`AuthorizationCodeStrategy`, `ClientCredentialsStrategy`, `PasswordStrategy`, and `RefreshTokenStrategy`) to use claims-based refresh tokens and store them in the repository. [[1]](diffhunk://#diff-9aeaa5ec79488fd2633542f47a05840dc292d200ef20165732c1d0b524cb3146L76-R103) [[2]](diffhunk://#diff-0efee62507564b26e60201b566ccb575d188f1066f16fd357bb0eb6fabc45c39L75-R99) [[3]](diffhunk://#diff-533fefff37302deec2bc3006629082888315731bce42d55072618a0cbf86fc29L79-R103) [[4]](diffhunk://#diff-93f7f2affbf0ea7f45ee13fc66a5b3e39994012e02151f26e7b5782cfdfab092R81-R90) [[5]](diffhunk://#diff-93f7f2affbf0ea7f45ee13fc66a5b3e39994012e02151f26e7b5782cfdfab092L98-R103)

### JWT Claim Adjustments:

* Updated `JwtClaim` to set expiration times for refresh tokens (24 hours) and access tokens (1 hour). [[1]](diffhunk://#diff-2d768a3a53a9540fde419e490df280d438af4e1c0d14912e11010d199e6600d4L44-R44) [[2]](diffhunk://#diff-2d768a3a53a9540fde419e490df280d438af4e1c0d14912e11010d199e6600d4L63-R63)
* Introduced the `JwtClaim::new_refresh_token` method in grant type strategies to generate claims specifically for refresh tokens. [[1]](diffhunk://#diff-9aeaa5ec79488fd2633542f47a05840dc292d200ef20165732c1d0b524cb3146L76-R103) [[2]](diffhunk://#diff-0efee62507564b26e60201b566ccb575d188f1066f16fd357bb0eb6fabc45c39L75-R99) [[3]](diffhunk://#diff-533fefff37302deec2bc3006629082888315731bce42d55072618a0cbf86fc29L79-R103) [[4]](diffhunk://#diff-93f7f2affbf0ea7f45ee13fc66a5b3e39994012e02151f26e7b5782cfdfab092R81-R90)

### Codebase Improvements:

* Enhanced error handling and logging in `RefreshTokenStrategy` to provide better insights into invalid tokens and client mismatches. [[1]](diffhunk://#diff-93f7f2affbf0ea7f45ee13fc66a5b3e39994012e02151f26e7b5782cfdfab092L47-R56) [[2]](diffhunk://#diff-93f7f2affbf0ea7f45ee13fc66a5b3e39994012e02151f26e7b5782cfdfab092L68-R66)
* Simplified and clarified the `generate_refresh_token` method in `JwtService`, removing hardcoded values and relying on passed-in claims.

These changes collectively improve the security and maintainability of the token-based authentication system.