### PR TITLE
fix: update Ferriskey chart values for front and api image tags in release candidate workflow

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -92,8 +92,12 @@ jobs:
           ls infrastructure/charts/ferriskey
           echo "📦 Processing Ferriskey chart"
           cp infrastructure/charts/ferriskey/Chart.yaml /tmp/Chart.yaml.orig
+          cp infrastructure/charts/ferriskey/values.yaml /tmp/values.yaml.orig
 
           yq eval ".version = \"${{ needs.prepare-ci.outputs.version }}\" | .appVersion = \"${{ needs.prepare-ci.outputs.version }}\"" /tmp/Chart.yaml.orig > infrastructure/charts/ferriskey/Chart.yaml
+          // Update values.yaml front.image.tag and api.image.tag no operator
+          yq eval ".front.image.tag = \"${{ needs.prepare-ci.outputs.version }}\" | .api.image.tag = \"${{ needs.prepare-ci.outputs.version }}\"" /tmp/values.yaml.orig > infrastructure/charts/ferriskey/values.yaml
+          
 
           helm package infrastructure/charts/ferriskey --destination .cr_releases
           ls -a .cr_releases


### PR DESCRIPTION
This pull request updates the release candidate workflow to ensure version consistency across Helm chart files. The most important changes involve adding steps to handle the `values.yaml` file and updating image tags dynamically.

Changes to Helm chart processing:

* [`.github/workflows/release-candidate.yaml`](diffhunk://#diff-4ab7baa97c9a8c2edc36605dfd374440e1b732546419a6958116578e91ffee90R95-R100): Added a step to copy the `values.yaml` file to a temporary location for modification.
* [`.github/workflows/release-candidate.yaml`](diffhunk://#diff-4ab7baa97c9a8c2edc36605dfd374440e1b732546419a6958116578e91ffee90R95-R100): Updated the `values.yaml` file to dynamically set `front.image.tag` and `api.image.tag` to match the version output from the `prepare-ci` job.