### PR TITLE
fix: enhance SSO cookie handling and auth flow

### DIFF
--- a/api/src/application/http/authentication/handlers/logout.rs
+++ b/api/src/application/http/authentication/handlers/logout.rs
@@ -35,12 +35,14 @@ fn clear_session_cookies_headers(base_url: &str) -> Result<HeaderMap, ApiError> 
     let mut clear_session_cookie = Cookie::build((AUTH_SESSION_COOKIE, ""))
         .path("/")
         .http_only(true)
-        .same_site(SameSite::Lax);
+        .same_site(SameSite::Lax)
+        .removal();
 
     let mut clear_identity_cookie = Cookie::build((IDENTITY_COOKIE, ""))
         .path("/")
         .http_only(true)
-        .same_site(SameSite::Lax);
+        .same_site(SameSite::Lax)
+        .removal();
 
     if is_secure {
         clear_session_cookie = clear_session_cookie.secure(true);

--- a/front/src/pages/authentication/feature/execution/configure-otp-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/configure-otp-feature.tsx
@@ -50,24 +50,11 @@ export default function ConfigureOtpFeature() {
     },
   })
 
-
   const handle = useCallback(() => {
-    const cookies = document.cookie.split(';').reduce(
-      (acc, cookie) => {
-        const [key, value] = cookie.trim().split('=')
-        acc[key] = value
-        return acc
-      },
-      {} as Record<string, string>
-    )
-
-    const sessionCode = cookies['FERRISKEY_SESSION'] || ''
-
     authenticate({
       clientId: 'security-admin-console',
       realm: realm_name ?? 'master',
       data: {},
-      sessionCode,
       useToken: true,
       token: token ?? undefined,
     })

--- a/front/src/pages/authentication/feature/execution/update-password-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/update-password-feature.tsx
@@ -37,21 +37,10 @@ export default function UpdatePasswordFeature() {
 
   useEffect(() => {
     if (responseUpdatePassword) {
-      const cookies = document.cookie.split(';').reduce(
-        (acc, cookie) => {
-          const [key, value] = cookie.trim().split('=')
-          acc[key] = value
-          return acc
-        },
-        {} as Record<string, string>
-      )
-
-      const sessionCode = cookies['FERRISKEY_SESSION'] || ''
       authenticate({
         clientId: 'security-admin-console',
         realm: realm_name ?? 'master',
         data: {},
-        sessionCode,
         token: token ?? undefined
       })
     }

--- a/front/src/pages/authentication/feature/page-login-feature.tsx
+++ b/front/src/pages/authentication/feature/page-login-feature.tsx
@@ -93,22 +93,11 @@ export default function PageLoginFeature() {
   }, [authenticateData, form, navigate, realm_name])
 
   function onSubmit(data: AuthenticateSchema) {
-    const cookies = document.cookie.split(';').reduce(
-      (acc, cookie) => {
-        const [key, value] = cookie.trim().split('=')
-        acc[key] = value
-        return acc
-      },
-      {} as Record<string, string>
-    )
-
-    const sessionCode = cookies['FERRISKEY_SESSION'] || '123456' // Fallback to default if not found
     const { clientId } = getAuthParamsFromUrl()
     authenticate({
       data,
       realm: realm_name ?? 'master',
       clientId,
-      sessionCode,
     })
   }
 

--- a/front/src/pages/authentication/ui/page-callback.tsx
+++ b/front/src/pages/authentication/ui/page-callback.tsx
@@ -1,3 +1,4 @@
+import LoaderSpinner from '@/components/ui/loader-spinner'
 import { XCircle } from 'lucide-react'
 
 export interface PageCallbackProps {
@@ -12,8 +13,7 @@ export default function PageCallback({ code, setup }: PageCallbackProps) {
 
   return (
     <div>
-      <h1>Page callback</h1>
-      <p>{code}</p>
+      <LoaderSpinner />
     </div>
   )
 }


### PR DESCRIPTION
Ensure identity cookie is non-empty before attempting automatic SSO and add
warnings for SSO attempts and failures. Add a token fingerprint/segment context when token verification fails and improve JWT decode error messages to include error kind. Mark identity and session cookies with removal() when clearing them.

Switch frontend authenticate call to a manual fetch that includes credentials,
Content-Type, and better HTTP error handling. Remove reliance on sessionCode
and cookie parsing in multiple auth pages. Add a loader spinner to the callback page.