### PR TITLE
Safe handling of session cookie unwrapping

### DIFF
--- a/api/src/lib/application/http/authentication/handlers/authentificate.rs
+++ b/api/src/lib/application/http/authentication/handlers/authentificate.rs
@@ -116,7 +116,10 @@ pub async fn authenticate(
     cookie: CookieManager,
     ValidateJson(payload): ValidateJson<AuthenticateRequest>,
 ) -> Result<Response<AuthenticateResponse>, ApiError> {
-    let session_code = cookie.get("FERRISKEY_SESSION").unwrap();
+    let session_code = match cookie.get("FERRISKEY_SESSION"){
+        Some(cookie) => cookie,
+        None => return Err(ApiError::Unauthorized("Missing session cookie".to_string()))
+    };
     let session_code = session_code.value().to_string();
 
     let session_code = Uuid::parse_str(&session_code).unwrap();


### PR DESCRIPTION
The issue was that the cookie was unsafely unpacked causes crashes when the cookie wasn't set.
I have decided to put a 401 Unauthorized code but could be 400 Bad Request I guess ...