### PR TITLE
feat: iinitialise a page to create a role

### DIFF
--- a/api/src/lib/application/http/role/validators.rs
+++ b/api/src/lib/application/http/role/validators.rs
@@ -11,7 +11,7 @@ use crate::domain::role::entities::CreateRoleDto;
 pub struct CreateRoleValidator {
     pub name: String,
     pub description: Option<String>,
-    pub permissions: i32,
+    pub permissions: Vec<String>,
 }
 
 impl CreateRoleValidator {

--- a/api/src/lib/domain/mediator/services/mediator_service.rs
+++ b/api/src/lib/domain/mediator/services/mediator_service.rs
@@ -189,7 +189,7 @@ impl MediatorService for MediatorServiceImpl {
             .create(CreateRoleDto {
                 client_id: Some(master_realm_client.id),
                 name: "master-realm".to_string(),
-                permissions: Permissions::ManageRealm as i32,
+                permissions: Permissions::to_names(&[Permissions::ManageRealm]),
                 realm_id: realm.id,
                 description: None,
             })

--- a/api/src/lib/domain/realm/services/realm_service.rs
+++ b/api/src/lib/domain/realm/services/realm_service.rs
@@ -109,10 +109,13 @@ where
             .map_err(|_| RealmError::InternalServerError)?;
 
         // Create role for client
-        let permissions: i32 = Permissions::ManageRealm as i32
-            | Permissions::ManageClients as i32
-            | Permissions::ManageRoles as i32
-            | Permissions::ManageUsers as i32;
+        let permissions = Permissions::to_names(&[
+            Permissions::ManageRealm,
+            Permissions::ManageClients,
+            Permissions::ManageRoles,
+            Permissions::ManageUsers,
+        ]);
+
         let role = self
             .role_repository
             .create(CreateRoleDto {

--- a/api/src/lib/domain/role/entities.rs
+++ b/api/src/lib/domain/role/entities.rs
@@ -11,7 +11,7 @@ pub mod permission;
 pub struct CreateRoleDto {
     pub name: String,
     pub description: Option<String>,
-    pub permissions: i32,
+    pub permissions: Vec<String>,
     #[typeshare(serialized_as = "string")]
     pub realm_id: Uuid,
     #[typeshare(serialized_as = "string", optional)]

--- a/api/src/lib/domain/role/entities/permission.rs
+++ b/api/src/lib/domain/role/entities/permission.rs
@@ -133,6 +133,20 @@ impl Permissions {
             _ => None,
         }
     }
+
+    pub fn from_names(names: &[String]) -> Vec<Self> {
+        names
+            .iter()
+            .filter_map(|name| Self::from_name(name))
+            .collect()
+    }
+
+    pub fn to_names(permissions: &[Self]) -> Vec<String> {
+        permissions
+            .iter()
+            .map(|permission| permission.name())
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/api/src/lib/infrastructure/repositories/role_repository.rs
+++ b/api/src/lib/infrastructure/repositories/role_repository.rs
@@ -48,11 +48,14 @@ impl PostgresRoleRepository {
 impl RoleRepository for PostgresRoleRepository {
     async fn create(&self, payload: CreateRoleDto) -> Result<Role, RoleError> {
         let id = generate_uuid_v7();
+        let permissions = Permissions::from_names(&payload.permissions);
+        let bitfield = Permissions::to_bitfield(&permissions);
+
         let model = entity::roles::ActiveModel {
             id: Set(id),
             name: Set(payload.name),
             description: Set(payload.description),
-            permissions: Set(payload.permissions as i64),
+            permissions: Set(bitfield as i64),
             realm_id: Set(payload.realm_id),
             client_id: Set(payload.client_id),
             created_at: Set(Utc::now().naive_utc()),

--- a/front/package.json
+++ b/front/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.7",
     "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.2.2",
     "@radix-ui/react-switch": "^1.2.5",

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.2
         version: 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.2.9
+        version: 1.2.9(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-separator':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -414,6 +417,9 @@ packages:
   '@pkgr/core@0.1.2':
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
@@ -855,6 +861,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.9':
     resolution: {integrity: sha512-ZzrIFnMYHHCNqSNCsuN6l7wlewBEq0O0BCSBkabJMFXVO51LRUTq71gLP1UxFvmrXElqmPjA5VX7IqC9VpazAQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.9':
+    resolution: {integrity: sha512-YSjEfBXnhUELsO2VzjdtYYD4CfQjvao+lhhrX5XsHD7/cyUNzljF1FHEbgTPN7LH2MClfwRMIsYlqTYpKTTe2A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3071,6 +3090,8 @@ snapshots:
 
   '@pkgr/core@0.1.2': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.1': {}
 
   '@radix-ui/primitive@1.1.2': {}
@@ -3487,6 +3508,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.12)(react@19.1.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.12)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
+      '@types/react-dom': 19.0.4(@types/react@19.0.12)
+
+  '@radix-ui/react-scroll-area@1.2.9(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.12)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.12)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.12)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.12)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.12)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:

--- a/front/src/api/api.interface.ts
+++ b/front/src/api/api.interface.ts
@@ -45,7 +45,7 @@ export interface ClientsResponse {
 export interface CreateRoleDto {
 	name: string;
 	description?: string;
-	permissions: number;
+	permissions: string[];
 	realm_id: string;
 	client_id: string;
 }
@@ -53,7 +53,7 @@ export interface CreateRoleDto {
 export interface CreateRoleValidator {
 	name: string;
 	description?: string;
-	permissions: number;
+	permissions: string[];
 }
 
 export interface Role {

--- a/front/src/components/ui/scroll-area.tsx
+++ b/front/src/components/ui/scroll-area.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/front/src/pages/role/feature/create-role-modal-feature.tsx
+++ b/front/src/pages/role/feature/create-role-modal-feature.tsx
@@ -4,12 +4,14 @@ import BadgeColor, { BadgeColorScheme } from "@/components/ui/badge-color";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { InputText } from "@/components/ui/input-text";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { createRoleSchema, CreateRoleSchema } from "../schemas/create-role.schema";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 export default function CreateRoleModalFeature() {
   const [selectedPermissions, setSelectedPermissions] = useState<Permissions[]>([]);
@@ -21,6 +23,15 @@ export default function CreateRoleModalFeature() {
         : [...prev, permission]
     );
   };
+
+  const form = useForm<CreateRoleSchema>({
+    resolver: zodResolver(createRoleSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+      permissions: []
+    }
+  })
 
   const permissionsList = Object.values(Permissions).filter(value => typeof value === 'string');
 

--- a/front/src/pages/role/feature/create-role-modal-feature.tsx
+++ b/front/src/pages/role/feature/create-role-modal-feature.tsx
@@ -1,38 +1,224 @@
+import { Permissions } from "@/api/api.interface";
+import { Badge } from "@/components/ui/badge";
+import BadgeColor, { BadgeColorScheme } from "@/components/ui/badge-color";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { InputText } from "@/components/ui/input-text";
 import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { useState } from "react";
 
 export default function CreateRoleModalFeature() {
+  const [selectedPermissions, setSelectedPermissions] = useState<Permissions[]>([]);
+
+  const handlePermissionToggle = (permission: Permissions) => {
+    setSelectedPermissions(prev => 
+      prev.includes(permission) 
+        ? prev.filter(p => p !== permission)
+        : [...prev, permission]
+    );
+  };
+
+  const permissionsList = Object.values(Permissions).filter(value => typeof value === 'string');
+
+  const handleSelectAllInGroup = (groupPermissions: Permissions[]) => {
+    const allSelected = groupPermissions.every(perm => selectedPermissions.includes(perm))
+
+    if (allSelected) {
+      setSelectedPermissions(prev => prev.filter(perm => !groupPermissions.includes(perm)))
+    } else {
+      setSelectedPermissions(prev => {
+        const newPerms = [...prev]
+        groupPermissions.forEach(perm => {
+          if (!newPerms.includes(perm)) {
+            newPerms.push(perm)
+          }
+        })
+
+        return newPerms
+      })
+    }
+  }
+
+  const permissionGroups = {
+    "User Management": [
+      Permissions.ManageUsers,
+      Permissions.ViewUsers,
+      Permissions.QueryUsers,
+    ],
+    "Client Management": [
+      Permissions.CreateClient,
+      Permissions.ManageClients,
+      Permissions.ViewClients,
+      Permissions.QueryClients,
+    ],
+    "Role & Authorization": [
+      Permissions.ManageRoles,
+      Permissions.ViewRoles,
+      Permissions.ManageAuthorization,
+      Permissions.ViewAuthorization,
+    ],
+    "Realm Management": [
+      Permissions.ManageRealm,
+      Permissions.ViewRealm,
+      Permissions.QueryRealms,
+    ],
+    "Identity Providers": [
+      Permissions.ManageIdentityProviders,
+      Permissions.ViewIdentityProviders,
+    ],
+    "Events & Audit": [
+      Permissions.ManageEvents,
+      Permissions.ViewEvents,
+    ],
+    "Groups": [
+      Permissions.QueryGroups,
+    ],
+  }
+
+  const formatPermissionName = (permission: string) => {
+    return permission
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, l => l.toUpperCase())
+  }
+
+  const getPermissionVariant = (permission: Permissions) => {
+    if (permission.toString().startsWith('manage')) return BadgeColorScheme.RED;
+    if (permission.toString().startsWith('create')) return BadgeColorScheme.GREEN;
+    if (permission.toString().startsWith('view')) return BadgeColorScheme.BLUE;
+    if (permission.toString().startsWith('query')) return BadgeColorScheme.YELLOW;
+    return BadgeColorScheme.GRAY;
+  };
+
   return (
     <Dialog>
       <DialogTrigger asChild>
         <Button>
-          Create User
+          Create Role
         </Button>
       </DialogTrigger>
 
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>Edit profile</DialogTitle>
+          <DialogTitle>Create Role</DialogTitle>
           <DialogDescription>
-            Make changes to your profile here. Click save when you're done.
+            Fill in the details to create a new role.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 py-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="name" className="text-right">
-              Name
-            </Label>
-            <Input id="name" value="Pedro Duarte" className="col-span-3" />
+
+        <div>
+          <div className="flex flex-col gap-4">
+            <InputText 
+              name="name"
+              label="Name"
+            />
+
+            <InputText 
+              name="description"
+              label="Description"
+            />
+
+            {/* Permissions sélectionnées */}
+            <div>
+              <Label className="text-sm font-medium">
+                Selected Permissions ({selectedPermissions.length})
+              </Label>
+              <div className="mt-2 flex flex-wrap gap-1 min-h-[60px] p-2 border rounded-md bg-muted/20">
+                {selectedPermissions.length === 0 ? (
+                  <span className="text-sm text-muted-foreground">No permissions selected</span>
+                ) : (
+                  selectedPermissions.map((permission) => (
+                    <Badge 
+                      key={permission} 
+                      variant={getPermissionVariant(permission)}
+                      className="text-xs cursor-pointer hover:bg-destructive hover:text-destructive-foreground"
+                      onClick={() => handlePermissionToggle(permission)}
+                    >
+                      {formatPermissionName(permission.toString())}
+                      <span className="ml-1">×</span>
+                    </Badge>
+                  ))
+                )}
+              </div>
+            </div>
           </div>
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="username" className="text-right">
-              Username
+
+          {/* Sélection des permissions */}
+          <div>
+            <Label className="text-sm font-medium mb-3 block">
+              Available Permissions
             </Label>
-            <Input id="username" value="@peduarte" className="col-span-3" />
+            <ScrollArea className="h-[400px] rounded-md border bg-background">
+              <div className="p-4 space-y-4">
+                {Object.entries(permissionGroups).map(([groupName, groupPermissions]) => {
+                  const allSelected = groupPermissions.every(perm => selectedPermissions.includes(perm));
+                  const someSelected = groupPermissions.some(perm => selectedPermissions.includes(perm));
+                  
+                  return (
+                    <div key={groupName} className="space-y-3">
+                      {/* En-tête du groupe */}
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-2">
+                          <Checkbox
+                            id={`group-${groupName}`}
+                            checked={allSelected}
+                            ref={(el) => {
+                              if (el) el.indeterminate = someSelected && !allSelected;
+                            }}
+                            onCheckedChange={() => handleSelectAllInGroup(groupPermissions)}
+                          />
+                          <Label 
+                            htmlFor={`group-${groupName}`}
+                            className="text-sm font-medium cursor-pointer"
+                          >
+                            {groupName}
+                          </Label>
+                        </div>
+                        <BadgeColor color={BadgeColorScheme.GRAY} className="text-xs">
+                        {groupPermissions.filter(perm => selectedPermissions.includes(perm)).length}/{groupPermissions.length}
+
+                        </BadgeColor>
+                      </div>
+
+                      {/* Permissions du groupe */}
+                      <div className="ml-6 space-y-2">
+                        {groupPermissions.map((permission) => (
+                          <div key={permission} className="flex items-center space-x-2">
+                            <Checkbox
+                              id={permission.toString()}
+                              checked={selectedPermissions.includes(permission)}
+                              onCheckedChange={() => handlePermissionToggle(permission)}
+                            />
+                            <Label 
+                              htmlFor={permission.toString()}
+                              className="text-sm cursor-pointer flex-1"
+                            >
+                              {formatPermissionName(permission.toString())}
+                            </Label>
+                            <BadgeColor 
+                              color={getPermissionVariant(permission)}
+                              className="text-xs"
+                            >
+                              {permission.toString().split('_')[0]}
+                            </BadgeColor>
+                          </div>
+                        ))}
+                      </div>
+                      
+                      {Object.keys(permissionGroups).indexOf(groupName) < Object.keys(permissionGroups).length - 1 && (
+                        <Separator className="mt-4" />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </ScrollArea>
           </div>
         </div>
+
         <DialogFooter>
           <Button type="submit">Save changes</Button>
         </DialogFooter>

--- a/front/src/pages/role/schemas/create-role.schema.ts
+++ b/front/src/pages/role/schemas/create-role.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createRoleSchema = z.object({
+  name: z.string().min(1, { message: "Role name is required" }),
+  description: z.string().optional(),
+  permissions: z.array(z.string()),
+})
+
+export type CreateRoleSchema = z.infer<typeof createRoleSchema>

--- a/front/src/pages/role/ui/create-role-modal.tsx
+++ b/front/src/pages/role/ui/create-role-modal.tsx
@@ -1,0 +1,46 @@
+import { UseFormReturn } from "react-hook-form";
+import { CreateRoleSchema } from "../schemas/create-role.schema";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { InputText } from "@/components/ui/input-text";
+import { Permissions } from "@/api/api.interface";
+
+export interface CreateRoleModalProps {
+  form: UseFormReturn<CreateRoleSchema>
+  selectedPermissions: Permissions[]
+}
+
+export default function CreateRoleModal({}: CreateRoleModalProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>
+          Create Role
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Create Role</DialogTitle>
+          <DialogDescription>
+            Fill in the details to create a new role.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div>
+          <div className="flex flex-col gap-4">
+            <InputText 
+              name="name"
+              label="Name"
+            />
+
+            <InputText 
+              name="description"
+              label="Description"
+            />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front/src/utils/index.ts
+++ b/front/src/utils/index.ts
@@ -1,0 +1,10 @@
+import { Permissions } from "@/api/api.interface";
+import { BadgeColorScheme } from "@/components/ui/badge-color";
+
+export function getBadgeColorFromPermissionVariant (permission: Permissions): BadgeColorScheme {
+  if (permission.toString().startsWith('manage')) return BadgeColorScheme.RED
+  if (permission.toString().startsWith('create')) return BadgeColorScheme.GREEN
+  if (permission.toString().startsWith('view')) return BadgeColorScheme.BLUE
+  if (permission.toString().startsWith('query')) return BadgeColorScheme.YELLOW
+  return BadgeColorScheme.GRAY
+}


### PR DESCRIPTION
This pull request introduces significant changes to the role management functionality in the backend and frontend, including a migration from integer-based permissions to string-based permissions and the addition of a new UI component for managing permissions in a scrollable interface. Below is a summary of the most important changes:

### Backend Changes

**Migration to String-Based Permissions:**
* Updated `CreateRoleDto` and `CreateRoleValidator` to use `Vec<String>` for permissions instead of `i32`. (`api/src/lib/application/http/role/validators.rs` [[1]](diffhunk://#diff-431a52f65a32f831a472de335981386d85095d56be68ec2813e71e0b485e15abL14-R14)], `api/src/lib/domain/role/entities.rs` [[2]](diffhunk://#diff-ad2141cb5e9f40f0c006ea7589ee6e85b315aeeeed36b89f3e1da96dc33e5d17L14-R14)])
* Modified logic for handling permissions in the `MediatorService` and `RealmService` to use `Permissions::to_names` and `Permissions::from_names` for conversion between enums and strings. (`api/src/lib/domain/mediator/services/mediator_service.rs` [[1]](diffhunk://#diff-7e4e62c400176112b233721a9d3de43999df70cf018bf4d3b185ce773e9aa55dL192-R192)], `api/src/lib/domain/realm/services/realm_service.rs` [[2]](diffhunk://#diff-c5a1bf5c81414a205deacd818c90685b3b5f40559d31eaa7f13542541490de77L112-R118)])
* Added utility methods `from_names` and `to_names` to the `Permissions` struct for easier conversion. (`api/src/lib/domain/role/entities/permission.rs` [[api/src/lib/domain/role/entities/permission.rsR136-R149](diffhunk://#diff-0089524092cfb2625813ddb246a0a8c74bdf1615f0ebbc9505978da83b604d98R136-R149)])

**Database Adaptation:**
* Updated `PostgresRoleRepository` to convert string-based permissions to a bitfield for storage in the database. (`api/src/lib/infrastructure/repositories/role_repository.rs` [[api/src/lib/infrastructure/repositories/role_repository.rsR51-R58](diffhunk://#diff-b329d92dadd029a7f91f1289276f75312df0916e772d86b07d607006cd4f3b2aR51-R58)])

### Frontend Changes

**UI Enhancements for Role Creation:**
* Introduced a new `ScrollArea` component using `@radix-ui/react-scroll-area` for displaying permissions in a scrollable interface. (`front/src/components/ui/scroll-area.tsx` [[front/src/components/ui/scroll-area.tsxR1-R56](diffhunk://#diff-a29ee0f9a58a2443b7d575eae4f9788d160fea8e2a7bc46c071ea5b474f78a44R1-R56)])
* Enhanced the "Create Role" modal to include a dynamic permissions selection interface with grouped permissions and a "select all" feature for each group. (`front/src/pages/role/feature/create-role-modal-feature.tsx` [[front/src/pages/role/feature/create-role-modal-feature.tsxR1-R232](diffhunk://#diff-4f8d9000bfbafefc7e57ba537cde90feece69bd6190dae8733a61c8912281076R1-R232)])

**Schema and Type Updates:**
* Updated `CreateRoleDto` and `CreateRoleValidator` types in the frontend to use `string[]` for permissions. (`front/src/api/api.interface.ts` [[front/src/api/api.interface.tsL48-R56](diffhunk://#diff-723ed7de3cd17dcfd4433c6a9fe4451dd3f0cbd09af8ef001223c812ced4b1adL48-R56)])
* Added Zod schema validation for role creation, ensuring proper validation of the new permissions structure. (`front/src/pages/role/schemas/create-role.schema.ts` [[front/src/pages/role/schemas/create-role.schema.tsR1-R9](diffhunk://#diff-f7c789d11ebb7ee297fc38a2da7bd9aff52f510013838866faa1f97bb8f0cc14R1-R9)])

**Dependency Additions:**
* Added `@radix-ui/react-scroll-area` to the project dependencies for the scrollable permissions UI. (`front/package.json` [[1]](diffhunk://#diff-ca702b44edbd4e2dacdcc476120b86b9c80adddef71a6ca381a85184175a5df3R20)], `front/pnpm-lock.yaml` [[2]](diffhunk://#diff-9528db834071cea67e01b9cb1e7639de4a0f895977b5d5f509023abdef20ccadR32-R34) [[3]](diffhunk://#diff-9528db834071cea67e01b9cb1e7639de4a0f895977b5d5f509023abdef20ccadR875-R887)])

These changes collectively improve the flexibility and usability of role and permissions management in both the backend and frontend.