### PR TITLE
fix: include root_path in OpenID Connect discovery document

### DIFF
--- a/api/src/application/http/authentication/handlers/auth.rs
+++ b/api/src/application/http/authentication/handlers/auth.rs
@@ -22,7 +22,7 @@ use crate::application::url::FullUrl;
 const AUTH_SESSION_COOKIE: &str = "FERRISKEY_SESSION";
 const IDENTITY_COOKIE: &str = "FERRISKEY_IDENTITY";
 
-fn root_scoped_base_url(base_url: &str, root_path: &str) -> String {
+pub fn root_scoped_base_url(base_url: &str, root_path: &str) -> String {
     if root_path.is_empty() || root_path == "/" {
         return base_url.to_string();
     }

--- a/api/src/application/http/authentication/handlers/openid_configuration.rs
+++ b/api/src/application/http/authentication/handlers/openid_configuration.rs
@@ -1,6 +1,10 @@
-use crate::application::http::server::api_entities::response::Response;
+use super::auth::root_scoped_base_url;
+use crate::application::http::server::{api_entities::response::Response, app_state::AppState};
 use axum::http::Request;
-use axum::{body::Body, extract::Path};
+use axum::{
+    body::Body,
+    extract::{Path, State},
+};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -30,6 +34,7 @@ pub struct GetOpenIdConfigurationResponse {
 )]
 pub async fn get_openid_configuration(
     Path(realm_name): Path<String>,
+    State(state): State<AppState>,
     req: Request<Body>,
 ) -> Result<Response<GetOpenIdConfigurationResponse>, String> {
     // Here you would typically fetch the issuer from a database or configuration
@@ -46,7 +51,12 @@ pub async fn get_openid_configuration(
     });
 
     let base_url = format!("{scheme}://{host}");
-    let issuer = format!("{base_url}/realms/{realm_name}");
+
+    let issuer = format!(
+        "{}/realms/{}",
+        root_scoped_base_url(&base_url, &state.args.server.root_path),
+        realm_name
+    );
 
     Ok(Response::OK(GetOpenIdConfigurationResponse {
         issuer: issuer.clone(),


### PR DESCRIPTION
Closes #559

The OpenID Connect discovery document did not include the configured root_path in generated URLs. When FerrisKey is
deployed behind a reverse proxy with a root path (e.g. /api), OIDC clients failed to authenticate because the
endpoints in the discovery document did not match the actual deployed paths.

Reuses the existing root_scoped_base_url helper from auth.rs (now public) to build the base URL with the root path
prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenID configuration endpoint now correctly computes issuer and related endpoint URLs when the application is served under a root path, ensuring clients receive accurate discovery metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->