### PR TITLE
docs: add front .env.example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ cargo run
 
 ```bash
 cd ../front
-source env.sh
+cp .env.example .env
 pnpm install
 pnpm run dev
 ```

--- a/front/.env.example
+++ b/front/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3333


### PR DESCRIPTION
Replace 'source env.sh' with instructions to copy .env.example to .env. Add front/.env.example containing VITE_API_URL to document the default API endpoint.