### PR TITLE
fix: invalidate client using existing query key

### DIFF
--- a/front/src/api/client.api.ts
+++ b/front/src/api/client.api.ts
@@ -48,12 +48,19 @@ export const useUpdateClient = () => {
   return useMutation({
     ...window.tanstackApi.mutation('patch', '/realms/{realm_name}/clients/{client_id}')
       .mutationOptions,
-    onSuccess: async (payload) => {
+    onSuccess: async (payload, variables) => {
       const client = await payload.json()
+
+      const keys = window.tanstackApi.get('/realms/{realm_name}/clients/{client_id}', {
+        path: {
+          client_id: variables.path.client_id,
+          realm_name: variables.path.realm_name,
+        },
+      }).queryKey
 
       toast.success(`Client ${client.name} was updated successfully`)
       queryClient.invalidateQueries({
-        queryKey: ['client', client.id],
+        queryKey: keys,
       })
     },
   })


### PR DESCRIPTION
Pass variables into onSuccess and derive the mutation's exact queryKey via window.tanstackApi.get(...).queryKey to ensure the correct cache entry is invalidated