### PR TITLE
feat: update Docker build and push workflow to include image name and organization inputs

### DIFF
--- a/.github/workflows/build-and-push-docker.yaml
+++ b/.github/workflows/build-and-push-docker.yaml
@@ -40,7 +40,13 @@ on:
         type: boolean
         default: false
         description: "Whether to include the latest tag"
-
+      image_name:
+        required: true
+        type: string
+      organization:
+        required: false
+        type: string
+        default: "ferriskey"
     secrets:
       PAT:
         required: true
@@ -63,7 +69,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.registry }}/${{ github.repository }}
+          images: ${{ inputs.registry }}/${{ inputs.organization }}/${{ inputs.image_name }}
           tags: |
             ${{ inputs.include_latest_tag == true && 'latest' || '' }}
             ${{ inputs.tag }}


### PR DESCRIPTION
This pull request updates the Docker workflow configuration to enhance flexibility by introducing new input parameters and modifying how image names and organizations are handled.

### Workflow configuration updates:

* [`.github/workflows/build-and-push-docker.yaml`](diffhunk://#diff-213e016dde61ce79758886da05ad828e7adb1ebeb0efd3341e88ac84cf656b97L43-R49): Added new input parameters `image_name` (required, type: string) and `organization` (optional, type: string, default: "ferriskey"). These parameters allow more control over naming and organization of Docker images.
* [`.github/workflows/build-and-push-docker.yaml`](diffhunk://#diff-213e016dde61ce79758886da05ad828e7adb1ebeb0efd3341e88ac84cf656b97L66-R72): Updated the `docker/metadata-action` step to use the new `organization` and `image_name` inputs for constructing image names, replacing the previous hardcoded repository-based approach.