### PR TITLE
feat: implement role unassignment and success notification in user role mapping feature

### DIFF
--- a/api/src/lib/application/http/user/handlers/get_user_roles.rs
+++ b/api/src/lib/application/http/user/handlers/get_user_roles.rs
@@ -5,7 +5,6 @@ use crate::{
 use axum::{Extension, extract::State};
 use axum_macros::TypedPath;
 use serde::{Deserialize, Serialize};
-use tracing::info;
 use typeshare::typeshare;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -69,16 +68,11 @@ pub async fn get_user_roles(
         ));
     }
 
-    info!("Fetching roles for user: {}", user_id);
-
-    // Get the target user's roles
     let roles = state
         .user_service
         .get_user_roles(user_id)
         .await
         .map_err(ApiError::from)?;
-
-    info!("Roles retrieved for user: {}", user_id);
 
     Ok(Response::OK(GetUserRolesResponse { data: roles }))
 }

--- a/api/src/lib/domain/authentication/grant_type_strategies/client_credentials_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/client_credentials_strategy.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
-use tracing::info;
 
 use crate::domain::{
     authentication::{
@@ -53,8 +52,6 @@ impl GrantTypeStrategy for ClientCredentialsStrategy {
                 if client.secret != params.client_secret {
                     return Err(AuthenticationError::InvalidClientSecret);
                 }
-
-                info!("success to login with client: {:?}", client.name);
 
                 let user = self
                     .user_service

--- a/front/src/pages/user/feature/page-user-role-mapping-feature.tsx
+++ b/front/src/pages/user/feature/page-user-role-mapping-feature.tsx
@@ -2,6 +2,9 @@ import { useParams } from 'react-router'
 import { useGetUserRoles } from '@/api/user.api'
 import { UserRouterParams } from '@/routes/sub-router/user.router'
 import PageUserRoleMapping from '../ui/page-user-role-mapping'
+import { useUnassignUserRole } from '@/api/user_role.api'
+import { useEffect } from 'react'
+import { toast } from 'sonner'
 
 export default function PageUserRoleMappingFeature() {
   const { realm_name, user_id } = useParams<UserRouterParams>()
@@ -14,10 +17,25 @@ export default function PageUserRoleMappingFeature() {
     realm: realm_name || 'master',
     userId: user_id || '',
   })
+  const { mutate: unassignRole, isSuccess } = useUnassignUserRole()
 
   const handleUnassignRole = (roleId: string) => {
-    console.log(`Unassigning role with ID: ${roleId}`)
+    unassignRole({
+      realm: realm_name,
+      userId: user_id,
+      payload: {
+        roleId,
+      },
+    })
   }
+
+  useEffect(() => {
+    if (isSuccess) {
+      toast.success('Role unassigned successfully', {
+        description: 'The role has been successfully removed from the user.',
+      })
+    }
+  }, [isSuccess])
 
   return (
     <PageUserRoleMapping


### PR DESCRIPTION
This pull request focuses on removing unnecessary logging statements in the backend and enhancing functionality in the frontend for user role management. The most important changes include cleaning up logging in Rust files and adding a feature to unassign user roles with success notifications in the React frontend.

### Backend changes (Rust):

* Removed `tracing::info` logging statements from `get_user_roles.rs` to eliminate redundant logs when fetching user roles.
* Removed `tracing::info` logging statements from `client_credentials_strategy.rs` to streamline the authentication process logs.

### Frontend changes (React):

* Added the `useUnassignUserRole` hook and `toast` notifications to the `PageUserRoleMappingFeature` component, enabling users to unassign roles with a success message.