### PR TITLE
feat: operator owner reference

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push
-        uses: docker/build-push-action
+        uses: docker/build-push-action@v6
         with:
           context: operator
           push: true

--- a/operator/src/controller/cluster.rs
+++ b/operator/src/controller/cluster.rs
@@ -1,4 +1,5 @@
 use crate::crd::cluster::FerriskeyCluster;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::api::{Patch, PatchParams};
 use kube::{Api, Client, Resource, ResourceExt};
 use serde_json::json;
@@ -6,6 +7,17 @@ use serde_json::json;
 pub mod api;
 pub mod frontend;
 pub mod postgres;
+
+fn build_owner_reference(cluster: &FerriskeyCluster) -> OwnerReference {
+    OwnerReference {
+        api_version: "ferriskey.io/v1".to_string(),
+        kind: "FerriskeyCluster".to_string(),
+        name: cluster.name_any(),
+        uid: cluster.meta().uid.clone().unwrap_or_default(),
+        controller: Some(true),
+        block_owner_deletion: Some(true),
+    }
+}
 
 async fn ensure_finalizer(cluster: &FerriskeyCluster, client: &Client) -> Result<(), kube::Error> {
     if cluster

--- a/operator/src/controller/cluster/api.rs
+++ b/operator/src/controller/cluster/api.rs
@@ -1,6 +1,7 @@
 use crate::btreemap;
 use crate::crd::cluster::FerriskeyCluster;
 
+use crate::controller::cluster::build_owner_reference;
 use k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString::Int;
 use k8s_openapi::{
@@ -123,6 +124,7 @@ pub async fn reconcile_api(cluster: &FerriskeyCluster, client: &Client) -> Resul
             name: Some(api_name.clone()),
             namespace: Some(ns.clone()),
             labels: Some(labels.clone()),
+            owner_references: Some(vec![build_owner_reference(cluster)]),
             ..Default::default()
         },
         spec: Some(DeploymentSpec {
@@ -199,6 +201,7 @@ pub async fn reconcile_api_service(
                 "app".to_string() => cluster.name_any(),
                 "component".to_string() => "api".to_string(),
             }),
+            owner_references: Some(vec![build_owner_reference(cluster)]),
             ..Default::default()
         },
         spec: Some(ServiceSpec {

--- a/operator/src/controller/cluster/frontend.rs
+++ b/operator/src/controller/cluster/frontend.rs
@@ -1,4 +1,5 @@
 use crate::btreemap;
+use crate::controller::cluster::build_owner_reference;
 use crate::crd::cluster::FerriskeyCluster;
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec};
 use k8s_openapi::api::core::v1::{
@@ -36,6 +37,7 @@ pub async fn reconcile_frontend(
         metadata: ObjectMeta {
             name: Some(name.clone()),
             labels: Some(labels.clone()),
+            owner_references: Some(vec![build_owner_reference(cluster)]),
             ..Default::default()
         },
 
@@ -111,6 +113,7 @@ pub async fn reconcile_frontend_service(
                 "app".to_string() => cluster.name_any(),
                 "component".to_string() => "front".to_string(),
             }),
+            owner_references: Some(vec![build_owner_reference(cluster)]),
             ..Default::default()
         },
         spec: Some(ServiceSpec {

--- a/operator/src/controller/cluster/postgres.rs
+++ b/operator/src/controller/cluster/postgres.rs
@@ -43,7 +43,7 @@ pub async fn reconcile_postgres(
         "clusters", // ⚠️ Doit être le pluriel défini dans la CRD CNPG
     );
 
-    let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &cluster_ar);
+    let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), ns, &cluster_ar);
 
     if cluster.meta().deletion_timestamp.is_some() {
         if api.get_opt(&name).await?.is_some() {

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -6,10 +6,14 @@ use crate::crd::cluster::FerriskeyCluster;
 
 use crate::controller::cluster::reconcile_cluster;
 use futures::StreamExt;
+use k8s_openapi::api::apps::v1::Deployment;
+use k8s_openapi::api::core::v1::Service;
+use kube::api::{ApiResource, DynamicObject, GroupVersionKind};
 use kube::{
     Api, Client, ResourceExt,
     runtime::controller::{Action, Controller},
 };
+use kube_runtime::watcher;
 use std::sync::Arc;
 use tracing::{info, warn};
 
@@ -23,13 +27,22 @@ async fn main() -> anyhow::Result<()> {
 async fn run() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
     let ferriskey_cluster = Api::<FerriskeyCluster>::all(client.clone());
+    let deployments = Api::<Deployment>::all(client.clone());
+    let services = Api::<Service>::all(client.clone());
 
-    Controller::new(ferriskey_cluster, Default::default())
+    let cnpg_gvk = GroupVersionKind::gvk("postgresql.cnpg.io", "v1", "Cluster");
+    let cnpg_ar = ApiResource::from_gvk(&cnpg_gvk);
+    let cnpg_api: Api<DynamicObject> = Api::all_with(client.clone(), &cnpg_ar);
+
+    Controller::new(ferriskey_cluster, watcher::Config::default())
+        .owns(deployments, watcher::Config::default())
+        .owns(services, watcher::Config::default())
+        .owns_with(cnpg_api, cnpg_ar, watcher::Config::default())
         .run(
             |cluster, ctx| async move {
                 reconcile_cluster(&cluster, &ctx)
                     .await
-                    .map(|_| Action::requeue(std::time::Duration::from_secs(300)))
+                    .map(|_| Action::await_change())
             },
             |cluster, err, _ctx| {
                 warn!(


### PR DESCRIPTION
This pull request introduces enhancements to the Kubernetes operator, focusing on improving resource ownership management, updating dependencies, and refining the reconciliation logic. The most significant changes include adding `ownerReferences` to Kubernetes resources, introducing a helper function for constructing `OwnerReference` objects, and updating the `docker/build-push-action` version in the CI workflow.

### Enhancements to resource ownership:

* Added a `build_owner_reference` function in `operator/src/controller/cluster.rs` to create `OwnerReference` objects for Kubernetes resources. This ensures proper ownership relationships between custom resources and their associated deployments and services.
* Updated reconciliation functions to include `ownerReferences` for the API, frontend, and their respective services using the `build_owner_reference` function. [[1]](diffhunk://#diff-158d1506ce0fe0e5fef8f6b96abc88487c9e85d135a47f225ec0dafb2a0fe6bfR127) [[2]](diffhunk://#diff-158d1506ce0fe0e5fef8f6b96abc88487c9e85d135a47f225ec0dafb2a0fe6bfR204) [[3]](diffhunk://#diff-84bca1b8ae2436e1dbc458a9946f5fa0359c4421355802ee123fdd3abbe251eaR40) [[4]](diffhunk://#diff-84bca1b8ae2436e1dbc458a9946f5fa0359c4421355802ee123fdd3abbe251eaR116)

### Dependency and CI updates:

* Updated the `docker/build-push-action` version in `.github/workflows/release-dev.yml` from an unspecified version to `v6` for improved stability and compatibility.

### Reconciliation logic improvements:

* Modified the `Controller` in `operator/src/main.rs` to watch for and manage additional Kubernetes resources (`Deployment`, `Service`, and a custom `Cluster` resource for PostgreSQL). This enhances the operator's ability to handle related resources.
* Updated the reconciliation logic to use `Action::await_change()` instead of requeuing after a fixed interval, improving efficiency and responsiveness.

### Minor fixes and refinements:

* Fixed a minor issue in `operator/src/controller/cluster/postgres.rs` by removing an unnecessary `clone()` call for a namespace variable.
* Added imports for new Kubernetes resource types and utilities in `operator/src/main.rs` to support the updated functionality.