### PR TITLE
fix(docs): update readme launch api Closes #426

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,12 @@ cp env.example .env
 docker compose up -d
 cd ../core
 # to install sqlx you might need to run `cargo install sqlx-cli`
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/ferriskey sqlx migrate run
+DATABASE_URL=postgres://ferriskey:ferriskey@localhost:5432/ferriskey sqlx migrate run
 ```
 3. Launch the API
 
 ```bash
+# to upgrade rustc version to 1.89.0, you can run `rustup update`
 cd ../api
 cargo run
 ```


### PR DESCRIPTION
fix: use stable-aarch64-apple-darwin unchanged - rustc 1.87.0 launch api
```
   Compiling ferriskey-core v0.1.0 (/Users/arjun/Code/rust/ferriskey/core)
error[E0658]: `let` expressions in this position are unstable
  --> core/src/domain/jwt/services.rs:81:12
   |
81 |         if let Some(exp) = token_data.claims.exp
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

error[E0658]: `let` expressions in this position are unstable
   --> core/src/domain/jwt/services.rs:103:12
    |
103 |         if let Some(expires_at) = refresh_token.expires_at
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `ferriskey-core` (lib) due to 2 previous errors
```