### PR TITLE
fix: append root_path to broker base URLs

### DIFF
--- a/api/src/application/http/broker/handlers/callback.rs
+++ b/api/src/application/http/broker/handlers/callback.rs
@@ -40,6 +40,7 @@ pub async fn broker_callback(
     FullUrl(_, base_url): FullUrl,
     Query(params): Query<BrokerCallbackQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
+    let base_url = format!("{base_url}{}", state.args.server.root_path);
     let result = state
         .service
         .handle_callback(BrokerCallbackInput {

--- a/api/src/application/http/broker/handlers/login.rs
+++ b/api/src/application/http/broker/handlers/login.rs
@@ -38,6 +38,7 @@ pub async fn broker_login(
     FullUrl(_, base_url): FullUrl,
     Query(params): Query<BrokerLoginRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    let base_url = format!("{base_url}{}", state.args.server.root_path);
     let result = state
         .service
         .initiate_login(BrokerLoginInput {


### PR DESCRIPTION
Ensure broker callback and login handlers include the configured server.root_path when constructing the base URL. This fixes incorrect redirects when the API is mounted under a subpath

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL path handling in authentication flows to properly incorporate server root path configuration when constructing broker login and callback URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->