### PR TITLE
feat: add client service integration to password strategy for client credential verification

### DIFF
--- a/api/src/lib/domain/authentication/service/authentication.rs
+++ b/api/src/lib/domain/authentication/service/authentication.rs
@@ -75,6 +75,7 @@ impl AuthenticationServiceImpl {
             jwt_service.clone(),
             user_service.clone(),
             credential_service.clone(),
+            client_service.clone()
         );
 
         let authorization_code_strategy = AuthorizationCodeStrategy::new(


### PR DESCRIPTION
This pull request enhances the `PasswordStrategy` implementation by introducing client validation during the authentication process. It adds a dependency on the `ClientService` and updates the logic to verify the client's credentials. Below are the most important changes grouped by theme:

### Enhancements to `PasswordStrategy`:

* Added a new dependency on `ClientService` to the `PasswordStrategy` struct, including updates to its constructor to accept and initialize this service. (`api/src/lib/domain/authentication/grant_type_strategies/password_strategy.rs`)
* Implemented client validation in the `PasswordStrategy` by retrieving the client using `client_id` and validating the `client_secret`. If the secret is invalid, an `AuthenticationError::InvalidClientSecret` is returned. (`api/src/lib/domain/authentication/grant_type_strategies/password_strategy.rs`)

### Updates to `AuthenticationServiceImpl`:

* Updated the initialization of `PasswordStrategy` in `AuthenticationServiceImpl` to pass the `ClientService` dependency. (`api/src/lib/domain/authentication/service/authentication.rs`)