### PR TITLE
feat: add typeshare support for JwkKey struct and interface

### DIFF
--- a/api/src/lib/domain/jwt/entities/jwt.rs
+++ b/api/src/lib/domain/jwt/entities/jwt.rs
@@ -8,6 +8,7 @@ use rsa::{
     pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding},
 };
 use serde::{Deserialize, Serialize};
+use typeshare::typeshare;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -29,6 +30,7 @@ pub struct JwtKeyPair {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, ToSchema)]
+#[typeshare]
 pub struct JwkKey {
     pub kid: String,
     pub kty: String,

--- a/front/src/api/api.interface.ts
+++ b/front/src/api/api.interface.ts
@@ -118,6 +118,16 @@ export interface DeleteUserCredentialResponse {
 	message: string;
 }
 
+export interface JwkKey {
+	kid: string;
+	kty: string;
+	use_: string;
+	alg: string;
+	x5c: string;
+	n: string;
+	e: string;
+}
+
 export interface GetCertsResponse {
 	keys: JwkKey[];
 }


### PR DESCRIPTION
This pull request introduces a new `JwkKey` structure to support JSON Web Key (JWK) representation in both the backend and frontend. The changes include adding the `typeshare` attribute for cross-language type sharing and updating the API interface in the frontend.

### Backend updates:

* [`api/src/lib/domain/jwt/entities/jwt.rs`](diffhunk://#diff-dac3f445b9d02a159ee1b97cd16258d7245e4a3d69ba99478115b791dc67e8a0R33): Added the `typeshare` attribute to the `JwkKey` struct to enable cross-language type sharing.
* [`api/src/lib/domain/jwt/entities/jwt.rs`](diffhunk://#diff-dac3f445b9d02a159ee1b97cd16258d7245e4a3d69ba99478115b791dc67e8a0R11): Imported the `typeshare` crate to support the new attribute.

### Frontend updates:

* [`front/src/api/api.interface.ts`](diffhunk://#diff-723ed7de3cd17dcfd4433c6a9fe4451dd3f0cbd09af8ef001223c812ced4b1adR121-R130): Introduced the `JwkKey` interface to represent JSON Web Key properties and updated the `GetCertsResponse` interface to include an array of `JwkKey`.