### PR TITLE
feat: add endpoint to delete a role for a user

### DIFF
--- a/api/src/lib/application/http/user/handlers.rs
+++ b/api/src/lib/application/http/user/handlers.rs
@@ -7,4 +7,5 @@ pub mod get_user;
 pub mod get_user_roles;
 pub mod get_users;
 pub mod reset_password;
+pub mod unassign_role;
 pub mod update_user;

--- a/api/src/lib/application/http/user/handlers/assign_role.rs
+++ b/api/src/lib/application/http/user/handlers/assign_role.rs
@@ -57,7 +57,7 @@ pub async fn assign_role(
         .await
         .map_err(ApiError::from)?;
 
-    if UserRolePolicy::store(identity, state.clone(), realm).await? {
+    if !UserRolePolicy::store(identity, state.clone(), realm).await? {
         return Err(ApiError::Forbidden(
             "You do not have permission to assign roles".to_string(),
         ));

--- a/api/src/lib/application/http/user/handlers/unassign_role.rs
+++ b/api/src/lib/application/http/user/handlers/unassign_role.rs
@@ -65,7 +65,7 @@ pub async fn unassign_role(
         .await
         .map_err(ApiError::from)?;
 
-    if UserRolePolicy::delete(identity, state.clone(), realm).await? {
+    if !UserRolePolicy::delete(identity, state.clone(), realm).await? {
         return Err(ApiError::Forbidden(
             "You do not have permission to unassign roles".to_string(),
         ));

--- a/api/src/lib/application/http/user/handlers/unassign_role.rs
+++ b/api/src/lib/application/http/user/handlers/unassign_role.rs
@@ -1,6 +1,8 @@
 use axum::{Extension, extract::State};
 use axum_macros::TypedPath;
 use serde::{Deserialize, Serialize};
+use typeshare::typeshare;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::{
@@ -19,21 +21,22 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct AssignRoleResponse {
-    pub message: String,
-}
-
 #[derive(TypedPath, Deserialize)]
 #[typed_path("/realms/{realm_name}/users/{user_id}/roles/{role_id}")]
-pub struct AssignRoleRoute {
+pub struct UnassignRoleRoute {
     pub realm_name: String,
     pub user_id: Uuid,
     pub role_id: Uuid,
 }
 
+#[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq)]
+#[typeshare]
+pub struct UnassignRoleResponse {
+    pub message: String,
+}
+
 #[utoipa::path(
-    post,
+    delete,
     path = "/{user_id}/roles/{role_id}",
     tag = "user",
     params(
@@ -41,37 +44,41 @@ pub struct AssignRoleRoute {
         ("user_id" = Uuid, Path, description = "User ID"),
         ("role_id" = Uuid, Path, description = "Role ID"),
     ),
+    responses(
+        (status = 200, body = UnassignRoleResponse, description = "Role unassigned successfully"),
+        (status = 403, description = "Forbidden - You do not have permission to unassign roles"),
+        (status = 404, description = "User or role not found")
+    )
 )]
-pub async fn assign_role(
-    AssignRoleRoute {
+pub async fn unassign_role(
+    UnassignRoleRoute {
         realm_name,
         user_id,
         role_id,
-    }: AssignRoleRoute,
+    }: UnassignRoleRoute,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
-) -> Result<Response<AssignRoleResponse>, ApiError> {
+) -> Result<Response<UnassignRoleResponse>, ApiError> {
     let realm = state
         .realm_service
         .get_by_name(realm_name.clone())
         .await
         .map_err(ApiError::from)?;
 
-    if UserRolePolicy::store(identity, state.clone(), realm).await? {
+    if UserRolePolicy::delete(identity, state.clone(), realm).await? {
         return Err(ApiError::Forbidden(
-            "You do not have permission to assign roles".to_string(),
+            "You do not have permission to unassign roles".to_string(),
         ));
     }
 
     state
         .user_role_service
-        .assign_role(realm_name.clone(), user_id, role_id)
-        .await
-        .map_err(ApiError::from)?;
+        .revoke_role(user_id, role_id)
+        .await?;
 
-    Ok(Response::OK(AssignRoleResponse {
+    Ok(Response::OK(UnassignRoleResponse {
         message: format!(
-            "Role {} assigned to user {} in realm {}",
+            "Role {} unassigned from user {} in realm {}",
             role_id, user_id, realm_name
         ),
     }))

--- a/api/src/lib/application/http/user/router.rs
+++ b/api/src/lib/application/http/user/router.rs
@@ -15,6 +15,7 @@ use super::handlers::{
     get_user_roles::{__path_get_user_roles, get_user_roles},
     get_users::{__path_get_users, get_users},
     reset_password::{__path_reset_password, reset_password},
+    unassign_role::{__path_unassign_role, unassign_role},
     update_user::{__path_update_user, update_user},
 };
 
@@ -29,7 +30,8 @@ use super::handlers::{
     bulk_delete_user,
     reset_password,
     get_user_credentials,
-    delete_user_credential
+    delete_user_credential,
+    unassign_role,
 ))]
 pub struct UserApiDoc;
 
@@ -45,5 +47,6 @@ pub fn user_routes(state: AppState) -> Router<AppState> {
         .typed_delete(bulk_delete_user)
         .typed_delete(delete_user_credential)
         .typed_post(assign_role)
+        .typed_delete(unassign_role)
         .layer(middleware::from_fn_with_state(state.clone(), auth))
 }

--- a/api/src/lib/domain/user/ports.rs
+++ b/api/src/lib/domain/user/ports.rs
@@ -1,3 +1,4 @@
 pub mod user_repository;
+pub mod user_role_repository;
 pub mod user_role_service;
 pub mod user_service;

--- a/api/src/lib/domain/user/ports/user_repository.rs
+++ b/api/src/lib/domain/user/ports/user_repository.rs
@@ -21,6 +21,10 @@ pub trait UserRepository: Clone + Send + Sync + 'static {
     ) -> impl Future<Output = Result<User, UserError>> + Send;
 
     fn get_by_id(&self, user_id: Uuid) -> impl Future<Output = Result<User, UserError>> + Send;
+
+    #[deprecated(
+        note = "Use `get_user_roles` in UserRoleRepository. This method will be removed in future versions."
+    )]
     fn get_roles_by_user_id(
         &self,
         user_id: Uuid,
@@ -36,7 +40,19 @@ pub trait UserRepository: Clone + Send + Sync + 'static {
         ids: Vec<Uuid>,
     ) -> impl Future<Output = Result<u64, UserError>> + Send;
 
+    #[deprecated(
+        note = "Use `assign_role` in UserRoleRepository. This method will be removed in future versions."
+    )]
     fn assign_role_to_user(
+        &self,
+        user_id: Uuid,
+        role_id: Uuid,
+    ) -> impl Future<Output = Result<(), UserError>> + Send;
+
+    #[deprecated(
+        note = "Use `revoke_role` in UserRoleRepository. This method will be removed in future versions."
+    )]
+    fn unassign_role_from_user(
         &self,
         user_id: Uuid,
         role_id: Uuid,

--- a/api/src/lib/domain/user/ports/user_role_repository.rs
+++ b/api/src/lib/domain/user/ports/user_role_repository.rs
@@ -1,0 +1,25 @@
+use uuid::Uuid;
+
+use crate::domain::{role::entities::models::Role, user::entities::error::UserError};
+
+pub trait UserRoleRepository: Clone + Send + Sync + 'static {
+    fn assign_role(
+        &self,
+        user_id: Uuid,
+        role_id: Uuid,
+    ) -> impl Future<Output = Result<(), UserError>> + Send;
+    fn revoke_role(
+        &self,
+        user_id: Uuid,
+        role_id: Uuid,
+    ) -> impl Future<Output = Result<(), UserError>> + Send;
+    fn get_user_roles(
+        &self,
+        user_id: Uuid,
+    ) -> impl Future<Output = Result<Vec<Role>, UserError>> + Send;
+    fn has_role(
+        &self,
+        user_id: Uuid,
+        role_id: Uuid,
+    ) -> impl Future<Output = Result<bool, UserError>> + Send;
+}

--- a/api/src/lib/infrastructure/user.rs
+++ b/api/src/lib/infrastructure/user.rs
@@ -1,3 +1,4 @@
 pub mod links;
 pub mod mappers;
+pub mod repositories;
 pub mod repository;

--- a/api/src/lib/infrastructure/user/repositories.rs
+++ b/api/src/lib/infrastructure/user/repositories.rs
@@ -1,0 +1,1 @@
+pub mod user_role_repository;

--- a/api/src/lib/infrastructure/user/repositories/user_role_repository.rs
+++ b/api/src/lib/infrastructure/user/repositories/user_role_repository.rs
@@ -1,0 +1,95 @@
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, Condition, DatabaseConnection, EntityTrait,
+    JoinType, QueryFilter, QuerySelect, RelationTrait, prelude::Expr, sea_query::IntoCondition,
+};
+use tracing::error;
+use uuid::Uuid;
+
+use crate::domain::{
+    role::entities::models::Role,
+    user::{entities::error::UserError, ports::user_role_repository::UserRoleRepository},
+};
+
+#[derive(Debug, Clone)]
+pub struct PostgresUserRoleRepository {
+    pub db: DatabaseConnection,
+}
+
+impl PostgresUserRoleRepository {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+impl UserRoleRepository for PostgresUserRoleRepository {
+    async fn assign_role(&self, user_id: Uuid, role_id: Uuid) -> Result<(), UserError> {
+        let user_role = entity::user_role::ActiveModel {
+            role_id: Set(role_id),
+            user_id: Set(user_id),
+            ..Default::default()
+        };
+
+        user_role
+            .insert(&self.db)
+            .await
+            .map_err(|_| UserError::InternalServerError)?;
+
+        Ok(())
+    }
+
+    async fn get_user_roles(&self, user_id: Uuid) -> Result<Vec<Role>, UserError> {
+        let roles = entity::roles::Entity::find()
+            .join(
+                JoinType::InnerJoin,
+                entity::user_role::Relation::Roles
+                    .def()
+                    .rev()
+                    .on_condition(move |_left, right| {
+                        Expr::col((right, entity::user_role::Column::UserId))
+                            .eq(user_id)
+                            .into_condition()
+                    }),
+            )
+            .join(JoinType::LeftJoin, entity::roles::Relation::Clients.def())
+            .select_also(entity::clients::Entity)
+            .all(&self.db)
+            .await
+            .map_err(|e| {
+                error!("error getting user roles: {:?}", e);
+                UserError::InternalServerError
+            })?
+            .iter()
+            .map(|(model, client)| {
+                let mut role: Role = model.clone().into();
+                if let Some(client) = client {
+                    role.client = Some(client.clone().into());
+                }
+                role
+            })
+            .collect::<Vec<Role>>();
+
+        Ok(roles)
+    }
+
+    async fn has_role(&self, _user_id: Uuid, _role_id: Uuid) -> Result<bool, UserError> {
+        todo!("Implement has_role in PostgresUserRoleRepository");
+    }
+
+    async fn revoke_role(&self, user_id: Uuid, role_id: Uuid) -> Result<(), UserError> {
+        let rows = entity::user_role::Entity::delete_many()
+            .filter(
+                Condition::all()
+                    .add(entity::user_role::Column::UserId.eq(user_id))
+                    .add(entity::user_role::Column::RoleId.eq(role_id)),
+            )
+            .exec(&self.db)
+            .await
+            .map_err(|_| UserError::InternalServerError)?;
+
+        if rows.rows_affected == 0 {
+            return Err(UserError::NotFound);
+        }
+
+        Ok(())
+    }
+}

--- a/api/src/lib/infrastructure/user/repository.rs
+++ b/api/src/lib/infrastructure/user/repository.rs
@@ -178,6 +178,24 @@ impl UserRepository for PostgresUserRepository {
         Ok(())
     }
 
+    async fn unassign_role_from_user(&self, user_id: Uuid, role_id: Uuid) -> Result<(), UserError> {
+        let rows = entity::user_role::Entity::delete_many()
+            .filter(
+                Condition::all()
+                    .add(entity::user_role::Column::UserId.eq(user_id))
+                    .add(entity::user_role::Column::RoleId.eq(role_id)),
+            )
+            .exec(&self.db)
+            .await
+            .map_err(|_| UserError::InternalServerError)?;
+
+        if rows.rows_affected == 0 {
+            return Err(UserError::NotFound);
+        }
+
+        Ok(())
+    }
+
     async fn update_user(&self, user_id: Uuid, dto: UpdateUserDto) -> Result<User, UserError> {
         let user = entity::users::Entity::find()
             .filter(entity::users::Column::Id.eq(user_id))

--- a/front/src/api/api.interface.ts
+++ b/front/src/api/api.interface.ts
@@ -192,6 +192,10 @@ export interface TokenRequestValidator {
 	refresh_token?: string;
 }
 
+export interface UnassignRoleResponse {
+	message: string;
+}
+
 export interface UpdateUserResponse {
 	data: User;
 }

--- a/front/src/api/user_role.api.ts
+++ b/front/src/api/user_role.api.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { UserMutateContract} from './user.api'
+import { authStore } from "@/store/auth.store"
+import { apiClient } from "."
+export const useUnassignUserRole = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ realm, userId, payload }: UserMutateContract<{ roleId: string }>) => {
+      const accessToken = authStore.getState().accessToken
+
+      const response = await apiClient.delete(`/realms/${realm}/users/${userId}/roles/${payload.roleId}`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        }
+      })
+
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["user-roles"],
+      })
+    }
+  })
+}

--- a/front/src/api/user_role.api.ts
+++ b/front/src/api/user_role.api.ts
@@ -2,14 +2,15 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { UserMutateContract} from './user.api'
 import { authStore } from "@/store/auth.store"
 import { apiClient } from "."
+import { UnassignRoleResponse } from "./api.interface"
 export const useUnassignUserRole = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ realm, userId, payload }: UserMutateContract<{ roleId: string }>) => {
+    mutationFn: async ({ realm, userId, payload }: UserMutateContract<{ roleId: string }>): Promise<UnassignRoleResponse> => {
       const accessToken = authStore.getState().accessToken
 
-      const response = await apiClient.delete(`/realms/${realm}/users/${userId}/roles/${payload.roleId}`, {
+      const response = await apiClient.delete<UnassignRoleResponse>(`/realms/${realm}/users/${userId}/roles/${payload.roleId}`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         }

--- a/front/src/pages/user/feature/page-user-role-mapping-feature.tsx
+++ b/front/src/pages/user/feature/page-user-role-mapping-feature.tsx
@@ -1,15 +1,23 @@
-import { useParams } from "react-router";
-import { useGetUserRoles } from "@/api/user.api";
-import { UserRouterParams } from "@/routes/sub-router/user.router";
-import PageUserRoleMapping from "../ui/page-user-role-mapping";
+import { useParams } from 'react-router'
+import { useGetUserRoles } from '@/api/user.api'
+import { UserRouterParams } from '@/routes/sub-router/user.router'
+import PageUserRoleMapping from '../ui/page-user-role-mapping'
 
 export default function PageUserRoleMappingFeature() {
-  const { realm_name, user_id } = useParams<UserRouterParams>();
+  const { realm_name, user_id } = useParams<UserRouterParams>()
 
-  const { data: userRoles, isLoading, isError } = useGetUserRoles({ 
-    realm: realm_name || "master", 
-    userId: user_id || "" 
-  });
+  const {
+    data: userRoles,
+    isLoading,
+    isError,
+  } = useGetUserRoles({
+    realm: realm_name || 'master',
+    userId: user_id || '',
+  })
+
+  const handleUnassignRole = (roleId: string) => {
+    console.log(`Unassigning role with ID: ${roleId}`)
+  }
 
   return (
     <PageUserRoleMapping
@@ -17,6 +25,7 @@ export default function PageUserRoleMappingFeature() {
       isLoading={isLoading}
       isError={isError}
       userId={user_id}
+      handleUnassignRole={handleUnassignRole}
     />
-  );
-} 
+  )
+}

--- a/front/src/pages/user/ui/page-user-role-mapping.tsx
+++ b/front/src/pages/user/ui/page-user-role-mapping.tsx
@@ -2,15 +2,21 @@ import { Role } from '@/api/api.interface'
 import RoleMappingModalFeature from '../feature/modals/role-mapping-modal-feature'
 import { DataTable } from '@/components/ui/data-table'
 import { columns } from '../columns/list-user-roles.column'
+import { Delete } from 'lucide-react'
 
 interface PageUserRoleMappingProps {
   userRoles: Role[]
   isLoading: boolean
   isError: boolean
+  handleUnassignRole: (roleId: string) => void
   userId?: string
 }
 
-export default function PageUserRoleMapping({ userRoles, isLoading }: PageUserRoleMappingProps) {
+export default function PageUserRoleMapping({
+  userRoles,
+  isLoading,
+  handleUnassignRole,
+}: PageUserRoleMappingProps) {
   return (
     <div className="">
       <DataTable
@@ -18,6 +24,15 @@ export default function PageUserRoleMapping({ userRoles, isLoading }: PageUserRo
         data={userRoles ?? []}
         isLoading={isLoading}
         emptyState={<NoUserRoles />}
+        rowActions={[
+          {
+            label: 'Unassign',
+            icon: <Delete className="h-4 w-4" />,
+            onClick: (role) => {
+              handleUnassignRole(role.id)
+            },
+          },
+        ]}
       />
     </div>
   )


### PR DESCRIPTION
This pull request introduces a significant refactor to the user role management system in the application. The changes include adding a new `UserRoleRepository` interface, implementing new endpoints for unassigning roles, and updating the existing policies and services to leverage the new repository. Additionally, deprecated methods in the `UserRepository` have been marked for future removal, signaling a shift towards a more modular and maintainable architecture.

### New Features and Endpoints:

* Added a new `unassign_role` endpoint to allow the removal of roles from users. This includes the route definition, handler implementation, and API documentation.

### Refactoring and Repository Updates:

* Introduced a new `UserRoleRepository` interface with methods for assigning, revoking, and querying user roles. This replaces role-related responsibilities previously handled by `UserRepository`.

### Policy Enhancements:

* Added new methods (`store` and `delete`) to the `UserRolePolicy` for fine-grained permission checks when assigning or unassigning roles. These methods validate user permissions based on their identity and the target realm..

### Deprecations:

* Marked methods in `UserRepository` related to role assignments as deprecated, encouraging the use of `UserRoleRepository` instead.

### Codebase Integration:

* Updated all relevant services, policies, and application layers to integrate the new `UserRoleRepository` and ensure compatibility with the refactored architecture.