### PR TITLE
feat: refactor get_user_realms to improve realm handling and update realm-switcher navigation

### DIFF
--- a/api/src/lib/application/http/realm/handlers/get_user_realms.rs
+++ b/api/src/lib/application/http/realm/handlers/get_user_realms.rs
@@ -42,7 +42,7 @@ pub struct UserRealmsResponse {
     )
 )]
 pub async fn get_user_realms(
-    GetUserRealmsRoute { realm_name }: GetUserRealmsRoute,
+    _: GetUserRealmsRoute,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Response<UserRealmsResponse>, ApiError> {
@@ -54,9 +54,14 @@ pub async fn get_user_realms(
             .await
             .map_err(|_| ApiError::Forbidden("Client not found".to_string()))?,
     };
+
+    let realm = user.realm.clone().ok_or(ApiError::Forbidden(
+        "User does not belong to any realm".to_string(),
+    ))?;
+
     let realms = state
         .user_service
-        .get_user_realms(user, realm_name)
+        .get_user_realms(user, realm.name)
         .await
         .map_err(|_| ApiError::Forbidden("User not found".to_string()))?;
 

--- a/front/src/components/realm-switcher.tsx
+++ b/front/src/components/realm-switcher.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router"
+import { useNavigate, useParams } from "react-router"
 
 import {
   DropdownMenu,
@@ -34,16 +34,23 @@ import { FormField } from '@/components/ui/form.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { useCreateRealm } from '@/api/realm.api.ts'
 import { toast } from 'sonner'
+import { REALM_OVERVIEW_URL, REALM_URL } from "@/routes/router"
 
 
 export default function RealmSwitcher() {
   const { realm_name } = useParams<{ realm_name: string }>()
+  const navigate = useNavigate()
   const { isMobile } = useSidebar()
   const [open, setOpen] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [activeRealm, setActiveRealm] = useState<Realm | null>(null)
   const [_, setHasRealmMaster] = useState(false)
   const { userRealms } = useRealmStore()
+
+  const handleClick = (realm: Realm) => {
+    setActiveRealm(realm)
+    navigate(`${REALM_URL(realm.name)}${REALM_OVERVIEW_URL}`)
+  }
 
 
   useEffect(() => {
@@ -96,7 +103,7 @@ export default function RealmSwitcher() {
               {userRealms.map((realm, index) => (
                 <DropdownMenuItem
                   key={realm.name}
-                  onClick={() => setActiveRealm(realm)}
+                  onClick={() => handleClick(realm)}
                   className="gap-2 p-2"
                 >
                   <div className="flex size-6 items-center justify-center rounded-md border">


### PR DESCRIPTION
This pull request introduces changes to improve realm handling in both the backend and frontend. Key updates include refining realm-related logic in the `get_user_realms` handler, and enhancing the `RealmSwitcher` component to support navigation to realm-specific pages.

### Backend Updates:
* **Refactored `get_user_realms` handler**:
  - Removed unused `realm_name` parameter from `GetUserRealmsRoute`.
  - Added logic to ensure that the user belongs to a realm before proceeding, with appropriate error handling.

### Frontend Updates:
* **Enhanced `RealmSwitcher` Component**:
  - Added `useNavigate` for programmatic navigation and updated imports accordingly.
  - Introduced `REALM_URL` and `REALM_OVERVIEW_URL` constants for constructing realm-specific URLs.
  - Implemented a `handleClick` function to navigate to the selected realm's overview page, replacing direct state updates in dropdown menu items.