### PR TITLE
Fix/socket addr resolving

### DIFF
--- a/api/src/bin/ferriskey-server.rs
+++ b/api/src/bin/ferriskey-server.rs
@@ -21,7 +21,7 @@ use ferriskey_api::application::http::server::http_server::{router, state};
 use ferriskey_api::args::{Args, LogArgs};
 use ferriskey_core::domain::common::entities::StartupConfig;
 use ferriskey_core::domain::common::ports::CoreService;
-use tracing::{debug, info, error};
+use tracing::{debug, error, info};
 use tracing_subscriber::EnvFilter;
 
 fn init_logger(args: &LogArgs) {


### PR DESCRIPTION
This small change helps resolving "localhost" as the proper socket address when its used as SERVER_HOST value.
Previous version didn't correctly resolve localhost as 127.0.0.1 on MacOS
This change should also resolve any kind of custom hostnames set in /etc/hosts on Macos, linux and the windows counterpart

I wasn't sure about how to dispatch the actual error message so I used a tracing::error! instead of an expect. Although the actual error case should never happen because empty SERVER_HOST and SERVER_PORT cause an early exception