### PR TITLE
refacto: refactor API client usage to window-scoped instances

### DIFF
--- a/front/src/api/auth.api.ts
+++ b/front/src/api/auth.api.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { apiClient } from '.'
 import {
   AuthenticateRequest,
   AuthenticateResponse,
@@ -27,7 +26,7 @@ export const useAuthQuery = (params: AuthQuery) => {
   return useQuery({
     queryKey: ['auth'],
     queryFn: async (): Promise<AuthResponse> => {
-      const response = await apiClient.get<AuthResponse>(
+      const response = await window.axios.get<AuthResponse>(
         `/realms/${params.realm}/protocol/openid-connect/auth?${params.query}`
       )
 
@@ -45,7 +44,7 @@ export const useAuthenticateMutation = () => {
         headers.Authorization = `Bearer ${params.token}`
       }
 
-      const response = await apiClient.post<AuthenticateResponse>(
+      const response = await window.axios.post<AuthenticateResponse>(
         `/realms/${params.realm}/login-actions/authenticate?client_id=${params.clientId}&session_code=${params.sessionCode}`,
         params.data,
         {
@@ -87,7 +86,7 @@ export const useTokenMutation = () => {
         formData.append('refresh_token', params.data.refresh_token)
       }
 
-      const response = await apiClient.post<JwtToken>(
+      const response = await window.axios.post<JwtToken>(
         `/realms/${params.realm}/protocol/openid-connect/token`,
         formData,
         {

--- a/front/src/api/client.api.ts
+++ b/front/src/api/client.api.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { BaseQuery, tanstackApi } from '.'
+import { BaseQuery } from '.'
 import { CreateClientSchema } from '@/pages/client/schemas/create-client.schema.ts'
 import { toast } from 'sonner'
 
 export const useGetClients = ({ realm }: BaseQuery) => {
   return useQuery(
-    tanstackApi.get('/realms/{realm_name}/clients', {
+    window.tanstackApi.get('/realms/{realm_name}/clients', {
       path: {
         realm_name: realm || 'master',
       },
@@ -15,7 +15,7 @@ export const useGetClients = ({ realm }: BaseQuery) => {
 
 export const useGetClient = ({ realm, clientId }: BaseQuery & { clientId?: string }) => {
   return useQuery({
-    ...tanstackApi.get('/realms/{realm_name}/clients/{client_id}', {
+    ...window.tanstackApi.get('/realms/{realm_name}/clients/{client_id}', {
       path: {
         client_id: clientId!,
         realm_name: realm!,
@@ -34,7 +34,7 @@ export const useCreateClient = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    ...tanstackApi.mutation('post', '/realms/{realm_name}/clients').mutationOptions,
+    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/clients').mutationOptions,
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: ['clients'],
@@ -46,7 +46,8 @@ export const useCreateClient = () => {
 export const useUpdateClient = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    ...tanstackApi.mutation('patch', '/realms/{realm_name}/clients/{client_id}').mutationOptions,
+    ...window.tanstackApi.mutation('patch', '/realms/{realm_name}/clients/{client_id}')
+      .mutationOptions,
     onSuccess: async (payload) => {
       const client = await payload.json()
 
@@ -61,7 +62,8 @@ export const useUpdateClient = () => {
 export const useDeleteClient = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    ...tanstackApi.mutation('delete', '/realms/{realm_name}/clients/{client_id}').mutationOptions,
+    ...window.tanstackApi.mutation('delete', '/realms/{realm_name}/clients/{client_id}')
+      .mutationOptions,
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: ['clients'],
@@ -72,7 +74,7 @@ export const useDeleteClient = () => {
 
 export const useGetClientRoles = ({ realm, clientId }: BaseQuery & { clientId?: string }) => {
   return useQuery({
-    ...tanstackApi.get('/realms/{realm_name}/clients/{client_id}/roles', {
+    ...window.tanstackApi.get('/realms/{realm_name}/clients/{client_id}/roles', {
       path: {
         realm_name: realm!,
         client_id: clientId!,

--- a/front/src/api/config.api.ts
+++ b/front/src/api/config.api.ts
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
-import { apiClient } from '.'
 import { GetConfigResponse } from './api.interface'
 
 export const useGetConfig = () => {
   return useQuery({
     queryKey: ['config'],
     queryFn: async (): Promise<GetConfigResponse> => {
-      const response = await apiClient.get<GetConfigResponse>('/config')
+      const response = await window.axios.get<GetConfigResponse>('/config')
 
       return response.data
     },

--- a/front/src/api/credential.api.ts
+++ b/front/src/api/credential.api.ts
@@ -1,10 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { tanstackApi } from '@/api/index.ts'
 
 export const useDeleteUserCredential = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    ...tanstackApi.mutation(
+    ...window.tanstackApi.mutation(
       'delete',
       '/realms/{realm_name}/users/{user_id}/credentials/{credential_id}',
       async (res) => {
@@ -12,7 +11,7 @@ export const useDeleteUserCredential = () => {
       }
     ).mutationOptions,
     onSuccess: async (payload) => {
-      const keys = tanstackApi.get('/realms/{realm_name}/users/{user_id}/credentials', {
+      const keys = window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/credentials', {
         path: {
           realm_name: payload.realm_name,
           user_id: payload.user_id,

--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -1,25 +1,11 @@
-import axios from 'axios'
-import { createApiClient, Fetcher } from '@/api/api.client.ts'
-import { TanstackQueryApiClient } from '@/api/api.tanstack.ts'
+import { Fetcher } from '@/api/api.client.ts'
 import { authStore } from '@/store/auth.store.ts'
-
-export const apiUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:3333'
 
 export interface BaseQuery {
   realm?: string
 }
 
-const defaultHeaders = {
-  'Content-Type': 'application/json',
-}
-
-export const apiClient = axios.create({
-  baseURL: apiUrl,
-  headers: defaultHeaders,
-  withCredentials: true,
-})
-
-const fetcher: Fetcher = async (method, apiUrl, params) => {
+export const fetcher: Fetcher = async (method, apiUrl, params) => {
   const headers = new Headers()
 
   const accessToken = authStore.getState().accessToken
@@ -86,7 +72,3 @@ function replacePathParams(url: string, params: Record<string, string>): string 
     .replace(/{(\w+)}/g, (_, key: string) => params[key] || `{${key}}`)
     .replace(/:([a-zA-Z0-9_]+)/g, (_, key: string) => params[key] || `:${key}`)
 }
-
-export const api = createApiClient(fetcher, apiUrl)
-
-export const tanstackApi = new TanstackQueryApiClient(api)

--- a/front/src/api/realm.api.ts
+++ b/front/src/api/realm.api.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { tanstackApi } from '.'
 
 export interface UserRealmsQuery {
   realm: string
@@ -7,7 +6,7 @@ export interface UserRealmsQuery {
 
 export const useGetUserRealmsQuery = ({ realm }: UserRealmsQuery) => {
   return useQuery(
-    tanstackApi.get('/realms/{realm_name}/users/@me/realms', {
+    window.tanstackApi.get('/realms/{realm_name}/users/@me/realms', {
       path: {
         realm_name: realm,
       },
@@ -19,7 +18,7 @@ export const useCreateRealm = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    ...tanstackApi.mutation('post', '/realms', async (response) => {
+    ...window.tanstackApi.mutation('post', '/realms', async (response) => {
       const data = await response.json()
       return data
     }).mutationOptions,

--- a/front/src/api/redirect_uris.api.ts
+++ b/front/src/api/redirect_uris.api.ts
@@ -1,11 +1,10 @@
 import { authStore } from '@/store/auth.store'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { apiClient } from '.'
 import { RedirectUri } from './core.interface'
 
 export interface CreateRedirectUriMutate {
-  realmName: string,
-  clientId: string,
+  realmName: string
+  clientId: string
   payload: {
     value: string
   }
@@ -17,28 +16,32 @@ export const useCreateRedirectUri = () => {
     mutationFn: async ({ realmName, clientId, payload }: CreateRedirectUriMutate) => {
       const accessToken = authStore.getState().accessToken
 
-      const response = await apiClient.post<RedirectUri>(`/realms/${realmName}/clients/${clientId}/redirects`, {
-        value: payload.value,
-        enabled: true,
-      }, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
+      const response = await window.axios.post<RedirectUri>(
+        `/realms/${realmName}/clients/${clientId}/redirects`,
+        {
+          value: payload.value,
+          enabled: true,
         },
-      })
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
 
       return response.data
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['client']
+        queryKey: ['client'],
       })
-    }
+    },
   })
 }
 
 export interface DeleteRedirectUriMutate {
-  realmName: string,
-  clientId: string,
+  realmName: string
+  clientId: string
   redirectUriId: string
 }
 
@@ -48,18 +51,21 @@ export const useDeleteRedirectUri = () => {
     mutationFn: async ({ realmName, clientId, redirectUriId }: DeleteRedirectUriMutate) => {
       const accessToken = authStore.getState().accessToken
 
-      const response = await apiClient.delete(`/realms/${realmName}/clients/${clientId}/redirects/${redirectUriId}`, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
+      const response = await window.axios.delete(
+        `/realms/${realmName}/clients/${clientId}/redirects/${redirectUriId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
 
       return response.data
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['client']
+        queryKey: ['client'],
       })
-    }
+    },
   })
 }

--- a/front/src/api/role.api.ts
+++ b/front/src/api/role.api.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { BaseQuery, tanstackApi } from '.'
+import { BaseQuery } from '.'
 
 export const useGetRoles = ({ realm = 'master' }: BaseQuery) => {
   return useQuery(
-    tanstackApi.get('/realms/{realm_name}/roles', {
+    window.tanstackApi.get('/realms/{realm_name}/roles', {
       path: {
         realm_name: realm,
       },
@@ -14,7 +14,7 @@ export const useGetRoles = ({ realm = 'master' }: BaseQuery) => {
 
 export const useGetRole = ({ realm, roleId }: BaseQuery & { roleId?: string }) => {
   return useQuery({
-    ...tanstackApi.get('/realms/{realm_name}/roles/{role_id}', {
+    ...window.tanstackApi.get('/realms/{realm_name}/roles/{role_id}', {
       path: {
         realm_name: realm!,
         role_id: roleId!,
@@ -29,7 +29,7 @@ export const useCreateRole = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    ...tanstackApi.mutation(
+    ...window.tanstackApi.mutation(
       'post',
       '/realms/{realm_name}/clients/{client_id}/roles',
       async (res) => {
@@ -46,7 +46,7 @@ export const useUpdateRole = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    ...tanstackApi.mutation('put', '/realms/{realm_name}/roles/{role_id}', async (res) =>
+    ...window.tanstackApi.mutation('put', '/realms/{realm_name}/roles/{role_id}', async (res) =>
       res.json()
     ).mutationOptions,
     onSuccess(res) {
@@ -67,7 +67,7 @@ export const useUpdateRolePermissions = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    ...tanstackApi.mutation(
+    ...window.tanstackApi.mutation(
       'patch',
       '/realms/{realm_name}/roles/{role_id}/permissions',
       async (res) => res.json()

--- a/front/src/api/trident.api.ts
+++ b/front/src/api/trident.api.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { apiClient, BaseQuery, tanstackApi } from '.'
+import { BaseQuery } from '.'
 import {
   ChallengeOtpRequest,
   ChallengeOtpResponse,
@@ -12,7 +12,7 @@ export const useSetupOtp = ({ realm, token }: BaseQuery & { token?: string | nul
   return useQuery({
     queryKey: ['setup-otp'],
     queryFn: async (): Promise<SetupOtpResponse> => {
-      const response = await apiClient.get<SetupOtpResponse>(
+      const response = await window.axios.get<SetupOtpResponse>(
         `/realms/${realm}/login-actions/setup-otp`,
         {
           headers: {
@@ -35,7 +35,7 @@ export interface VerifyOtpRequest {
 export const useVerifyOtp = () => {
   return useMutation({
     mutationFn: async ({ realm, data, token }: BaseQuery & VerifyOtpRequest) => {
-      const response = await apiClient.post<VerifyOtpResponse>(
+      const response = await window.axios.post<VerifyOtpResponse>(
         `/realms/${realm}/login-actions/verify-otp`,
         data,
         {
@@ -62,7 +62,7 @@ export const useChallengeOtp = () => {
       data,
       token,
     }: BaseQuery & MutationChallengeOtpRequest): Promise<ChallengeOtpResponse> => {
-      const response = await apiClient.post<ChallengeOtpResponse>(
+      const response = await window.axios.post<ChallengeOtpResponse>(
         `/realms/${realm}/login-actions/challenge-otp`,
         data,
         {
@@ -79,7 +79,7 @@ export const useChallengeOtp = () => {
 
 export const useUpdatePassword = () => {
   return useMutation({
-    ...tanstackApi.mutation('post', '/realms/{realm_name}/login-actions/update-password')
+    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/login-actions/update-password')
       .mutationOptions,
   })
 }

--- a/front/src/api/user.api.ts
+++ b/front/src/api/user.api.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { BaseQuery, tanstackApi } from '.'
+import { BaseQuery } from '.'
 
 export interface UserMutateContract<T> {
   realm?: string
@@ -14,7 +14,7 @@ export interface GetUserQueryParams {
 
 export const useGetUsers = ({ realm }: BaseQuery) => {
   return useQuery({
-    ...tanstackApi.get('/realms/{realm_name}/users', {
+    ...window.tanstackApi.get('/realms/{realm_name}/users', {
       path: {
         realm_name: realm || 'master',
       },
@@ -24,7 +24,7 @@ export const useGetUsers = ({ realm }: BaseQuery) => {
 
 export const useGetUser = ({ realm, userId }: GetUserQueryParams) => {
   return useQuery({
-    ...tanstackApi.get('/realms/{realm_name}/users/{user_id}', {
+    ...window.tanstackApi.get('/realms/{realm_name}/users/{user_id}', {
       path: {
         realm_name: realm!,
         user_id: userId!,
@@ -36,7 +36,7 @@ export const useGetUser = ({ realm, userId }: GetUserQueryParams) => {
 
 export const useGetUserCredentials = ({ realm, userId }: GetUserQueryParams) => {
   return useQuery({
-    ...tanstackApi.get('/realms/{realm_name}/users/{user_id}/credentials', {
+    ...window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/credentials', {
       path: {
         realm_name: realm!,
         user_id: userId!,
@@ -49,12 +49,12 @@ export const useGetUserCredentials = ({ realm, userId }: GetUserQueryParams) => 
 export const useCreateUser = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    ...tanstackApi.mutation('post', '/realms/{realm_name}/users', async (res) => {
+    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/users', async (res) => {
       return res.json()
     }).mutationOptions,
     onSuccess: async (res) => {
       console.log(res)
-      const queryKeys = tanstackApi.get('/realms/{realm_name}/users', {
+      const queryKeys = window.tanstackApi.get('/realms/{realm_name}/users', {
         path: {
           realm_name: res.data.realm!.name,
         },
@@ -71,7 +71,7 @@ export const useCreateUser = () => {
 export const useUpdateUser = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    ...tanstackApi.mutation('put', '/realms/{realm_name}/users/{user_id}', async (res) => {
+    ...window.tanstackApi.mutation('put', '/realms/{realm_name}/users/{user_id}', async (res) => {
       return res.json()
     }).mutationOptions,
     onSuccess: () => {
@@ -85,7 +85,7 @@ export const useUpdateUser = () => {
 export const useBulkDeleteUser = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    ...tanstackApi.mutation('delete', '/realms/{realm_name}/users/bulk', async (res) => {
+    ...window.tanstackApi.mutation('delete', '/realms/{realm_name}/users/bulk', async (res) => {
       const data = await res.json()
       return data
     }).mutationOptions,
@@ -101,7 +101,7 @@ export const useResetUserPassword = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    ...tanstackApi.mutation(
+    ...window.tanstackApi.mutation(
       'put',
       '/realms/{realm_name}/users/{user_id}/reset-password',
       async (res) => {
@@ -110,7 +110,7 @@ export const useResetUserPassword = () => {
       }
     ).mutationOptions,
     onSuccess: async (res) => {
-      const keys = tanstackApi.get('/realms/{realm_name}/users/{user_id}/credentials', {
+      const keys = window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/credentials', {
         path: {
           realm_name: res.realm_name,
           user_id: res.user_id,
@@ -125,7 +125,7 @@ export const useResetUserPassword = () => {
 
 export const useGetUserRoles = ({ realm, userId }: BaseQuery & { userId: string }) => {
   return useQuery({
-    ...tanstackApi.get('/realms/{realm_name}/users/{user_id}/roles', {
+    ...window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/roles', {
       path: {
         realm_name: realm!,
         user_id: userId!,
@@ -139,11 +139,11 @@ export const useAssignUserRole = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    ...tanstackApi.mutation('post', '/realms/{realm_name}/users/{user_id}/roles/{role_id}')
+    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/users/{user_id}/roles/{role_id}')
       .mutationOptions,
     onSuccess: async (res) => {
       const data = await res.json()
-      const keys = tanstackApi.get('/realms/{realm_name}/users/{user_id}/roles', {
+      const keys = window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/roles', {
         path: {
           realm_name: data.realm_name,
           user_id: data.user_id,

--- a/front/src/api/user_role.api.ts
+++ b/front/src/api/user_role.api.ts
@@ -1,10 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { tanstackApi } from '.'
 
 export const useUnassignUserRole = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    ...tanstackApi.mutation(
+    ...window.tanstackApi.mutation(
       'delete',
       '/realms/{realm_name}/users/{user_id}/roles/{role_id}',
       async (response) => {
@@ -13,7 +12,7 @@ export const useUnassignUserRole = () => {
       }
     ).mutationOptions,
     onSuccess: async (res) => {
-      const keys = tanstackApi.get('/realms/{realm_name}/users/{user_id}/roles', {
+      const keys = window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/roles', {
         path: {
           realm_name: res.realm_name,
           user_id: res.user_id,

--- a/front/src/pages/authentication/feature/page-login-feature.tsx
+++ b/front/src/pages/authentication/feature/page-login-feature.tsx
@@ -6,7 +6,6 @@ import { useNavigate, useParams } from 'react-router'
 import { z } from 'zod'
 import PageLogin from '../ui/page-login'
 import { toast } from 'sonner'
-import { apiUrl } from '@/api'
 import { AuthenticationStatus } from '@/api/api.interface.ts'
 
 const authenticateSchema = z.object({
@@ -111,7 +110,7 @@ export default function PageLoginFeature() {
   useEffect(() => {
     if (isSetup && !isAuthInitiated) {
       const { query, realm } = getOAuthParams()
-      window.location.href = `${apiUrl}/realms/${realm}/protocol/openid-connect/auth?${query}`
+      window.location.href = `${window.apiUrl}/realms/${realm}/protocol/openid-connect/auth?${query}`
     }
   }, [isSetup, isAuthInitiated, getOAuthParams])
 


### PR DESCRIPTION
Move axios and TanstackQueryApiClient to window for global access. Update all API hooks to use window.axios and window.tanstackApi. Remove direct imports of apiClient and tanstackApi.