### PR TITLE
feat: github-star-modal branding update

### DIFF
--- a/front/src/components/github-star-modal.tsx
+++ b/front/src/components/github-star-modal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from './ui/dialog'
 import { Button } from './ui/button'
-import { GitBranch, Heart, Star } from 'lucide-react'
+import { Heart, Star } from 'lucide-react'
 
 const STORAGE_KEY = 'ferriskey-github-star-modal-dismissed'
 
@@ -57,7 +57,7 @@ export default function GithubStarModal() {
           <div className='flex justify-center'>
             <div className='relative'>
               <div className='w-20 h-20 bg-gradient-to-br from-blue-400 via-purple-500 to-pink-500 rounded-full flex items-center justify-center animate-pulse'>
-                <GitBranch className='h-10 w-10 text-white' />
+                <img src='/logo_ferriskey.png' alt='Unofficial Rust mascot, Ferris the crab, holding a key in left claw which is used as project branding for FerrisKey' className='h-15 w-15'/>
               </div>
               <div className='absolute -top-1 -right-1 w-6 h-6 bg-yellow-400 rounded-full flex items-center justify-center animate-bounce'>
                 <Star className='h-3 w-3 text-yellow-800' fill='currentColor' />


### PR DESCRIPTION
Fixes #337 

---

* replace `<GitHub .../>` component with FerrisKey logo

Related to: ferriskey/ferriskey#337

---

Preview of change:

// Safari

<img width="1268" height="1399" alt="safari" src="https://github.com/user-attachments/assets/0a9302ea-9639-4edf-8b9c-011acd09b7bd" />

// Chrome

<img width="1269" height="1399" alt="chrome" src="https://github.com/user-attachments/assets/25ed8bc0-07f4-4854-bf1c-7dbfae87f7fc" />

// Firefox

<img width="1269" height="1399" alt="firefox" src="https://github.com/user-attachments/assets/4ac538d3-ecb7-4647-b165-e34731091632" />

---

I was going to remove the animation and decorations (bouncing star), but it looked pretty good to me.