### PR TITLE
Small fix for utoipa to treat AuthRequest as Query parameters in swagger-ui

### DIFF
--- a/api/src/application/http/authentication/handlers/auth.rs
+++ b/api/src/application/http/authentication/handlers/auth.rs
@@ -18,6 +18,7 @@ use validator::Validate;
 use crate::application::http::server::{api_entities::api_error::ApiError, app_state::AppState};
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct AuthRequest {
     #[validate(length(min = 1, message = "response_type is required"))]
     #[serde(default)]


### PR DESCRIPTION
Screenshot attached, after the fix the parameters correctly appear in the "Query parameters" section and the generated curl request correctly has the query params attached

<img width="1517" height="465" alt="Capture d’écran 2025-09-15 à 11 48 02" src="https://github.com/user-attachments/assets/c7353f1f-0b52-4162-b4d2-5178b4934b8f" />
