### PR TITLE
feat: add docker-compose template configuration for application services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,59 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:17
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=ferriskey
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+  api-migration:
+    image: ghcr.io/ferriskey/ferriskey-api:latest
+    environment:
+      - PORT=3333
+      - ENV=development
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/ferriskey
+      - ADMIN_PASSWORD=admin
+      - ADMIN_USERNAME=admin
+      - ADMIN_EMAIL=super@ferriskey.dev
+      - ALLOWED_ORIGINS=http://localhost:5555,http://localhost:3333
+    depends_on:
+      - postgres
+    command: >
+      bash -c "
+        sqlx migrate run &&
+        echo 'Database migrations completed!'
+      "
+    restart: "no"
+  api:
+    image: ghcr.io/ferriskey/ferriskey-api:latest
+    environment:
+      - PORT=3333
+      - ENV=development
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/ferriskey
+      - ADMIN_PASSWORD=admin
+      - ADMIN_USERNAME=admin
+      - ADMIN_EMAIL=super@ferriskey.dev
+      - ALLOWED_ORIGINS=http://localhost:5555,http://localhost:3333
+    depends_on:
+      api-migration:
+        condition: service_completed_successfully
+    ports:
+      - "3333:3333"
+    restart: unless-stopped
+  frontend:
+    image: ghcr.io/ferriskey/ferriskey-front:latest
+    ports:
+      - "5555:80"
+    environment:
+      - APP_API_URL=http://localhost:3333
+    depends_on:
+      - api
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
This pull request introduces a `docker-compose.yaml` file to streamline the setup of a development environment using Docker. It defines services for PostgreSQL, API migrations, the API itself, and the frontend application, along with their respective configurations.

### Docker Compose Setup:

* **PostgreSQL Service**: Configured with the `postgres:17` image, environment variables for user credentials and database name, and a volume for persistent data storage.
* **API Migration Service**: Runs database migrations using the `ghcr.io/ferriskey/ferriskey-api:latest` image, with environment variables for database connection and admin credentials. It depends on the PostgreSQL service and stops after completing migrations.
* **API Service**: Uses the same API image, exposes port `3333`, and depends on the migration service to ensure migrations are completed before starting. It includes environment variables for configuration and allowed origins.
* **Frontend Service**: Configured with the `ghcr.io/ferriskey/ferriskey-front:latest` image, exposes port `5555`, and depends on the API service. It includes an environment variable to specify the API URL.
* **Volumes**: Defines a `postgres_data` volume for storing PostgreSQL data persistently.