### PR TITLE
feat: add domain account hint

### DIFF
--- a/api/src/application/http/error.rs
+++ b/api/src/application/http/error.rs
@@ -195,6 +195,9 @@ impl From<CoreError> for ApiError {
             CoreError::ClientNotFound => {
                 Self::NotFound("Client not found".to_string())
             }
+            CoreError::HintsNotFound => {
+                Self::NotFound("Account hints not found".to_string())
+            }
         }
     }
 }

--- a/core/src/domain/account/entities.rs
+++ b/core/src/domain/account/entities.rs
@@ -1,0 +1,30 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::domain::realm::entities::RealmId;
+
+#[derive(Debug, Clone)]
+pub struct AccountHint {
+    pub user_id: Uuid,
+    pub realm_id: RealmId,
+    pub display_name: String,
+    pub avatar_url: Option<String>,
+    pub last_used_at: DateTime<Utc>,
+}
+
+impl AccountHint {
+    pub fn new(
+        user_id: Uuid,
+        realm_id: RealmId,
+        display_name: String,
+        avatar_url: Option<String>,
+    ) -> Self {
+        Self {
+            user_id,
+            realm_id,
+            display_name,
+            avatar_url,
+            last_used_at: Utc::now(),
+        }
+    }
+}

--- a/core/src/domain/account/mod.rs
+++ b/core/src/domain/account/mod.rs
@@ -1,0 +1,3 @@
+pub mod entities;
+pub mod ports;
+pub mod services;

--- a/core/src/domain/account/ports.rs
+++ b/core/src/domain/account/ports.rs
@@ -1,0 +1,53 @@
+use std::future::Future;
+use uuid::Uuid;
+
+use crate::domain::account::entities::AccountHint;
+use crate::domain::common::entities::app_errors::CoreError;
+use crate::domain::realm::entities::RealmId;
+
+pub trait AccountHintService: Send + Sync {
+    fn create_account_hint(
+        &self,
+        user_id: Uuid,
+        realm_id: RealmId,
+        display_name: &str,
+        avatar_url: Option<String>,
+    ) -> impl Future<Output = Result<AccountHint, CoreError>> + Send;
+
+    fn update_account_hint(
+        &self,
+        account_hint: AccountHint,
+    ) -> impl Future<Output = Result<AccountHint, CoreError>> + Send;
+
+    fn get_account_hints(
+        &self,
+        user_id: Uuid,
+        realm_id: RealmId,
+    ) -> impl Future<Output = Result<Vec<AccountHint>, CoreError>> + Send;
+}
+
+#[cfg_attr(test, mockall::automock)]
+pub trait AccountHintRepository: Send + Sync {
+    fn update_hint(
+        &self,
+        user_id: &Uuid,
+        realm_id: &RealmId,
+    ) -> impl Future<Output = Result<AccountHint, CoreError>> + Send;
+    fn add_hint(
+        &self,
+        user_id: &Uuid,
+        realm_id: &RealmId,
+        display_name: &str,
+        avatar_url: &Option<String>,
+    ) -> impl Future<Output = Result<AccountHint, CoreError>> + Send;
+    fn get_hint(
+        &self,
+        user_id: &Uuid,
+        realm_id: &RealmId,
+    ) -> impl Future<Output = Result<AccountHint, CoreError>> + Send;
+    fn get_hints(
+        &self,
+        user_id: &Uuid,
+        realm_id: &RealmId,
+    ) -> impl Future<Output = Result<Vec<AccountHint>, CoreError>> + Send;
+}

--- a/core/src/domain/account/services.rs
+++ b/core/src/domain/account/services.rs
@@ -1,0 +1,73 @@
+use uuid::Uuid;
+
+use crate::domain::account::{
+    entities::AccountHint,
+    ports::{AccountHintRepository, AccountHintService},
+};
+use crate::domain::common::entities::app_errors::CoreError;
+use crate::domain::realm::entities::RealmId;
+
+#[derive(Clone)]
+pub struct AccountHintServiceImpl<A>
+where
+    A: AccountHintRepository,
+{
+    pub account_hint_repository: A,
+}
+
+impl<A> AccountHintServiceImpl<A>
+where
+    A: AccountHintRepository,
+{
+    pub fn new(account_hint_repository: A) -> Self {
+        Self {
+            account_hint_repository,
+        }
+    }
+}
+
+impl<A> AccountHintService for AccountHintServiceImpl<A>
+where
+    A: AccountHintRepository,
+{
+    async fn create_account_hint(
+        &self,
+        user_id: Uuid,
+        realm_id: RealmId,
+        display_name: &str,
+        avatar_url: Option<String>,
+    ) -> Result<AccountHint, CoreError> {
+        self.account_hint_repository
+            .add_hint(&user_id, &realm_id, display_name, &avatar_url)
+            .await
+    }
+
+    async fn update_account_hint(
+        &self,
+        account_hint: AccountHint,
+    ) -> Result<AccountHint, CoreError> {
+        self.account_hint_repository
+            .get_hints(&account_hint.user_id, &account_hint.realm_id)
+            .await?;
+
+        self.account_hint_repository
+            .update_hint(&account_hint.user_id, &account_hint.realm_id)
+            .await
+    }
+
+    async fn get_account_hints(
+        &self,
+        user_id: Uuid,
+        realm_id: RealmId,
+    ) -> Result<Vec<AccountHint>, CoreError> {
+        match self
+            .account_hint_repository
+            .get_hints(&user_id, &realm_id)
+            .await
+        {
+            Ok(account_hints) => Ok(account_hints),
+            Err(CoreError::HintsNotFound) => Err(CoreError::HintsNotFound),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/core/src/domain/mod.rs
+++ b/core/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod abyss;
+pub mod account;
 pub mod aegis;
 pub mod authentication;
 pub mod client;

--- a/core/src/domain/session/entities.rs
+++ b/core/src/domain/session/entities.rs
@@ -1,6 +1,14 @@
 use chrono::{DateTime, Duration, Utc};
+use sea_orm::EnumIter;
 use thiserror::Error;
 use uuid::Uuid;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, EnumIter)]
+pub enum SessionState {
+    Active,
+    SoftExpired,
+    Expired,
+}
 
 pub struct UserSession {
     pub id: Uuid,
@@ -10,6 +18,7 @@ pub struct UserSession {
     pub ip_address: Option<String>,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+    pub soft_expiry_duration: Option<Duration>,
 }
 
 impl UserSession {
@@ -18,7 +27,10 @@ impl UserSession {
         realm_id: Uuid,
         user_agent: Option<String>,
         ip_address: Option<String>,
+        session_duration: Duration,
+        soft_expiry_duration: Option<Duration>,
     ) -> Self {
+        let expires_at = Utc::now() + session_duration;
         Self {
             id: Uuid::new_v4(),
             user_id,
@@ -26,11 +38,46 @@ impl UserSession {
             user_agent,
             ip_address,
             created_at: Utc::now(),
-            expires_at: Utc::now() + Duration::days(1),
+            expires_at,
+            soft_expiry_duration,
         }
     }
+
     pub fn is_expired(&self) -> bool {
         Utc::now() > self.expires_at
+    }
+
+    pub fn get_state(&self) -> SessionState {
+        let now = Utc::now();
+
+        if now > self.expires_at {
+            SessionState::Expired
+        } else if let Some(soft_expiry_duration) = self.soft_expiry_duration {
+            if now > self.expires_at - soft_expiry_duration {
+                SessionState::SoftExpired
+            } else {
+                SessionState::Active
+            }
+        } else {
+            SessionState::Active
+        }
+    }
+}
+
+impl SessionState {
+    // Returns the string representation of the session state
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::SoftExpired => "soft-expired",
+            Self::Expired => "expired",
+        }
+    }
+}
+
+impl std::fmt::Display for SessionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/core/src/domain/session/ports.rs
+++ b/core/src/domain/session/ports.rs
@@ -1,3 +1,4 @@
+use chrono::Duration;
 use uuid::Uuid;
 
 use crate::domain::session::entities::{SessionError, UserSession};
@@ -9,6 +10,8 @@ pub trait UserSessionService: Send + Sync {
         realm_id: Uuid,
         user_agent: Option<String>,
         ip_address: Option<String>,
+        session_duration: Duration,
+        soft_expiry_duration: Option<Duration>,
     ) -> impl Future<Output = Result<UserSession, SessionError>> + Send;
 }
 

--- a/core/src/domain/session/services.rs
+++ b/core/src/domain/session/services.rs
@@ -1,3 +1,5 @@
+use chrono::Duration;
+
 use crate::domain::session::{
     entities::{SessionError, UserSession},
     ports::{UserSessionRepository, UserSessionService},
@@ -32,8 +34,17 @@ where
         realm_id: uuid::Uuid,
         user_agent: Option<String>,
         ip_address: Option<String>,
+        session_duration: Duration,
+        soft_expiry_duration: Option<Duration>,
     ) -> Result<UserSession, SessionError> {
-        let session = UserSession::new(user_id, realm_id, user_agent, ip_address);
+        let session = UserSession::new(
+            user_id,
+            realm_id,
+            user_agent,
+            ip_address,
+            session_duration,
+            soft_expiry_duration,
+        );
 
         self.user_session_repository.create(&session).await?;
 

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -246,6 +246,9 @@ pub enum CoreError {
 
     #[error("Client not found")]
     ClientNotFound,
+
+    #[error("Account hints not found")]
+    HintsNotFound,
 }
 
 impl From<AuthenticationError> for CoreError {


### PR DESCRIPTION
#672
1. Introduced presets for ```AccountHint``` domain model 
2. The ```UserSession``` domain model has been slightly expanded to match the new domain model
3. Added session states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account hint system expanded: realm-aware hints with display names, optional avatars, and automatic "last used" timestamps; new service and repository interfaces to create, update, and retrieve hints.
  * Session management enhanced: configurable session duration, optional soft-expiry duration, explicit session states (active → soft-expired → expired) and state reporting.

* **Chores**
  * Added a specific error for missing account hints and updated API mapping to return "not found".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->