### PR TITLE
docs: add issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature.yml
+++ b/.github/ISSUE_TEMPLATE/1-feature.yml
@@ -1,7 +1,7 @@
 # Feature Request Template
 name: 💡 Feature Request
 description: Suggest an idea for this project
-labels: [ "enhancement" ]
+labels: [ "type:feature" ]
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/2-refactor.yml
+++ b/.github/ISSUE_TEMPLATE/2-refactor.yml
@@ -1,7 +1,7 @@
 # Refactor Template
 name: 🔧 Refactor Request
 description: Propose a code refactoring
-labels: [ "refactor" ]
+labels: [ "type:refactor" ]
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -1,7 +1,7 @@
 # Documentation Template
 name: 📚 Documentation
 description: Report an issue or suggest an improvement for the documentation
-labels: [ "documentation" ]
+labels: [ "type:doc" ]
 body:
 - type: dropdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/4-bug.yml
+++ b/.github/ISSUE_TEMPLATE/4-bug.yml
@@ -1,7 +1,7 @@
 # Bug Report Template
 name: 🐛 Bug Report
 description: Report a bug to help us improve the project
-labels: [ "bug" ]
+labels: [ "type:bug" ]
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
To facilitate contributions and standardize issues, it would be beneficial to add issue templates. This will help contributors better structure their requests and provide all necessary information from the start.

LInked to this issue: https://github.com/ferriskey/ferriskey/issues/155