### PR TITLE
feat: add danger zone to delete realm in general settings

### DIFF
--- a/front/src/api/realm.api.ts
+++ b/front/src/api/realm.api.ts
@@ -64,6 +64,26 @@ export const useGetRealm = ({ realm }: BaseQuery) => {
   })
 }
 
+export const useDeleteRealm = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...window.tanstackApi.mutation('delete', '/realms/{name}').mutationOptions,
+    onSuccess: async (_, variables) => {
+      const keys = window.tanstackApi.get('/realms/{realm_name}/users/@me/realms', {
+        path: {
+          realm_name: variables.path.name,
+        },
+      }).queryKey
+
+      await queryClient.invalidateQueries({ queryKey: keys })
+    },
+    onError: (error: Error) => {
+      toast.error(error.message)
+    },
+  })
+}
+
 export const useUpdateRealmSettings = () => {
   const queryClient = useQueryClient()
 

--- a/front/src/components/confirm-delete-alert.tsx
+++ b/front/src/components/confirm-delete-alert.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -8,6 +9,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Input } from '@/components/ui/input'
 import { Trash2 } from 'lucide-react'
 
 interface ConfirmDeleteAlertProps {
@@ -16,6 +18,7 @@ interface ConfirmDeleteAlertProps {
   description: string
   onConfirm: () => void
   onCancel: () => void
+  confirmText?: string
 }
 
 export function ConfirmDeleteAlert({
@@ -24,9 +27,19 @@ export function ConfirmDeleteAlert({
   description,
   onConfirm,
   onCancel,
+  confirmText,
 }: ConfirmDeleteAlertProps) {
+  const [inputValue, setInputValue] = useState('')
+
+  const isConfirmDisabled = confirmText ? inputValue !== confirmText : false
+
+  const handleCancel = () => {
+    setInputValue('')
+    onCancel()
+  }
+
   return (
-    <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+    <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && handleCancel()}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <div className='flex gap-2 items-center'>
@@ -37,13 +50,26 @@ export function ConfirmDeleteAlert({
           </div>
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
+        {confirmText && (
+          <div className='flex flex-col gap-2'>
+            <p className='text-sm text-muted-foreground'>
+              Type <span className='font-semibold'>{confirmText}</span> to confirm.
+            </p>
+            <Input
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder={confirmText}
+            />
+          </div>
+        )}
         <AlertDialogFooter>
-          <AlertDialogCancel className='outline-none cursor-pointer' onClick={onCancel}>
+          <AlertDialogCancel className='outline-none cursor-pointer'>
             Cancel
           </AlertDialogCancel>
           <AlertDialogAction
             onClick={onConfirm}
-            className='bg-destructive text-destructive-foreground hover:bg-destructive/90 px-4 py-1 rounded-md text-white ml-3 cursor-pointer'
+            disabled={isConfirmDisabled}
+            className='bg-destructive text-destructive-foreground hover:bg-destructive/90 px-4 py-1 rounded-md text-white ml-3 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed'
           >
             Confirm
           </AlertDialogAction>

--- a/front/src/pages/realm/feature/page-realm-settings-general-feature.tsx
+++ b/front/src/pages/realm/feature/page-realm-settings-general-feature.tsx
@@ -5,13 +5,16 @@ import { SigningAlgorithm } from '@/api/core.interface'
 import { Form } from '@/components/ui/form'
 import PageRealmSettingsGeneral from '../ui/page-realm-settings-general'
 import { useFormChanges } from '@/hooks/use-form-changes'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import { RouterParams } from '@/routes/router'
-import { useGetRealm } from '@/api/realm.api'
+import { useDeleteRealm, useGetRealm } from '@/api/realm.api'
+import { toast } from 'sonner'
 
 export default function PageRealmSettingsGeneralFeature() {
   const { realm_name } = useParams<RouterParams>()
   const { data: realm } = useGetRealm({ realm: realm_name })
+  const navigate = useNavigate()
+  const deleteRealm = useDeleteRealm()
 
   const form = useForm<UpdateRealmSchema>({
     resolver: zodResolver(updateRealmValidator),
@@ -30,6 +33,19 @@ export default function PageRealmSettingsGeneralFeature() {
     }
   )
 
+  const handleDeleteRealm = () => {
+    if (!realm_name) return
+
+    deleteRealm.mutate(
+      { path: { name: realm_name } },
+      {
+        onSuccess: () => {
+          toast.success(`Realm "${realm_name}" has been deleted.`)
+          navigate('/realms/master/overview')
+        },
+      }
+    )
+  }
 
   if (!realm) return (
     <div>No realm</div>
@@ -37,7 +53,12 @@ export default function PageRealmSettingsGeneralFeature() {
 
   return (
     <Form {...form}>
-      <PageRealmSettingsGeneral hasChanges={hasChanges} />
+      <PageRealmSettingsGeneral
+        hasChanges={hasChanges}
+        realmName={realm_name ?? ''}
+        isMaster={realm_name === 'master'}
+        onDeleteRealm={handleDeleteRealm}
+      />
     </Form>
   )
 }

--- a/front/src/pages/realm/ui/page-realm-settings-general.tsx
+++ b/front/src/pages/realm/ui/page-realm-settings-general.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import BlockContent from '@/components/ui/block-content'
 import { FormField } from '@/components/ui/form'
 import { InputText } from '@/components/ui/input-text'
@@ -6,15 +7,21 @@ import { useFormContext } from 'react-hook-form'
 import { SigningAlgorithm } from '@/api/core.interface'
 import { Select, SelectItem, SelectTrigger, SelectValue, SelectContent } from '@/components/ui/select'
 import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
 import FloatingActionBar from '@/components/ui/floating-action-bar'
+import { ConfirmDeleteAlert } from '@/components/confirm-delete-alert'
 
 export interface PageRealmSettingsGeneralProps {
   hasChanges: boolean
+  realmName: string
+  isMaster: boolean
+  onDeleteRealm: () => void
 }
 
 
-export default function PageRealmSettingsGeneral({ hasChanges }: PageRealmSettingsGeneralProps) {
+export default function PageRealmSettingsGeneral({ hasChanges, realmName, isMaster, onDeleteRealm }: PageRealmSettingsGeneralProps) {
   const form = useFormContext<UpdateRealmSchema>()
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
   return (<div className='w-full'>
     <BlockContent title='General settings'>
@@ -54,6 +61,39 @@ export default function PageRealmSettingsGeneral({ hasChanges }: PageRealmSettin
         />
       </div>
     </BlockContent>
+
+    <BlockContent title='Danger zone' className='border-destructive'>
+      <div className='flex items-center justify-between'>
+        <div>
+          <p className='text-sm font-medium'>Delete this realm</p>
+          <p className='text-sm text-muted-foreground'>
+            Once deleted, all data associated with this realm will be permanently removed.
+          </p>
+        </div>
+        <Button
+          variant='destructive'
+          disabled={isMaster}
+          onClick={() => setShowDeleteDialog(true)}
+        >
+          Delete realm
+        </Button>
+      </div>
+      {isMaster && (
+        <p className='text-sm text-muted-foreground mt-2'>
+          The master realm cannot be deleted.
+        </p>
+      )}
+    </BlockContent>
+
+    <ConfirmDeleteAlert
+      open={showDeleteDialog}
+      title='Delete realm'
+      description={`This will permanently delete the realm "${realmName}" and all its data including users, clients, and roles.`}
+      confirmText={realmName}
+      onConfirm={onDeleteRealm}
+      onCancel={() => setShowDeleteDialog(false)}
+    />
+
     <FloatingActionBar
       show={hasChanges}
       title={'Save changes'}


### PR DESCRIPTION
Closes #664             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
Adds a danger zone at the bottom of the realm General settings page to allow realm deletion. The master realm cannot be deleted (button is disabled with an explanation message). Deletion requires typing the realm name to confirm, similar to GitHub's repo deletion flow.      
                                                                                                                                                                                                                                                                                                                                                 
Changes:                                                                                                                                                                                                                                                                                                         
- realm.api.ts - Added useDeleteRealm hook                                                                                                                                                                                                                                                                       
- confirm-delete-alert.tsx - Added optional confirmText prop to require typing a confirmation value before enabling the delete button
- page-realm-settings-general.tsx - Added danger zone UI section
- page-realm-settings-general-feature.tsx - Wired up delete logic with navigation to master realm after deletion

Note: The DELETE /realms/{name} endpoint currently returns a 500 due to missing ON DELETE CASCADE on the clients and users foreign keys. This is a pre-existing backend issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete realms from the General Settings page.
  * Destructive Delete button disabled for master realms.
  * Confirmation dialog can require typing the realm name to enable Delete; cancel resets the input.
  * Successful deletion shows a confirmation notification and redirects to the master overview; failures show an error notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->