### PR TITLE
Removed 2 un-necessary clones

### DIFF
--- a/api/src/bin/main.rs
+++ b/api/src/bin/main.rs
@@ -57,10 +57,6 @@ async fn main() -> Result<(), anyhow::Error> {
     })
     .await?;
 
-    let use_case_bundle = UseCaseBundle::new(service_bundle.clone());
-
-    let app_state = AppState::new(env.clone(), service_bundle.clone(), use_case_bundle);
-
     let startup_orchestrator = StartupOrchestrator::new(StartupOrchestratorBuilder {
         realm_service: service_bundle.realm_service.clone(),
         user_service: service_bundle.user_service.clone(),
@@ -86,6 +82,8 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let server_config = HttpServerConfig::new(env.port.clone());
 
+    let use_case_bundle = UseCaseBundle::new(&service_bundle);
+    let app_state = AppState::new(env.clone(), service_bundle, use_case_bundle);
     let http_server = HttpServer::new(env.clone(), server_config, app_state).await?;
 
     http_server.run().await?;

--- a/core/src/application/common/factories.rs
+++ b/core/src/application/common/factories.rs
@@ -92,7 +92,7 @@ pub struct UseCaseBundle {
 }
 
 impl UseCaseBundle {
-    pub fn new(service_bundle: ServiceBundle) -> Self {
+    pub fn new(service_bundle: &ServiceBundle) -> Self {
         // Auth (use-cases)
 
         let exchange_token_use_case = ExchangeTokenUseCase::new(


### PR DESCRIPTION
Change `ServiceBundle` argument to be passed by reference, removing the need to clone it.
Re-order the initialization in the stack, removing the need to clone it.
