### PR TITLE
feat: add create_realm test for RealmService

### DIFF
--- a/core/src/domain/realm/services.rs
+++ b/core/src/domain/realm/services.rs
@@ -463,18 +463,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        domain::{
-            client::ports::MockClientRepository,
-            common::services::tests::{
-                create_test_realm_with_name, create_test_user_identity_with_realm,
-            },
-            realm::{entities::RealmId, ports::MockRealmRepository},
-            role::ports::MockRoleRepository,
-            user::ports::{MockUserRepository, MockUserRoleRepository},
-            webhook::ports::MockWebhookRepository,
+    use crate::domain::{
+        client::ports::MockClientRepository,
+        common::services::tests::{
+            create_test_realm_with_name, create_test_user_identity_with_realm,
         },
-        entity::realm_settings::{self, Entity},
+        realm::{entities::RealmId, ports::MockRealmRepository},
+        role::ports::MockRoleRepository,
+        user::ports::{MockUserRepository, MockUserRoleRepository},
+        webhook::ports::MockWebhookRepository,
     };
 
     struct RealmServiceTestBuilder {


### PR DESCRIPTION
This pull request adds a comprehensive set of unit tests for the `RealmServiceImpl` in `core/src/domain/realm/services.rs`. The new tests use mock repositories and a builder pattern to simulate and verify the realm creation workflow, ensuring that all dependencies and side effects are correctly handled.

**Testing infrastructure and coverage improvements:**

* Added a `RealmServiceTestBuilder` struct with methods to configure mock behaviors for all major dependencies (`RealmRepository`, `RoleRepository`, `WebhookRepository`, `UserRoleRepository`, `ClientRepository`, `UserRepository`). This allows flexible and reusable setup for different test scenarios.
* Implemented a comprehensive async test (`test_create_realm`) that exercises the entire realm creation flow, including user permission checks, realm and client creation, role assignment, and settings initialization.
* Used `mockall` predicates and expectations to precisely control and verify the interactions with each mocked dependency, ensuring that the service logic is thoroughly validated.
* Provided utility methods in the test builder to simulate creation of system clients, admin-cli clients, role creation, and assignment, as well as user permissions and realm settings.