### PR TITLE
fix: deprecated PORTAL URL and updated env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ services:
     environment:
       - PORT=3333
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/ferriskey
-      - PORTAL_URL=http://localhost:5555
       - ADMIN_EMAIL=admin@example.com
       - ADMIN_PASSWORD=admin
       - ADMIN_USERNAME=admin
@@ -183,7 +182,6 @@ PORT=3333
 ENV=development
 LOG_LEVEL=info
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/ferriskey
-PORTAL_URL=http://localhost:5555
 
 ADMIN_PASSWORD=admin
 ADMIN_USERNAME=admin

--- a/api/env.example
+++ b/api/env.example
@@ -1,10 +1,19 @@
-PORT=3333
+SERVER_PORT=3333
+SERVER_HOST=localhost
+SERVER_ROOT_PATH=
+
 ENV=development
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/ferriskey
+
+DATABASE_NAME=ferriskey
+DATABASE_HOST=localhost
+DATABASE_USER=postgres
+DATABASE_PASSWORD=postgres
 
 ADMIN_PASSWORD=admin
 ADMIN_USERNAME=admin
 ADMIN_EMAIL=admin@example.com
 
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
-PORTAL_URL=http://localhost:5555
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001,http://localhost:5555
+
+LOG_FILTER=info
+LOG_JSON=false

--- a/api/src/application/http/server/http_server.rs
+++ b/api/src/application/http/server/http_server.rs
@@ -20,7 +20,7 @@ use axum::routing::get;
 use axum_cookie::prelude::*;
 use axum_prometheus::PrometheusMetricLayer;
 use tower_http::cors::CorsLayer;
-use tracing::info_span;
+use tracing::{debug, info_span};
 use utoipa::OpenApi;
 use utoipa_scalar::{Scalar, Servable};
 
@@ -59,6 +59,8 @@ pub fn router(state: AppState) -> Result<Router, anyhow::Error> {
         .iter()
         .map(|origin| HeaderValue::from_str(origin).unwrap())
         .collect::<Vec<HeaderValue>>();
+
+    debug!("Allowed origins: {:?}", allowed_origins);
 
     let cors = CorsLayer::new()
         .allow_methods([

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -43,7 +43,6 @@ services:
       - ADMIN_USERNAME=admin
       - ADMIN_EMAIL=super@ferriskey.local
       - ALLOWED_ORIGINS=http://localhost:5555,http://localhost:3333
-      - PORTAL_URL=http://localhost:5555
     depends_on:
       api-migration:
         condition: service_completed_successfully

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,6 @@ services:
       - ADMIN_USERNAME=admin
       - ADMIN_EMAIL=super@ferriskey.dev
       - ALLOWED_ORIGINS=http://localhost:5555,http://localhost:3333
-      - PORTAL_URL=http://localhost:5555
     depends_on:
       api-migration:
         condition: service_completed_successfully

--- a/docs/src/content/docs/welcome/installation.mdx
+++ b/docs/src/content/docs/welcome/installation.mdx
@@ -29,8 +29,6 @@ ADMIN_USERNAME=super
 ADMIN_EMAIL=super@ferriskey.fr
 
 ALLOWED_ORIGINS=http://localhost:5555,http://localhost:5556
-
-PORTAL_URL=http://localhost:5555
 ```
 
 ## With Docker
@@ -50,7 +48,6 @@ docker run -p 3333:3333 \
   -e ADMIN_USERNAME=admin -e ADMIN_PASSWORD=admin \
   -e ADMIN_EMAIL=admin@example.com \
   -e ALLOWED_ORIGINS=http://localhost:5555,http://localhost:5554 \
-  -e PORTAL_URL=http://localhost:5555 \
   ghcr.io/ferriskey/ferriskey-api
 ```
 

--- a/operator/crds/crd-ferriskeycluster.yaml
+++ b/operator/crds/crd-ferriskeycluster.yaml
@@ -37,9 +37,6 @@ spec:
                   password:
                     nullable: true
                     type: string
-                  portal_url:
-                    nullable: true
-                    type: string
                   replicas:
                     format: uint8
                     minimum: 0.0

--- a/operator/src/controller/cluster/api.rs
+++ b/operator/src/controller/cluster/api.rs
@@ -74,11 +74,6 @@ pub async fn reconcile_api(cluster: &FerriskeyCluster, client: &Client) -> Resul
         .unwrap_or(vec!["http://localhost:5555".into()])
         .join(",");
 
-    let portal_url = backend
-        .portal_url
-        .clone()
-        .unwrap_or("http://localhost:5555".into());
-
     let env_vars = vec![
         EnvVar {
             name: "PORT".into(),
@@ -120,11 +115,6 @@ pub async fn reconcile_api(cluster: &FerriskeyCluster, client: &Client) -> Resul
         EnvVar {
             name: "ALLOWED_ORIGINS".into(),
             value: Some(allowed_origins),
-            ..Default::default()
-        },
-        EnvVar {
-            name: "PORTAL_URL".into(),
-            value: Some(portal_url),
             ..Default::default()
         },
     ];

--- a/operator/src/crd/cluster.rs
+++ b/operator/src/crd/cluster.rs
@@ -32,7 +32,6 @@ pub struct BackendSpec {
     pub password: Option<String>,
     pub email: Option<String>,
     pub allowed_origins: Option<Vec<String>>,
-    pub portal_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]


### PR DESCRIPTION
This PR fixes #390 . Long story short, a recent refactor of the backend configuration changed a lot of env variables. I just modified the env example to fix that. 

While doing that, I realised that the `PORTAL_URL` environment variable was useless so I removed it.