### PR TITLE
feat: create service account for new clients

### DIFF
--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -113,6 +113,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
         ),
         client_service: ClientServiceImpl::new(
             realm.clone(),
+            user.clone(),
             client.clone(),
             webhook.clone(),
             redirect_uri.clone(),

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
 use jsonwebtoken::{Header, Validation};
-use tracing::error;
+use tracing::{error, info};
 use uuid::Uuid;
 
 use crate::domain::{
@@ -296,11 +296,16 @@ where
             return Err(CoreError::InvalidClientSecret);
         }
 
+        info!("try to fetch user client, client id: {}", client.id);
+
         let user = self
             .user_repository
             .get_by_client_id(client.id)
             .await
-            .map_err(|_| CoreError::InternalServerError)?;
+            .map_err(|e| {
+                error!("error when get client (user): {}", e);
+                CoreError::InternalServerError
+            })?;
 
         let scope_manager = ScopeManager::new();
         let final_scope = scope_manager.merge_with_defaults(params.scope);


### PR DESCRIPTION
Wire UserRepository into ClientService and its constructor. When a client is created with service_account_enabled, create a service account user (username/email) linked to the client. Clone client_id to avoid moves. Add info and error logs when fetching a user by client id, and pass user.clone into create_service.