### PR TITLE
fix: support absolute and relative provider login URLs

### DIFF
--- a/front/src/pages/authentication/ui/login-providers.tsx
+++ b/front/src/pages/authentication/ui/login-providers.tsx
@@ -10,9 +10,14 @@ export type LoginProvidersProps = {
   providers: IdentityProviderPresentation[]
 }
 
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value)
+
 const buildProviderLoginUrl = (provider: IdentityProviderPresentation) => {
-  const url = new URL(provider.login_url, window.apiUrl)
+  const base = window.apiUrl.endsWith('/') ? window.apiUrl : `${window.apiUrl}/`
+  const path = provider.login_url.replace(/^\//, '')
+  const url = new URL(isAbsoluteUrl(provider.login_url) ? provider.login_url : path, base)
   const currentParams = new URLSearchParams(window.location.search)
+
   currentParams.forEach((value, key) => {
     if (!url.searchParams.has(key)) {
       url.searchParams.set(key, value)


### PR DESCRIPTION
Ensure the API base URL ends with a trailing slash and strip any leading slash from provider paths. Accept absolute provider.login_url values and preserve current window query parameters when constructing the final URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login URL handling to properly support both absolute and relative URLs while preserving query parameters during authentication flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->