### PR TITLE
fix: propagate JWT scope into refresh tokens

### DIFF
--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -195,6 +195,7 @@ where
             claims.iss.clone(),
             claims.aud.clone(),
             claims.azp,
+            claims.scope.clone(),
         );
 
         let refresh_token = self
@@ -507,7 +508,7 @@ where
                 realm_name: params.realm_name,
                 user_id: user.id,
                 username: user.username,
-                scope: None,
+                scope: claims.scope.clone(),
             })
             .await?;
 
@@ -1144,7 +1145,7 @@ where
         let jwt = self.generate_token(claims.clone(), realm.id).await?;
 
         let refresh_claims =
-            JwtClaim::new_refresh_token(claims.sub, claims.iss, claims.aud, claims.azp);
+            JwtClaim::new_refresh_token(claims.sub, claims.iss, claims.aud, claims.azp, None);
 
         let refresh_token = self
             .generate_token(refresh_claims.clone(), realm.id)

--- a/libs/ferriskey-security/src/jwt/entities.rs
+++ b/libs/ferriskey-security/src/jwt/entities.rs
@@ -96,7 +96,13 @@ impl JwtClaim {
         }
     }
 
-    pub fn new_refresh_token(sub: Uuid, iss: String, aud: Vec<String>, azp: String) -> Self {
+    pub fn new_refresh_token(
+        sub: Uuid,
+        iss: String,
+        aud: Vec<String>,
+        azp: String,
+        scope: Option<String>,
+    ) -> Self {
         Self {
             sub,
             iat: chrono::Utc::now().timestamp(),
@@ -105,7 +111,7 @@ impl JwtClaim {
             aud,
             typ: ClaimsTyp::Refresh,
             azp,
-            scope: None,
+            scope,
             preferred_username: None,
             email: None,
             exp: Some(chrono::Utc::now().timestamp() + 86400), // 24 hours
@@ -253,5 +259,26 @@ impl JwtKeyPair {
 
     pub fn to_jwt_key(&self) -> Result<JwkKey, SecurityError> {
         self.to_jwk_key()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClaimsTyp, JwtClaim};
+    use uuid::Uuid;
+
+    #[test]
+    fn refresh_claims_keep_scope() {
+        let scope = Some("openid profile email".to_string());
+        let claims = JwtClaim::new_refresh_token(
+            Uuid::new_v4(),
+            "https://issuer".to_string(),
+            vec!["test-realm".to_string()],
+            "client-id".to_string(),
+            scope.clone(),
+        );
+
+        assert_eq!(claims.typ, ClaimsTyp::Refresh);
+        assert_eq!(claims.scope, scope);
     }
 }


### PR DESCRIPTION
Allow JwtClaim::new_refresh_token to take an optional scope and store it in the claim. Update authentication service to pass the scope when creating refresh tokens and to persist scope on session records. Add a unit test to ensure refresh claims keep the scope.