### PR TITLE
Implement delete_by_id and get_by_client_id methods in RoleServiceImpl

### DIFF
--- a/api/src/lib/domain/role/services.rs
+++ b/api/src/lib/domain/role/services.rs
@@ -35,11 +35,17 @@ where
     }
 
     async fn delete_by_id(&self, _id: Uuid) -> Result<(), RoleError> {
-        todo!("delete role");
+        self.role_repository
+            .delete_by_id(_id)
+            .await
+            .map_err(|_| RoleError::NotFound)
     }
 
     async fn get_by_client_id(&self, _client_id: Uuid) -> Result<Vec<Role>, RoleError> {
-        todo!("get role by client id");
+        self.role_repository
+            .get_by_client_id(_client_id)
+            .await
+            .map_err(|_| RoleError::NotFound)
     }
 
     async fn get_by_client_id_text(


### PR DESCRIPTION
This pull request updates the `RoleService` implementation in `api/src/lib/domain/role/services.rs` to replace placeholder `todo!` calls with actual functionality for interacting with the `role_repository`.

Updates to `RoleService` methods:

* Implemented `delete_by_id` to call `role_repository.delete_by_id` and map errors to `RoleError::NotFound`.
* Implemented `get_by_client_id` to call `role_repository.get_by_client_id` and map errors to `RoleError::NotFound`.