### PR TITLE
refactor: authentication handler to use AuthenticateUseCase

### DIFF
--- a/api/src/lib/application/http/authentication/handlers/authentificate.rs
+++ b/api/src/lib/application/http/authentication/handlers/authentificate.rs
@@ -2,7 +2,6 @@ use axum::extract::{Query, State};
 use axum_cookie::CookieManager;
 use axum_macros::TypedPath;
 use serde::{Deserialize, Serialize};
-use tracing::{error, info};
 use typeshare::typeshare;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -13,13 +12,12 @@ use crate::application::http::server::api_entities::api_error::{ApiError, Valida
 use crate::application::http::server::api_entities::response::Response;
 use crate::application::http::server::app_state::AppState;
 use crate::application::url::FullUrl;
-use crate::domain::authentication::ports::{
-    auth_session::AuthSessionService, authentication::AuthenticationService,
+
+use crate::domain::authentication::use_cases::entities::{
+    AuthenticateCommand, AuthenticateResult, AuthenticationStepStatus,
 };
-use crate::domain::jwt::ports::jwt_service::JwtService;
-use crate::domain::realm::ports::realm_service::RealmService;
+
 use crate::domain::user::entities::required_action::RequiredAction;
-use crate::domain::utils::generate_random_string;
 
 #[derive(Serialize, Deserialize)]
 #[typeshare]
@@ -64,6 +62,45 @@ pub struct TokenRoute {
     realm_name: String,
 }
 
+impl From<AuthenticateResult> for AuthenticateResponse {
+    fn from(result: AuthenticateResult) -> Self {
+        match result.status {
+            AuthenticationStepStatus::Success => AuthenticateResponse {
+                status: AuthenticationStatus::Success,
+                url: result.redirect_url,
+                required_actions: None,
+                token: None,
+                message: Some("Authentication successful".to_string()),
+            },
+            AuthenticationStepStatus::RequiresActions => AuthenticateResponse {
+                status: AuthenticationStatus::RequiresActions,
+                url: None,
+                required_actions: if result.required_actions.is_empty() {
+                    None
+                } else {
+                    Some(result.required_actions)
+                },
+                token: result.temporary_token,
+                message: Some("Additional actions required before login".to_string()),
+            },
+            AuthenticationStepStatus::RequiresOtpChallenge => AuthenticateResponse {
+                status: AuthenticationStatus::RequiresOtpChallenge,
+                url: None,
+                required_actions: None,
+                token: result.temporary_token,
+                message: Some("OTP verification required".to_string()),
+            },
+            AuthenticationStepStatus::Failed => AuthenticateResponse {
+                status: AuthenticationStatus::Failed,
+                url: None,
+                required_actions: None,
+                token: None,
+                message: Some("Authentication failed".to_string()),
+            },
+        }
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/login-actions/authenticate",
@@ -87,144 +124,41 @@ pub async fn authenticate(
 
     let session_code = Uuid::parse_str(&session_code).unwrap();
 
-    info!("Authenticating user with session code: {}", session_code);
-
-    let auth_session = state
-        .auth_session_service
-        .get_by_session_code(session_code)
-        .await
-        .map_err(|_| ApiError::Unauthorized("invalid session code".to_string()))?;
-
-    let realm = state
-        .realm_service
-        .get_by_name(realm_name.clone())
-        .await
-        .map_err(|_| ApiError::Unauthorized("invalid realm name".to_string()))?;
-
-    if let Some(result_token) = optional_token {
-        info!("optional_token present");
-        state
-            .jwt_service
-            .verify_token(result_token.token, realm.id)
-            .await
-            .map_err(|e| {
-                error!("invalid token: {}", e);
-                ApiError::Unauthorized("invalid token".to_string())
-            })?;
-
-        let auth_session = state
-            .auth_session_service
-            .get_by_session_code(session_code)
-            .await
-            .map_err(|_| ApiError::Unauthorized("invalid session code".to_string()))?;
-
-        let code = generate_random_string();
-        let user_id = Uuid::parse_str(&result_token.decoded_token.sub)
-            .map_err(|_| ApiError::Unauthorized("invalid sub id".to_string()))?;
-        state
-            .auth_session_service
-            .update_code(session_code, code.clone(), user_id)
-            .await
-            .map_err(|_| ApiError::Unauthorized("invalid session code".to_string()))?;
-
-        let current_state = auth_session
-            .state
-            .ok_or(ApiError::Unauthorized("Invlaid session state".to_string()))?;
-        let login_url = format!(
-            "{}?code={}&state={}",
-            auth_session.redirect_uri, code, current_state
-        );
-
-        let response = AuthenticateResponse {
-            status: AuthenticationStatus::Success,
-            url: Some(login_url),
-            required_actions: None,
-            message: None,
-            token: None,
-        };
-
-        return Ok(Response::OK(response));
-    }
-
-    let username = payload
-        .username
-        .ok_or(ApiError::Unauthorized("username is required".to_string()))?;
-
-    let password = payload
-        .password
-        .ok_or(ApiError::Unauthorized("password is required".to_string()))?;
-
-    let auth_result = state
-        .authentication_service
-        .using_session_code(
-            realm_name.clone(),
+    let command = if let Some(token) = optional_token {
+        AuthenticateCommand::with_existing_token(
+            realm_name,
             query.client_id,
-            auth_session.id,
+            session_code,
+            base_url,
+            token.token,
+        )
+    } else {
+        let username = payload
+            .username
+            .clone()
+            .ok_or_else(|| ApiError::BadRequest("username is required".to_string()))?;
+        let password = payload
+            .password
+            .clone()
+            .ok_or_else(|| ApiError::BadRequest("password is required".to_string()))?;
+
+        AuthenticateCommand::with_user_credentials(
+            realm_name.clone(),
+            query.client_id.clone(),
+            session_code,
+            base_url.clone(),
             username,
             password,
-            base_url,
         )
+    };
+
+    let result = state
+        .authenticate_use_case
+        .execute(command)
         .await
         .map_err(|_| ApiError::Unauthorized("invalid credentials".to_string()))?;
 
-    if !auth_result.required_actions.is_empty() {
-        let response = AuthenticateResponse {
-            status: AuthenticationStatus::RequiresActions,
-            url: None,
-            required_actions: Some(auth_result.required_actions),
-            message: Some("Additional actions required before login".to_string()),
-            token: auth_result.token,
-        };
-
-        return Ok(Response::OK(response));
-    }
-
-    let has_otp_credentials = auth_result.credentials.iter().any(|cred| cred == "otp");
-
-    if has_otp_credentials
-        && !auth_result
-            .required_actions
-            .contains(&RequiredAction::ConfigureOtp)
-    {
-        let response = AuthenticateResponse {
-            status: AuthenticationStatus::RequiresOtpChallenge,
-            url: None,
-            required_actions: None,
-            message: Some("OTP verification required".to_string()),
-            token: auth_result.token,
-        };
-
-        return Ok(Response::OK(response));
-    }
-
-    let code = auth_result.code.ok_or(ApiError::Unauthorized(
-        "No authorization code generated".to_string(),
-    ))?;
-
-    if auth_session.code.is_none() {
-        state
-            .auth_session_service
-            .update_code(session_code, code.clone(), auth_result.user_id)
-            .await
-            .map_err(|_| ApiError::Unauthorized("Failed to update session".to_string()))?;
-    }
-
-    let current_state = auth_session
-        .state
-        .ok_or(ApiError::Unauthorized("Invalid session state".to_string()))?;
-
-    let login_url = format!(
-        "{}?code={}&state={}",
-        auth_session.redirect_uri, code, current_state
-    );
-
-    let response = AuthenticateResponse {
-        status: AuthenticationStatus::Success,
-        url: Some(login_url),
-        required_actions: None,
-        message: None,
-        token: auth_result.token,
-    };
+    let response: AuthenticateResponse = result.into();
 
     Ok(Response::OK(response))
 }

--- a/api/src/lib/application/http/server/app_state.rs
+++ b/api/src/lib/application/http/server/app_state.rs
@@ -2,8 +2,12 @@ use std::sync::Arc;
 
 use crate::{
     domain::{
-        authentication::service::{
-            auth_session::DefaultAuthSessionService, authentication::DefaultAuthenticationService,
+        authentication::{
+            service::{
+                auth_session::DefaultAuthSessionService,
+                authentication::DefaultAuthenticationService,
+            },
+            use_cases::authenticate_use_case::AuthenticateUseCase,
         },
         client::services::{
             client_service::DefaultClientService, redirect_uri_service::DefaultRedirectUriService,
@@ -36,4 +40,7 @@ pub struct AppState {
     pub mediator_service: DefaultMediatorService,
     pub totp_service: DefaultTotpService,
     pub env: Arc<Env>,
+
+    // Use cases
+    pub authenticate_use_case: AuthenticateUseCase,
 }

--- a/api/src/lib/application/server.rs
+++ b/api/src/lib/application/server.rs
@@ -8,6 +8,7 @@ use crate::{
                 auth_session::DefaultAuthSessionService,
                 authentication::DefaultAuthenticationService,
             },
+            use_cases::authenticate_use_case::AuthenticateUseCase,
         },
         client::{
             ports::{
@@ -232,6 +233,13 @@ impl
 
         let totp_service = DefaultTotpService::new();
 
+        let authenticate_use_case = AuthenticateUseCase::new(
+            realm_service.clone(),
+            auth_session_service.clone(),
+            jwt_service.clone(),
+            authentication_service.clone(),
+        );
+
         AppState {
             realm_service,
             client_service,
@@ -246,6 +254,9 @@ impl
             mediator_service,
             totp_service,
             env: Arc::clone(&env),
+
+            // Use-cases
+            authenticate_use_case,
         }
     }
 }

--- a/api/src/lib/domain/authentication.rs
+++ b/api/src/lib/domain/authentication.rs
@@ -2,3 +2,4 @@ pub mod entities;
 pub mod grant_type_strategies;
 pub mod ports;
 pub mod service;
+pub mod use_cases;

--- a/api/src/lib/domain/authentication/use_cases.rs
+++ b/api/src/lib/domain/authentication/use_cases.rs
@@ -1,0 +1,2 @@
+pub mod authenticate_use_case;
+pub mod entities;

--- a/api/src/lib/domain/authentication/use_cases/authenticate_use_case.rs
+++ b/api/src/lib/domain/authentication/use_cases/authenticate_use_case.rs
@@ -1,0 +1,222 @@
+use tracing::info;
+use uuid::Uuid;
+
+use crate::domain::{
+    authentication::{
+        entities::{auth_session::AuthSession, error::AuthenticationError},
+        ports::{
+            auth_session::AuthSessionService,
+            authentication::{AuthenticationResult, AuthenticationService},
+        },
+        service::{
+            auth_session::DefaultAuthSessionService, authentication::DefaultAuthenticationService,
+        },
+        use_cases::entities::{AuthenticateCommand, AuthenticateResult, AuthenticationMethod},
+    },
+    jwt::{ports::jwt_service::JwtService, services::jwt_service::DefaultJwtService},
+    realm::{
+        entities::realm::Realm, ports::realm_service::RealmService,
+        services::realm_service::DefaultRealmService,
+    },
+    user::entities::required_action::RequiredAction,
+    utils::generate_random_string,
+};
+
+#[derive(Clone)]
+pub struct AuthenticateUseCase {
+    realm_service: DefaultRealmService,
+    auth_session_service: DefaultAuthSessionService,
+    jwt_service: DefaultJwtService,
+    authentication_service: DefaultAuthenticationService,
+}
+
+#[derive(Debug)]
+struct CredentialsAuthParams {
+    realm_name: String,
+    client_id: String,
+    session_code: Uuid,
+    base_url: String,
+    username: String,
+    password: String,
+}
+
+impl AuthenticateUseCase {
+    pub fn new(
+        realm_service: DefaultRealmService,
+        auth_session_service: DefaultAuthSessionService,
+        jwt_service: DefaultJwtService,
+        authentication_service: DefaultAuthenticationService,
+    ) -> Self {
+        Self {
+            realm_service,
+            auth_session_service,
+            jwt_service,
+            authentication_service,
+        }
+    }
+
+    pub async fn execute(
+        &self,
+        command: AuthenticateCommand,
+    ) -> Result<AuthenticateResult, AuthenticationError> {
+        info!("starting authentication for realm: {}", command.realm_name);
+
+        // 1. Valider la session et le realm
+        let (realm, auth_session) = self.validate_session_and_realm(&command).await?;
+
+        match command.auth_method {
+            AuthenticationMethod::ExistingToken { token } => {
+                self.handle_token_refresh(token, realm.id, auth_session, command.session_code)
+                    .await
+            }
+            AuthenticationMethod::UserCredentials { username, password } => {
+                let params = CredentialsAuthParams {
+                    realm_name: command.realm_name,
+                    client_id: command.client_id,
+                    session_code: command.session_code,
+                    base_url: command.base_url,
+                    username,
+                    password,
+                };
+
+                self.handle_user_credentials_authentication(params, auth_session)
+                    .await
+            }
+        }
+    }
+
+    async fn validate_session_and_realm(
+        &self,
+        command: &AuthenticateCommand,
+    ) -> Result<(Realm, AuthSession), AuthenticationError> {
+        let auth_session = self
+            .auth_session_service
+            .get_by_session_code(command.session_code)
+            .await
+            .map_err(|_| AuthenticationError::InternalServerError)?;
+
+        let realm = self
+            .realm_service
+            .get_by_name(command.realm_name.clone())
+            .await
+            .map_err(|_| AuthenticationError::InvalidRealm)?;
+
+        Ok((realm, auth_session))
+    }
+
+    async fn handle_token_refresh(
+        &self,
+        token: String,
+        realm_id: Uuid,
+        auth_session: AuthSession,
+        session_code: Uuid,
+    ) -> Result<AuthenticateResult, AuthenticationError> {
+        let claims = self
+            .jwt_service
+            .verify_token(token.clone(), realm_id)
+            .await
+            .map_err(|_| AuthenticationError::InternalServerError)?;
+
+        // Finaliser l'authentification
+        self.finalize_authentication(claims.sub, session_code, auth_session)
+            .await
+    }
+
+    async fn handle_user_credentials_authentication(
+        &self,
+        params: CredentialsAuthParams,
+        auth_session: AuthSession,
+    ) -> Result<AuthenticateResult, AuthenticationError> {
+        // Déléguer l'authentification au service existant
+        let auth_result = self
+            .authentication_service
+            .using_session_code(
+                params.realm_name,
+                params.client_id,
+                params.session_code,
+                params.username,
+                params.password,
+                params.base_url,
+            )
+            .await?;
+
+        // Analyser le résultat et déterminer la prochaine étape
+        self.determine_next_step(auth_result, params.session_code, auth_session)
+            .await
+    }
+
+    async fn determine_next_step(
+        &self,
+        auth_result: AuthenticationResult,
+        session_code: Uuid,
+        auth_session: AuthSession,
+    ) -> Result<AuthenticateResult, AuthenticationError> {
+        // 1. Vérifier s'il y a des actions requises
+        if !auth_result.required_actions.is_empty() {
+            return Ok(AuthenticateResult::requires_actions(
+                auth_result.user_id,
+                auth_result.required_actions,
+                auth_result
+                    .token
+                    .ok_or(AuthenticationError::InternalServerError)?,
+            ));
+        }
+
+        let has_otp_credentials = auth_result.credentials.iter().any(|cred| cred == "otp");
+        let needs_configure_otp = auth_result
+            .required_actions
+            .contains(&RequiredAction::ConfigureOtp);
+
+        if has_otp_credentials && !needs_configure_otp {
+            let token = auth_result
+                .token
+                .ok_or(AuthenticationError::InternalServerError)?;
+            return Ok(AuthenticateResult::requires_otp_challenge(
+                auth_result.user_id,
+                token,
+            ));
+        }
+
+        // 3. Authentification complète
+        self.finalize_authentication(auth_result.user_id, session_code, auth_session)
+            .await
+    }
+
+    async fn finalize_authentication(
+        &self,
+        user_id: Uuid,
+        session_code: Uuid,
+        auth_session: AuthSession,
+    ) -> Result<AuthenticateResult, AuthenticationError> {
+        let authorization_code = generate_random_string();
+
+        self.auth_session_service
+            .update_code(session_code, authorization_code.clone(), user_id)
+            .await
+            .map_err(|_| AuthenticationError::InternalServerError)?;
+
+        let redirect_url = self.build_redirect_url(&auth_session, &authorization_code)?;
+
+        Ok(AuthenticateResult::complete_with_redirect(
+            user_id,
+            authorization_code,
+            redirect_url,
+        ))
+    }
+
+    fn build_redirect_url(
+        &self,
+        auth_session: &AuthSession,
+        authorization_code: &str,
+    ) -> Result<String, AuthenticationError> {
+        let state = auth_session
+            .state
+            .as_ref()
+            .ok_or(AuthenticationError::InternalServerError)?;
+
+        Ok(format!(
+            "{}?code={}&state={}",
+            auth_session.redirect_uri, authorization_code, state
+        ))
+    }
+}

--- a/api/src/lib/domain/authentication/use_cases/entities.rs
+++ b/api/src/lib/domain/authentication/use_cases/entities.rs
@@ -1,0 +1,129 @@
+use uuid::Uuid;
+
+use crate::domain::user::entities::required_action::RequiredAction;
+
+#[derive(Debug, Clone)]
+pub struct AuthenticateResult {
+    pub user_id: Uuid,
+    pub status: AuthenticationStepStatus,
+    pub authorization_code: Option<String>,
+    pub temporary_token: Option<String>,
+    pub required_actions: Vec<RequiredAction>,
+    pub redirect_url: Option<String>,
+    pub session_state: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AuthenticationStepStatus {
+    Success,
+    RequiresActions,
+    RequiresOtpChallenge,
+    Failed,
+}
+
+impl AuthenticateResult {
+    pub fn complete_with_redirect(
+        user_id: Uuid,
+        authorization_code: String,
+        redirect_url: String,
+    ) -> Self {
+        Self {
+            user_id,
+            status: AuthenticationStepStatus::Success,
+            authorization_code: Some(authorization_code),
+            temporary_token: None,
+            required_actions: Vec::new(),
+            redirect_url: Some(redirect_url),
+            session_state: None,
+        }
+    }
+
+    pub fn requires_actions(
+        user_id: Uuid,
+        required_actions: Vec<RequiredAction>,
+        temporary_token: String,
+    ) -> Self {
+        Self {
+            user_id,
+            status: AuthenticationStepStatus::RequiresActions,
+            authorization_code: None,
+            temporary_token: Some(temporary_token),
+            required_actions,
+            redirect_url: None,
+            session_state: None,
+        }
+    }
+
+    pub fn requires_otp_challenge(user_id: Uuid, temporary_token: String) -> Self {
+        Self {
+            user_id,
+            status: AuthenticationStepStatus::RequiresOtpChallenge,
+            authorization_code: None,
+            temporary_token: Some(temporary_token),
+            required_actions: Vec::new(),
+            redirect_url: None,
+            session_state: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticateCommand {
+    pub realm_name: String,
+    pub client_id: String,
+    pub session_code: Uuid,
+    pub base_url: String,
+    pub auth_method: AuthenticationMethod,
+}
+
+#[derive(Debug, Clone)]
+pub enum AuthenticationMethod {
+    UserCredentials { username: String, password: String },
+    ExistingToken { token: String },
+}
+
+impl AuthenticateCommand {
+    pub fn with_user_credentials(
+        realm_name: String,
+        client_id: String,
+        session_code: Uuid,
+        base_url: String,
+        username: String,
+        password: String,
+    ) -> Self {
+        Self {
+            realm_name,
+            client_id,
+            session_code,
+            base_url,
+            auth_method: AuthenticationMethod::UserCredentials { username, password },
+        }
+    }
+
+    pub fn with_existing_token(
+        realm_name: String,
+        client_id: String,
+        session_code: Uuid,
+        base_url: String,
+        token: String,
+    ) -> Self {
+        Self {
+            realm_name,
+            client_id,
+            session_code,
+            base_url,
+            auth_method: AuthenticationMethod::ExistingToken { token },
+        }
+    }
+
+    pub fn is_token_refresh(&self) -> bool {
+        matches!(self.auth_method, AuthenticationMethod::ExistingToken { .. })
+    }
+
+    pub fn is_credential_auth(&self) -> bool {
+        matches!(
+            self.auth_method,
+            AuthenticationMethod::UserCredentials { .. }
+        )
+    }
+}


### PR DESCRIPTION
Move authentication logic into AuthenticateUseCase for improved separation of concerns and maintainability. Update handler and app state to use the new use case.