### PR TITLE
refactor: implement FullUrl struct and update authentication strategies to use base_url for claims

### DIFF
--- a/api/src/lib/application.rs
+++ b/api/src/lib/application.rs
@@ -1,3 +1,4 @@
 pub mod auth;
 pub mod http;
 pub mod server;
+pub mod url;

--- a/api/src/lib/application/url.rs
+++ b/api/src/lib/application/url.rs
@@ -1,0 +1,42 @@
+use axum::{RequestPartsExt, extract::FromRequestParts, http::Uri};
+
+#[derive(Debug, Clone)]
+pub struct FullUrl(pub String, pub String);
+
+impl<S> FromRequestParts<S> for FullUrl
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let uri = parts.extract::<Uri>().await.unwrap();
+
+        let headers = &parts.headers;
+
+        let scheme = if headers
+            .get("x-forwarded-proto")
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s == "https")
+            .unwrap_or(false)
+        {
+            "https"
+        } else {
+            "http"
+        };
+
+        let host = headers
+            .get("host")
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("localhost");
+
+        let base_url = format!("{}://{}", scheme, host);
+
+        let full_url = format!("{}://{}{}", scheme, host, uri.path());
+
+        Ok(FullUrl(full_url, base_url))
+    }
+}

--- a/api/src/lib/domain/authentication/grant_type_strategies/authorization_code_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/authorization_code_strategy.rs
@@ -67,11 +67,14 @@ impl GrantTypeStrategy for AuthorizationCodeStrategy {
             .await
             .map_err(|_| AuthenticationError::Invalid)?;
 
+        let iss = format!("{}/realms/{}", params.base_url, params.realm_name);
+        let realm_audit = format!("{}-realm", params.realm_name);
+
         let claims = JwtClaim::new(
             user.id,
             user.username,
-            "http://localhost:3333/realms/master".to_string(),
-            vec!["master-realm".to_string(), "account".to_string()],
+            iss,
+            vec![realm_audit, "account".to_string()],
             ClaimsTyp::Bearer,
             params.client_id,
             Some(user.email.clone()),

--- a/api/src/lib/domain/authentication/grant_type_strategies/client_credentials_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/client_credentials_strategy.rs
@@ -57,11 +57,14 @@ impl GrantTypeStrategy for ClientCredentialsStrategy {
                     .await
                     .map_err(|_| AuthenticationError::ServiceAccountNotFound)?;
 
+                let iss = format!("{}/realms/{}", params.base_url, params.realm_name);
+                let realm_audit = format!("{}-realm", params.realm_name);
+
                 let claims = JwtClaim::new(
                     user.id,
                     user.username,
-                    "http://localhost:3333/realms/master".to_string(),
-                    vec!["master-realm".to_string(), "account".to_string()],
+                    iss,
+                    vec![realm_audit, "account".to_string()],
                     ClaimsTyp::Bearer,
                     params.client_id.clone(),
                     Some(user.email.clone()),

--- a/api/src/lib/domain/authentication/grant_type_strategies/password_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/password_strategy.rs
@@ -78,11 +78,14 @@ impl GrantTypeStrategy for PasswordStrategy {
             return Err(AuthenticationError::Invalid);
         }
 
+        let iss = format!("{}/realms/{}", params.base_url, params.realm_name);
+        let realm_audit = format!("{}-realm", params.realm_name);
+
         let claims = JwtClaim::new(
             user.id,
             user.username,
-            "http://localhost:3333/realms/master".to_string(),
-            vec!["master-realm".to_string(), "account".to_string()],
+            iss,
+            vec![realm_audit, "account".to_string()],
             ClaimsTyp::Bearer,
             params.client_id,
             Some(user.email.clone()),

--- a/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
+++ b/api/src/lib/domain/authentication/grant_type_strategies/refresh_token_strategy.rs
@@ -61,11 +61,14 @@ impl GrantTypeStrategy for RefreshTokenStrategy {
             .await
             .map_err(|_| AuthenticationError::InvalidRefreshToken)?;
 
+        let iss = format!("{}/realms/{}", params.base_url, params.realm_name);
+        let realm_audit = format!("{}-realm", params.realm_name);
+
         let new_claims = JwtClaim::new(
             user.id,
             user.username,
-            "http://localhost:3333/realms/master".to_string(),
-            vec!["master-realm".to_string(), "account".to_string()],
+            iss,
+            vec![realm_audit, "account".to_string()],
             ClaimsTyp::Bearer,
             params.client_id,
             Some(user.email.clone()),

--- a/api/src/lib/domain/authentication/ports/authentication.rs
+++ b/api/src/lib/domain/authentication/ports/authentication.rs
@@ -17,5 +17,6 @@ pub trait AuthenticationService: Clone + Send + Sync + 'static {
     fn authenticate(
         &self,
         data: AuthenticateDto,
+        base_url: String,
     ) -> impl Future<Output = Result<JwtToken, AuthenticationError>> + Send;
 }

--- a/api/src/lib/domain/authentication/ports/grant_type_strategy.rs
+++ b/api/src/lib/domain/authentication/ports/grant_type_strategy.rs
@@ -4,6 +4,7 @@ use crate::domain::authentication::entities::{error::AuthenticationError, jwt_to
 
 pub struct GrantTypeParams {
     pub realm_id: Uuid,
+    pub base_url: String,
     pub realm_name: String,
     pub client_id: String,
     pub client_secret: Option<String>,

--- a/api/src/lib/domain/authentication/service/authentication.rs
+++ b/api/src/lib/domain/authentication/service/authentication.rs
@@ -144,7 +144,11 @@ impl AuthenticationService for AuthenticationServiceImpl {
         }
     }
 
-    async fn authenticate(&self, data: AuthenticateDto) -> Result<JwtToken, AuthenticationError> {
+    async fn authenticate(
+        &self,
+        data: AuthenticateDto,
+        base_url: String,
+    ) -> Result<JwtToken, AuthenticationError> {
         let realm = self
             .realm_service
             .get_by_name(data.realm_name.clone())
@@ -153,6 +157,7 @@ impl AuthenticationService for AuthenticationServiceImpl {
 
         let params = GrantTypeParams {
             realm_id: realm.id,
+            base_url,
             realm_name: realm.name,
             client_id: data.client_id.clone(),
             client_secret: data.client_secret.clone(),


### PR DESCRIPTION
This pull request introduces the `FullUrl` struct to extract and manage the full and base URLs of incoming requests, and updates the authentication flow to dynamically generate URLs and realm-specific claims. These changes enhance the flexibility and correctness of the URL handling and JWT claim generation processes.

### URL Handling Enhancements:
* Added a new `FullUrl` struct in `api/src/lib/application/url.rs` to extract the full and base URLs from incoming requests, using headers like `x-forwarded-proto` and `host` for accurate URL construction.
* Updated the `exchange_token` function in `api/src/lib/application/http/authentication/handlers/token.rs` to accept `FullUrl` as a parameter, providing the base URL for downstream processing.

### Authentication Flow Updates:
* Modified the `authenticate` method in the `AuthenticationService` trait to include a `base_url` parameter, enabling dynamic URL generation for JWT claims.
* Updated the `GrantTypeParams` struct in `api/src/lib/domain/authentication/ports/grant_type_strategy.rs` to include the `base_url` field for use in grant type strategies.

### JWT Claim Improvements:
* Replaced hardcoded URLs and realm names in JWT claims with dynamically generated values using the `base_url` and `realm_name` fields in all grant type strategies (`AuthorizationCodeStrategy`, `ClientCredentialsStrategy`, `PasswordStrategy`, and `RefreshTokenStrategy`).