### PR TITLE
feat: add JWKS endpoints and JWK 'use' field

### DIFF
--- a/api/src/application/http/authentication/handlers/openid_configuration.rs
+++ b/api/src/application/http/authentication/handlers/openid_configuration.rs
@@ -66,7 +66,7 @@ pub async fn get_openid_configuration(
         end_session_endpoint: format!("{issuer}/protocol/openid-connect/logout"),
         introspection_endpoint: format!("{issuer}/protocol/openid-connect/token/introspect"),
         userinfo_endpoint: format!("{issuer}/protocol/openid-connect/userinfo"),
-        jwks_uri: format!("{issuer}/protocol/openid-connect/certs"),
+        jwks_uri: format!("{issuer}/protocol/openid-connect/jwks.json"),
         grant_types_supported: vec![
             "authorization_code".to_string(),
             "refresh_token".to_string(),

--- a/api/src/application/http/authentication/router.rs
+++ b/api/src/application/http/authentication/router.rs
@@ -8,7 +8,7 @@ use utoipa::OpenApi;
 use super::handlers::{
     auth::{__path_auth_handler, auth_handler},
     authentificate::{__path_authenticate, authenticate},
-    get_certs::{__path_get_certs, get_certs},
+    get_certs::{__path_get_certs, __path_get_jwks_json, get_certs, get_jwks_json},
     introspect::{__path_introspect_token, introspect_token},
     logout::{__path_logout, logout},
     openid_configuration::{__path_get_openid_configuration, get_openid_configuration},
@@ -24,6 +24,7 @@ use crate::application::{auth::auth, http::server::app_state::AppState};
     introspect_token,
     authenticate,
     get_certs,
+    get_jwks_json,
     auth_handler,
     logout,
     get_openid_configuration,
@@ -74,6 +75,14 @@ pub fn authentication_routes(state: AppState, root_path: &str) -> Router<AppStat
         .route(
             &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/certs"),
             get(get_certs),
+        )
+        .route(
+            &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/jwks.json"),
+            get(get_jwks_json),
+        )
+        .route(
+            &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/jwks"),
+            get(get_jwks_json),
         )
         .route(
             &format!("{root_path}/realms/{{realm_name}}/.well-known/openid-configuration"),

--- a/front/openapi.yaml
+++ b/front/openapi.yaml
@@ -1965,7 +1965,7 @@ components:
       required:
         - kid
         - kty
-        - use_
+        - use
         - alg
         - x5c
         - x5t
@@ -1982,7 +1982,7 @@ components:
           type: string
         n:
           type: string
-        use_:
+        use:
           type: string
         x5c:
           type: array

--- a/libs/ferriskey-security/src/jwt/entities.rs
+++ b/libs/ferriskey-security/src/jwt/entities.rs
@@ -161,7 +161,7 @@ pub struct JwtKeyPair {
 pub struct JwkKey {
     pub kid: String,
     pub kty: String,
-    pub use_: String,
+    pub r#use: String,
     pub alg: String,
     pub x5c: Vec<String>,
     pub x5t: String,
@@ -291,7 +291,7 @@ impl JwtKeyPair {
         Ok(JwkKey {
             kid: self.id.to_string(),
             kty: "RSA".to_string(),
-            use_: "sig".to_string(),
+            r#use: "sig".to_string(),
             alg: "RS256".to_string(),
             x5c: vec![x5c_value],
             x5t,


### PR DESCRIPTION
Implement get_jwks_json with a shared fetch_realm_jwks helper and add routes
for /jwks.json and /jwks. Update openid_configuration to point jwks_uri to
/jwks.json. Adjust OpenAPI schema and JwkKey to use the 'use' property (r#use)
and update JWK generation accordingly. Add logging and map_err handling in
authentication services to provide better diagnostics for token and session
errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JWKS endpoint at `/protocol/openid-connect/jwks.json` and `/protocol/openid-connect/jwks` for improved OpenID Connect protocol compliance and interoperability.

* **Bug Fixes**
  * Fixed OpenAPI schema field naming in JwkKey structure for better API consistency.

* **Refactor**
  * Enhanced error handling and logging throughout JWT generation and authorization workflows for improved debugging and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->