### PR TITLE
Added minimal test to API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "axum-extra",
  "axum-macros",
  "axum-prometheus",
+ "axum-test",
  "base32",
  "base64",
  "chrono",
@@ -150,8 +151,10 @@ dependencies = [
  "dotenv",
  "ferriskey_core",
  "regex",
+ "sea-orm",
  "serde",
  "serde_json",
+ "test-context",
  "thiserror 2.0.12",
  "tokio",
  "tower-http",
@@ -190,6 +193,16 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -244,6 +257,12 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
 
 [[package]]
 name = "autocfg"
@@ -374,6 +393,36 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+]
+
+[[package]]
+name = "axum-test"
+version = "17.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb1dfb84bd48bad8e4aa1acb82ed24c2bb5e855b659959b4e03b4dca118fcac"
+dependencies = [
+ "anyhow",
+ "assert-json-diff",
+ "auto-future",
+ "axum",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -537,6 +586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bytesize"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
+
+[[package]]
 name = "cc"
 version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +687,16 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "cookie-rs"
@@ -818,6 +883,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2332,6 +2403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "reserve-port"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2749,21 @@ checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
 dependencies = [
  "sha2",
  "walkdir",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c839d037155ebc06a571e305af66ff9fd9063a6e662447051737e1ac75beea41"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "mime",
+ "rand 0.9.2",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3476,6 +3581,27 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "test-context"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb69cce03e432993e2dc1f93f7899b952300fcb6dc44191a1b830b60b8c3c8aa"
+dependencies = [
+ "futures",
+ "test-context-macros",
+]
+
+[[package]]
+name = "test-context-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e0639209021e54dbe19cafabfc0b5574b078c37358945e6d473eabe39bb974"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "thiserror"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -41,3 +41,8 @@ uuid = { version = "1.16.0", features = ["serde", "v4", "v7"] }
 validator = { version = "0.20.0", features = ["derive"] }
 base32 = "0.5.1"
 axum-prometheus = "0.8.0"
+
+[dev-dependencies]
+test-context = "*"
+axum-test = "*"
+sea-orm = { version = "1.1.14", features = ["sqlx-postgres"]}

--- a/api/src/lib/application/http/server/http_server.rs
+++ b/api/src/lib/application/http/server/http_server.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::application::http::authentication::router::authentication_routes;
 use crate::application::http::client::router::client_routes;
 use crate::application::http::realm::router::realm_routes;
@@ -10,124 +12,100 @@ use crate::application::http::user::router::user_routes;
 use super::config::get_config;
 use crate::application::http::health::health_routes;
 use crate::env::Env;
-use anyhow::Context;
 use axum::Router;
 use axum::http::header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
 use axum::http::{HeaderValue, Method};
+use axum::routing::get;
 use axum_cookie::prelude::*;
 use axum_extra::routing::RouterExt;
-use std::sync::Arc;
-use axum::routing::get;
 use axum_prometheus::PrometheusMetricLayer;
 use tower_http::cors::CorsLayer;
 use tracing::info_span;
-use tracing::log::info;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-pub struct HttpServerConfig {
-    port: String,
+use ferriskey_core::application::common::factories::UseCaseBundle;
+use ferriskey_core::infrastructure::common::factories::service_factory::{
+    ServiceFactory, ServiceFactoryConfig,
+};
+
+pub async fn state(env: Arc<Env>) -> Result<AppState, anyhow::Error> {
+    let service_bundle = ServiceFactory::create_all_services(ServiceFactoryConfig {
+        database_url: env.database_url.clone(),
+    })
+    .await?;
+
+    let use_case = UseCaseBundle::new(&service_bundle);
+
+    Ok(AppState::new(env, service_bundle, use_case))
 }
 
-impl HttpServerConfig {
-    pub fn new(port: String) -> Self {
-        Self { port }
-    }
-}
+///  Returns the [`Router`] of this application.
+pub fn router(state: AppState) -> Result<Router, anyhow::Error> {
+    let trace_layer = tower_http::trace::TraceLayer::new_for_http().make_span_with(
+        |request: &axum::extract::Request| {
+            let uri: String = request.uri().to_string();
+            info_span!("http_request", method = ?request.method(), uri)
+        },
+    );
 
-pub struct HttpServer {
-    router: Router,
-    listener: tokio::net::TcpListener,
-}
+    // Split the allowed origins from the environment variable (",") after this transform Vec<&str> into Vec<HeaderValue>
 
-impl HttpServer {
-    pub async fn new(
-        env: Arc<Env>,
-        config: HttpServerConfig,
-        state: AppState,
-    ) -> Result<Self, anyhow::Error> {
-        let trace_layer = tower_http::trace::TraceLayer::new_for_http().make_span_with(
-            |request: &axum::extract::Request| {
-                let uri: String = request.uri().to_string();
-                info_span!("http_request", method = ?request.method(), uri)
-            },
-        );
-
-        // Split the allowed origins from the environment variable (",") after this transform Vec<&str> into Vec<HeaderValue>
-
-        let allowed_origins_from_env = env
-            .allowed_origins
-            .clone()
-            .split(",")
-            .map(|origin| HeaderValue::from_str(origin).unwrap())
-            .collect::<Vec<HeaderValue>>();
-
-        let allowed_origins: Vec<HeaderValue> = vec![
-            HeaderValue::from_static("http://localhost:3000"),
-            HeaderValue::from_static("http://localhost:5173"),
-            HeaderValue::from_static("http://localhost:5174"),
-            HeaderValue::from_static("http://localhost:4321"),
-            HeaderValue::from_static("http://localhost:5555"),
-        ]
-        .into_iter()
-        .chain(allowed_origins_from_env.into_iter())
+    let allowed_origins_from_env = state
+        .env
+        .allowed_origins
+        .clone()
+        .split(",")
+        .map(|origin| HeaderValue::from_str(origin).unwrap())
         .collect::<Vec<HeaderValue>>();
 
-        let cors = CorsLayer::new()
-            .allow_methods([
-                Method::GET,
-                Method::POST,
-                Method::DELETE,
-                Method::PUT,
-                Method::PATCH,
-                Method::OPTIONS,
-            ])
-            .allow_origin(allowed_origins)
-            .allow_headers([
-                AUTHORIZATION,
-                CONTENT_TYPE,
-                CONTENT_LENGTH,
-                ACCEPT,
-                LOCATION,
-            ])
-            .allow_credentials(true);
+    let allowed_origins: Vec<HeaderValue> = vec![
+        HeaderValue::from_static("http://localhost:3000"),
+        HeaderValue::from_static("http://localhost:5173"),
+        HeaderValue::from_static("http://localhost:5174"),
+        HeaderValue::from_static("http://localhost:4321"),
+        HeaderValue::from_static("http://localhost:5555"),
+    ]
+    .into_iter()
+    .chain(allowed_origins_from_env.into_iter())
+    .collect::<Vec<HeaderValue>>();
 
-        let (prometheus_layer, metric_handle) = PrometheusMetricLayer::pair();
+    let cors = CorsLayer::new()
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::DELETE,
+            Method::PUT,
+            Method::PATCH,
+            Method::OPTIONS,
+        ])
+        .allow_origin(allowed_origins)
+        .allow_headers([
+            AUTHORIZATION,
+            CONTENT_TYPE,
+            CONTENT_LENGTH,
+            ACCEPT,
+            LOCATION,
+        ])
+        .allow_credentials(true);
 
-        let router = axum::Router::new()
-            .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
-            .typed_get(get_config)
-            .merge(realm_routes(state.clone()))
-            .merge(client_routes(state.clone()))
-            .merge(user_routes(state.clone()))
-            .merge(authentication_routes())
-            .merge(role_routes(state.clone()))
-            .merge(trident_routes(state.clone()))
-            .merge(health_routes())
-            .route("/metrics", get(|| async move { metric_handle.render() }))
-            .layer(trace_layer)
-            .layer(cors)
-            .layer(CookieLayer::default())
-            .layer(prometheus_layer)
-            .with_state(state);
+    let (prometheus_layer, metric_handle) = PrometheusMetricLayer::pair();
 
-        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", config.port))
-            .await
-            .with_context(|| format!("Failed to bind to port {}", config.port))?;
-
-        Ok(Self { router, listener })
-    }
-
-    pub async fn run(self) -> Result<(), anyhow::Error> {
-        info!(
-            "Server is running on http://{}",
-            self.listener.local_addr()?
-        );
-
-        axum::serve(self.listener, self.router)
-            .await
-            .context("received error while running server")?;
-
-        Ok(())
-    }
+    let router = axum::Router::new()
+        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .typed_get(get_config)
+        .merge(realm_routes(state.clone()))
+        .merge(client_routes(state.clone()))
+        .merge(user_routes(state.clone()))
+        .merge(authentication_routes())
+        .merge(role_routes(state.clone()))
+        .merge(trident_routes(state.clone()))
+        .merge(health_routes())
+        .route("/metrics", get(|| async move { metric_handle.render() }))
+        .layer(trace_layer)
+        .layer(cors)
+        .layer(CookieLayer::default())
+        .layer(prometheus_layer)
+        .with_state(state);
+    Ok(router)
 }

--- a/api/tests/it/docker.rs
+++ b/api/tests/it/docker.rs
@@ -1,0 +1,23 @@
+pub fn stop_container(id: &str) {
+    std::process::Command::new("docker")
+        .args(["rm", "-f", id])
+        .output()
+        .unwrap();
+}
+
+pub fn start_container(command: &str, args: &[&str], is_ready: impl Fn(&str) -> bool) -> String {
+    let r = std::process::Command::new(command)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(r.status.success());
+    let id = String::from_utf8(r.stdout).unwrap();
+
+    for _ in 0..20 {
+        if is_ready(&id) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+    id
+}

--- a/api/tests/it/main.rs
+++ b/api/tests/it/main.rs
@@ -1,0 +1,63 @@
+mod docker;
+mod postgres_context;
+
+use std::sync::Arc;
+
+use axum_test::TestServer;
+use postgres_context::DBContext;
+use test_context::test_context;
+
+use ferriskey::{
+    application::http::server::http_server::{router, state},
+    env::Env,
+};
+
+use sea_orm::Database;
+pub use sea_orm::DatabaseConnection;
+use sea_orm::{ConnectionTrait, Statement};
+
+fn mock_env(database_url: &str) -> Env {
+    Env {
+        port: "80".to_string(),
+        database_url: database_url.to_string(),
+        portal_url: "http://localhost:80".to_string(),
+        allowed_origins: "AllowOrigin::any()".to_string(),
+        admin_password: "password".to_string(),
+        admin_username: "admin".to_string(),
+        admin_email: "password".to_string(),
+        ..Default::default()
+    }
+}
+
+/// Test that we can interact with the database somehow.
+#[test_context(DBContext)]
+#[tokio::test]
+async fn test_db_client(ctx: &mut DBContext) -> Result<(), String> {
+    let db = Database::connect(ctx.url()).await.unwrap();
+
+    let stmt = Statement::from_string(
+        db.get_database_backend(),
+        "SELECT 'hello world' as value".to_owned(),
+    );
+    let row = db.query_one(stmt).await.unwrap().unwrap();
+    let result: String = row.try_get("", "value").unwrap();
+
+    assert_eq!(result, "hello world");
+    Ok(())
+}
+
+/// Test that we can start the server with the database, and return 404
+#[test_context(DBContext)]
+#[tokio::test]
+async fn test_404(ctx: &mut DBContext) -> Result<(), String> {
+    let env = mock_env(ctx.url());
+    let state = state(Arc::new(env)).await.unwrap();
+
+    let app = router(state).unwrap();
+
+    let server = TestServer::new(app).unwrap();
+
+    let r = server.get("/something-non-existent").await;
+    assert_eq!(r.status_code(), 404); // we can start the server and it returns 404, yey
+    Ok(())
+}

--- a/api/tests/it/postgres_context.rs
+++ b/api/tests/it/postgres_context.rs
@@ -1,0 +1,89 @@
+use std::sync::{Arc, LazyLock, Mutex};
+
+use test_context::AsyncTestContext;
+
+use crate::docker::*;
+
+fn start_db() -> String {
+    let args = [
+        "run",
+        "-d",
+        "-e",
+        "POSTGRES_PASSWORD=password",
+        "-p",
+        "5432:5432",
+        "postgres:latest",
+    ];
+    start_container("docker", &args, |id| {
+        std::process::Command::new("docker")
+            .args(["exec", &id, "pg_isready", "-t", "90"])
+            .output()
+            .unwrap()
+            .status
+            .success()
+    })
+}
+
+struct DB {
+    id: String,
+}
+
+impl DB {
+    fn new() -> Self {
+        Self { id: start_db() }
+    }
+}
+
+impl Drop for DB {
+    fn drop(&mut self) {
+        stop_container(&self.id)
+    }
+}
+
+static DB_INSTANCE: LazyLock<Mutex<Option<Arc<DB>>>> = LazyLock::new(|| Mutex::new(None));
+
+pub struct DBContext {
+    _id: Arc<DB>,
+}
+
+impl DBContext {
+    pub fn url(&self) -> &'static str {
+        "postgresql://postgres:password@localhost"
+    }
+}
+
+impl AsyncTestContext for DBContext {
+    async fn setup() -> DBContext {
+        let mut is_new = false;
+        let _id = {
+            let mut lock = DB_INSTANCE.lock().unwrap();
+            if let Some(db) = &*lock {
+                db.clone()
+            } else {
+                is_new = true;
+                let db = Arc::new(DB::new());
+                *lock = Some(db.clone());
+                db
+            }
+        };
+
+        if is_new {
+            // todo: migrate it
+            //let _ = migrate("postgresql://postgres:password@localhost")
+            //    .await
+            //    .unwrap();
+        }
+
+        DBContext { _id }
+    }
+
+    async fn teardown(self) {
+        let mut lock = DB_INSTANCE.lock().unwrap();
+        let arc = lock.as_ref();
+        if let Some(arc) = arc {
+            if Arc::strong_count(arc) == 2 {
+                *lock = None; // Remove from static; since static does not call Drop
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR prepares the testing infrastructure to test the API. It includes:

1. A test context manager to run a postgres container, so we can use it in tests
2. A test demonstrating that we can create the server and get a 404
3. A small refactor of the API lib to make it easier to get the router out of the Env

Note: the postgres container lives for the duration of all tests and gets removed at the end. This is usually better than handling it via a docker compose, as we can tie its lifecycle the tests, allowing developers to continue to be able to just use `cargo test`.