### PR TITLE
fix(handler): correct Path extractor usage with multiple params

### DIFF
--- a/api/src/application/http/client/handlers/delete_redirect_uri.rs
+++ b/api/src/application/http/client/handlers/delete_redirect_uri.rs
@@ -27,9 +27,7 @@ use uuid::Uuid;
     ),
 )]
 pub async fn delete_redirect_uri(
-    Path(realm_name): Path<String>,
-    Path(client_id): Path<Uuid>,
-    Path(uri_id): Path<Uuid>,
+    Path((realm_name, client_id, uri_id)): Path<(String, Uuid, Uuid)>,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Response<()>, ApiError> {

--- a/api/src/application/http/client/handlers/get_client_roles.rs
+++ b/api/src/application/http/client/handlers/get_client_roles.rs
@@ -32,8 +32,7 @@ pub struct GetClientRolesResponse {
     )
 )]
 pub async fn get_client_roles(
-    Path(realm_name): Path<String>,
-    Path(client_id): Path<Uuid>,
+    Path((realm_name, client_id)): Path<(String, Uuid)>,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Response<GetClientRolesResponse>, ApiError> {

--- a/api/src/application/http/client/handlers/update_redirect_uri.rs
+++ b/api/src/application/http/client/handlers/update_redirect_uri.rs
@@ -35,8 +35,7 @@ use uuid::Uuid;
     ),
 )]
 pub async fn update_redirect_uri(
-    Path((realm_name, client_id)): Path<(String, Uuid)>,
-    Path(uri_id): Path<Uuid>,
+    Path((realm_name, client_id, uri_id)): Path<(String, Uuid, Uuid)>,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
     ValidateJson(payload): ValidateJson<UpdateRedirectUriValidator>,

--- a/api/src/application/http/user/handlers/delete_credential.rs
+++ b/api/src/application/http/user/handlers/delete_credential.rs
@@ -37,9 +37,7 @@ pub struct DeleteUserCredentialResponse {
     )
 )]
 pub async fn delete_user_credential(
-    Path(realm_name): Path<String>,
-    Path(user_id): Path<Uuid>,
-    Path(credential_id): Path<Uuid>,
+    Path((realm_name, user_id, credential_id)): Path<(String, Uuid, Uuid)>,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Response<DeleteUserCredentialResponse>, ApiError> {

--- a/api/src/application/http/user/handlers/reset_password.rs
+++ b/api/src/application/http/user/handlers/reset_password.rs
@@ -41,8 +41,7 @@ pub struct ResetPasswordResponse {
     )
 )]
 pub async fn reset_password(
-    Path(realm_name): Path<String>,
-    Path(user_id): Path<Uuid>,
+    Path((realm_name, user_id)): Path<(String, Uuid)>,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
     ValidateJson(payload): ValidateJson<ResetPasswordValidator>,

--- a/api/src/application/http/user/handlers/unassign_role.rs
+++ b/api/src/application/http/user/handlers/unassign_role.rs
@@ -37,9 +37,7 @@ pub struct UnassignRoleResponse {
     )
 )]
 pub async fn unassign_role(
-    Path(realm_name): Path<String>,
-    Path(user_id): Path<Uuid>,
-    Path(role_id): Path<Uuid>,
+    Path((realm_name, user_id, role_id)): Path<(String, Uuid, Uuid)>,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Response<UnassignRoleResponse>, ApiError> {

--- a/api/src/application/http/user/handlers/update_user.rs
+++ b/api/src/application/http/user/handlers/update_user.rs
@@ -48,8 +48,7 @@ pub struct UpdateUserResponse {
     )
 )]
 pub async fn update_user(
-    Path(realm_name): Path<String>,
-    Path(user_id): Path<Uuid>,
+    Path((realm_name, user_id)): Path<(String, Uuid)>,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
     ValidateJson(payload): ValidateJson<UpdateUserValidator>,


### PR DESCRIPTION
fix: Wrong number of path arguments for Path. Expected 1 but got 2. Note that multiple parameters must be extracted with a tuple Path<(_, _)> or a struct Path<YourParams>

close #465
