### PR TITLE
feat: add overview UI components and integrate in pages

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo_ferriskey.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,400&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FerrisKey - Portail</title>
   </head>

--- a/front/src/App.css
+++ b/front/src/App.css
@@ -76,6 +76,7 @@
 }
 
 @theme inline {
+  --font-sans: 'IBM Plex Sans', sans-serif;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -120,6 +121,7 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: 'IBM Plex Sans', sans-serif;
   }
 
 }

--- a/front/src/components/ui/entity-avatar.tsx
+++ b/front/src/components/ui/entity-avatar.tsx
@@ -1,0 +1,21 @@
+interface EntityAvatarProps {
+  label: string
+  color?: string
+  size?: 'sm' | 'md'
+}
+
+const SIZE = {
+  sm: 'h-8 w-8 text-sm',
+  md: 'h-10 w-10 text-base',
+}
+
+export function EntityAvatar({ label, color = '#F97316', size = 'md' }: EntityAvatarProps) {
+  return (
+    <div
+      className={`${SIZE[size]} rounded-md flex items-center justify-center shrink-0 font-bold text-white`}
+      style={{ backgroundColor: color }}
+    >
+      {label?.[0]?.toUpperCase() || '?'}
+    </div>
+  )
+}

--- a/front/src/components/ui/overview-header.tsx
+++ b/front/src/components/ui/overview-header.tsx
@@ -1,0 +1,76 @@
+import { ReactNode } from 'react'
+import { Button } from './button'
+import { Plus, Upload } from 'lucide-react'
+
+interface Tab {
+  key: string
+  label: string
+  onClick: () => void
+  active: boolean
+}
+
+interface OverviewHeaderProps {
+  title: string
+  description: string
+  primaryAction?: {
+    label: string
+    onClick: () => void
+  }
+  secondaryAction?: {
+    label: string
+    onClick: () => void
+    icon?: ReactNode
+  }
+  tabs: Tab[]
+}
+
+export function OverviewHeader({
+  title,
+  description,
+  primaryAction,
+  secondaryAction,
+  tabs,
+}: OverviewHeaderProps) {
+  return (
+    <>
+      {/* Header */}
+      <div className='-mx-8 -mt-8 px-8 pt-8 pb-4 border-b flex items-start justify-between gap-4'>
+        <div>
+          <h1 className='text-2xl font-bold tracking-tight'>{title}</h1>
+          <p className='text-sm text-muted-foreground mt-1'>{description}</p>
+        </div>
+        <div className='flex items-center gap-2 shrink-0'>
+          {primaryAction && (
+            <Button onClick={primaryAction.onClick} size='sm'>
+              <Plus className='h-4 w-4' />
+              {primaryAction.label}
+            </Button>
+          )}
+          {secondaryAction && (
+            <Button variant='outline' size='sm' onClick={secondaryAction.onClick}>
+              {secondaryAction.icon ?? <Upload className='h-4 w-4' />}
+              {secondaryAction.label}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className='-mx-8 px-8 pb-4 border-b flex items-center gap-2 -mt-2'>
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={tab.onClick}
+            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors border ${
+              tab.active
+                ? 'bg-primary/10 text-primary border-primary/40'
+                : 'bg-transparent text-foreground border-border hover:bg-muted'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/front/src/components/ui/overview-list.tsx
+++ b/front/src/components/ui/overview-list.tsx
@@ -1,0 +1,152 @@
+import { ReactNode, useState, useMemo } from 'react'
+import { Plus, Search } from 'lucide-react'
+import { Input } from './input'
+import { Button } from './button'
+import { Skeleton } from './skeleton'
+
+export interface OverviewListProps<T extends { id: string }> {
+  data: T[]
+  isLoading?: boolean
+  searchKeys?: (keyof T)[]
+  searchPlaceholder?: string
+  pageSize?: number
+  title?: (count: number) => string
+  renderRow: (item: T) => ReactNode
+  emptyLabel?: string
+  action?: {
+    label: string
+    onClick: () => void
+  }
+}
+
+export function OverviewList<T extends { id: string }>({
+  data,
+  isLoading = false,
+  searchKeys = [],
+  searchPlaceholder = 'Search...',
+  pageSize = 10,
+  title = (n) => `Items (${n})`,
+  renderRow,
+  emptyLabel = 'No items found.',
+  action,
+}: OverviewListProps<T>) {
+  const [search, setSearch] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const filteredData = useMemo(() => {
+    if (!search.trim() || searchKeys.length === 0) return data
+    const q = search.toLowerCase()
+    return data.filter((item) =>
+      searchKeys.some((key) => String(item[key] ?? '').toLowerCase().includes(q))
+    )
+  }, [data, search, searchKeys])
+
+  const totalPages = Math.ceil(filteredData.length / pageSize)
+  const paginatedData = useMemo(() => {
+    const start = (currentPage - 1) * pageSize
+    return filteredData.slice(start, start + pageSize)
+  }, [filteredData, currentPage, pageSize])
+
+  const rangeStart = filteredData.length === 0 ? 0 : (currentPage - 1) * pageSize + 1
+  const rangeEnd = Math.min(currentPage * pageSize, filteredData.length)
+
+  const handleSearch = (value: string) => {
+    setSearch(value)
+    setCurrentPage(1)
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div className='flex items-center justify-between mb-3'>
+        <h2 className='text-base font-semibold'>{title(filteredData.length)}</h2>
+        <div className='flex items-center gap-2'>
+          {searchKeys.length > 0 && (
+            <div className='relative'>
+              <Search className='absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground' />
+              <Input
+                type='search'
+                placeholder={searchPlaceholder}
+                className='pl-9 h-9 w-64 bg-background text-sm'
+                value={search}
+                onChange={(e) => handleSearch(e.target.value)}
+              />
+            </div>
+          )}
+          {action && (
+            <Button size='sm' onClick={action.onClick}>
+              <Plus className='h-4 w-4' />
+              {action.label}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* List body */}
+      <div className='-mx-8 border-t border-b overflow-hidden'>
+        {isLoading ? (
+          Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className='flex items-center justify-between px-8 py-4 border-b last:border-b-0'>
+              <div className='flex items-center gap-3'>
+                <Skeleton className='h-10 w-10 rounded-md' />
+                <div className='space-y-2'>
+                  <Skeleton className='h-4 w-40' />
+                  <Skeleton className='h-3 w-32' />
+                </div>
+              </div>
+              <Skeleton className='h-6 w-16 rounded-md' />
+            </div>
+          ))
+        ) : paginatedData.length === 0 ? (
+          <div className='flex items-center justify-center h-24 text-sm text-muted-foreground'>
+            {emptyLabel}
+          </div>
+        ) : (
+          paginatedData.map((item) => (
+            <div key={item.id}>{renderRow(item)}</div>
+          ))
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className='flex items-center justify-between mt-4 px-1'>
+          <span className='text-sm text-muted-foreground'>
+            {rangeStart}-{rangeEnd} sur {filteredData.length}
+          </span>
+          <div className='flex items-center gap-1'>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
+              disabled={currentPage <= 1}
+              className='h-8'
+            >
+              Precedent
+            </Button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+              <Button
+                key={page}
+                variant={page === currentPage ? 'default' : 'outline'}
+                size='sm'
+                onClick={() => setCurrentPage(page)}
+                className='h-8 w-8 p-0'
+              >
+                {page}
+              </Button>
+            ))}
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => setCurrentPage((p) => Math.min(p + 1, totalPages))}
+              disabled={currentPage >= totalPages}
+              className='h-8'
+            >
+              Suivant
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/front/src/pages/client/columns/list-client.column.tsx
+++ b/front/src/pages/client/columns/list-client.column.tsx
@@ -5,6 +5,7 @@ import { ColumnDef } from '@/components/ui/data-table'
 
 import Client = Schemas.Client
 import { BadgeColorScheme } from '@/components/ui/badge-color.enum'
+import { AlertTriangle } from 'lucide-react'
 
 export const columns: ColumnDef<Client>[] = [
   {
@@ -27,20 +28,27 @@ export const columns: ColumnDef<Client>[] = [
     header: 'Type',
     cell: (client) => (
       <BadgeColor color={client.public_client ? BadgeColorScheme.BLUE : BadgeColorScheme.PURPLE}>
-        {client.public_client ? 'Public' : 'Confidential'}
+        {client.public_client ? 'public' : 'confidential'}
       </BadgeColor>
     ),
   },
   {
     id: 'status',
     header: 'Status',
-    cell: (client) => (
-      <div className='flex items-center gap-2'>
-        <span
-          className={`h-2 w-2 rounded-full ${client.enabled ? 'bg-emerald-500' : 'bg-red-500'}`}
-        ></span>
-        <span className='text-sm'>{client.enabled ? 'Active' : 'Inactive'}</span>
-      </div>
-    ),
+    cell: (client) => {
+      if (!client.enabled) {
+        return (
+          <span className='inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold border border-orange-500/40 text-orange-500 bg-orange-500/10'>
+            <AlertTriangle className='h-3 w-3' />
+            RISK
+          </span>
+        )
+      }
+      return (
+        <span className='inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold border border-emerald-500/40 text-emerald-600 bg-emerald-500/10'>
+          ACTIVE
+        </span>
+      )
+    },
   },
 ]

--- a/front/src/pages/client/container.tsx
+++ b/front/src/pages/client/container.tsx
@@ -1,25 +1,59 @@
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Users } from 'lucide-react'
-import { useState } from 'react'
-import PageHeader from '@/components/ui/page-header'
 import PageContainer from '@/components/ui/page-container'
+import { OverviewHeader } from '@/components/ui/overview-header'
+import { useNavigate, useParams } from 'react-router'
+import { RouterParams } from '@/routes/router'
+import { CLIENTS_URL, CLIENT_CREATE_URL } from '@/routes/sub-router/client.router'
+import { USERS_URL } from '@/routes/sub-router/user.router'
+import { ROLES_URL } from '@/routes/sub-router/role.router'
+import { useLocation } from 'react-router'
 
 export default function Container() {
-  const [tab, setTab] = useState('list')
+  const { realm_name } = useParams<RouterParams>()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const tabs = [
+    {
+      key: 'clients',
+      label: 'Clients',
+      onClick: () => navigate(`${CLIENTS_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(CLIENTS_URL(realm_name)),
+    },
+    {
+      key: 'users',
+      label: 'Users',
+      onClick: () => navigate(`${USERS_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(USERS_URL(realm_name)),
+    },
+    {
+      key: 'roles',
+      label: 'Roles',
+      onClick: () => navigate(`${ROLES_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(ROLES_URL(realm_name)),
+    },
+    {
+      key: 'client-scopes',
+      label: 'Client Scopes',
+      onClick: () => {},
+      active: false,
+    },
+  ]
 
   return (
     <PageContainer>
-      <PageHeader
-        icon={Users}
-        title='Clients'
-        description='Manage and configure OAuth clients for your applications'
-      >
-        <Tabs defaultValue={tab} onValueChange={setTab}>
-          <TabsList>
-            <TabsTrigger value={'list'}>Clients list</TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </PageHeader>
+      <OverviewHeader
+        title='Client and Access Administration'
+        description='Manage realm settings, users, and policy workflows'
+        primaryAction={{
+          label: 'New Client',
+          onClick: () => navigate(`${CLIENTS_URL(realm_name)}${CLIENT_CREATE_URL}`),
+        }}
+        secondaryAction={{
+          label: 'Import',
+          onClick: () => {},
+        }}
+        tabs={tabs}
+      />
     </PageContainer>
   )
 }

--- a/front/src/pages/client/ui/page-clients-overview.tsx
+++ b/front/src/pages/client/ui/page-clients-overview.tsx
@@ -1,13 +1,17 @@
-import { DataTable } from '@/components/ui/data-table'
-import { Edit, ExternalLink, Trash2 } from 'lucide-react'
-import { columns } from '../columns/list-client.column'
 import { Schemas } from '@/api/api.client.ts'
 import { ConfirmDeleteAlert } from '@/components/confirm-delete-alert'
 import { Filter, FilterFieldsConfig } from '@/components/ui/filters'
 import StatisticsCard from '../components/statistics-card'
 import ClientTrendChart from '../components/client-trend-chart'
+import { useState, useMemo } from 'react'
+import { AlertTriangle, Search, SlidersHorizontal } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 
 import Client = Schemas.Client
+
+type QuickFilter = 'all' | 'confidential' | 'deprecated'
 
 interface Statistics {
   totalClients: number
@@ -39,127 +43,269 @@ export interface PageClientsOverviewProps {
   onRowDelete: (client: Client) => void
 }
 
+const quickFilters: { key: QuickFilter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'confidential', label: 'Confidential' },
+  { key: 'deprecated', label: 'Deprecated' },
+]
+
+const PAGE_SIZE = 10
+
+function ClientAvatar({ name }: { name: string }) {
+  return (
+    <div className='h-10 w-10 rounded-md flex items-center justify-center shrink-0' style={{ backgroundColor: '#F97316' }}>
+      <span className='text-base font-bold text-white'>{name?.[0]?.toUpperCase() || 'C'}</span>
+    </div>
+  )
+}
+
+function StatusBadge({ enabled }: { enabled: boolean }) {
+  if (!enabled) {
+    return (
+      <span className='inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-semibold border border-orange-400/50 text-orange-500 bg-orange-50 dark:bg-orange-500/10'>
+        <AlertTriangle className='h-3 w-3' />
+        INACTIVE
+      </span>
+    )
+  }
+  return (
+    <span className='inline-flex items-center px-3 py-1 rounded-md text-xs font-semibold border border-emerald-400/50 text-emerald-600 bg-emerald-50 dark:bg-emerald-500/10'>
+      ACTIVE
+    </span>
+  )
+}
+
+function TypeBadge({ isPublic }: { isPublic: boolean }) {
+  return isPublic ? (
+    <span className='inline-flex items-center px-2.5 py-0.5 rounded-md border border-blue-300 text-blue-500 text-xs font-mono bg-blue-50 dark:bg-blue-500/10 dark:border-blue-400/40'>
+      public
+    </span>
+  ) : (
+    <span className='inline-flex items-center px-2.5 py-0.5 rounded-md border border-purple-300 text-purple-500 text-xs font-mono bg-purple-50 dark:bg-purple-500/10 dark:border-purple-400/40'>
+      confidential
+    </span>
+  )
+}
+
 export default function PageClientsOverview({
   data,
   isLoading,
   statistics,
-  filters,
-  filterFields,
-  onFiltersChange,
   confirm,
   onConfirmClose,
-  handleDeleteSelected,
   handleClickRow,
-  handleCreateClient,
-  onRowDelete,
 }: PageClientsOverviewProps) {
   const { totalClients, activeClients, publicClients, confidentialClients } = statistics
+  const [quickFilter, setQuickFilter] = useState<QuickFilter>('all')
+  const [search, setSearch] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const filteredData = useMemo(() => {
+    let result = data
+
+    if (quickFilter === 'confidential') result = result.filter((c) => !c.public_client)
+    else if (quickFilter === 'deprecated') result = result.filter((c) => !c.enabled)
+
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      result = result.filter(
+        (c) => c.name?.toLowerCase().includes(q) || c.client_id?.toLowerCase().includes(q)
+      )
+    }
+
+    return result
+  }, [data, quickFilter, search])
+
+  const totalPages = Math.ceil(filteredData.length / PAGE_SIZE)
+  const paginatedData = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE
+    return filteredData.slice(start, start + PAGE_SIZE)
+  }, [filteredData, currentPage])
+
+  const handleQuickFilter = (f: QuickFilter) => {
+    setQuickFilter(f)
+    setCurrentPage(1)
+  }
+
+  const rangeStart = filteredData.length === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1
+  const rangeEnd = Math.min(currentPage * PAGE_SIZE, filteredData.length)
 
   return (
     <div className='flex flex-col gap-6'>
-      {/* Statistics Cards */}
-      <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
-        <StatisticsCard
-          title='Total Clients'
-          value={totalClients}
-          isLoading={isLoading}
-          chart={
-            !isLoading && <ClientTrendChart clients={data} days={7} color='hsl(200 76% 36%)' />
-          }
-        />
-
-        <StatisticsCard
-          title='Active Clients'
-          value={activeClients}
-          isLoading={isLoading}
-          trend={{
-            value:
-              activeClients > 0 && totalClients > 0
-                ? Math.round((activeClients / totalClients) * 100)
-                : 0,
-            direction: 'up',
-          }}
-          chart={
-            !isLoading && (
-              <ClientTrendChart
-                clients={data.filter((c) => c.enabled)}
-                days={7}
-                color='hsl(142 76% 36%)'
-              />
-            )
-          }
-        />
-
-        <StatisticsCard
-          title='Public Clients'
-          value={publicClients}
-          isLoading={isLoading}
-          chart={
-            !isLoading && (
-              <ClientTrendChart
-                clients={data.filter((c) => c.public_client)}
-                days={7}
-                color='hsl(221 83% 53%)'
-              />
-            )
-          }
-        />
-
-        <StatisticsCard
-          title='Confidential Clients'
-          value={confidentialClients}
-          isLoading={isLoading}
-          chart={
-            !isLoading && (
-              <ClientTrendChart
-                clients={data.filter((c) => !c.public_client)}
-                days={7}
-                color='hsl(262 83% 58%)'
-              />
-            )
-          }
-        />
+      {/* Quick Filters */}
+      <div className='flex items-center gap-2'>
+        {quickFilters.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => handleQuickFilter(f.key)}
+            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors border ${quickFilter === f.key
+              ? 'bg-primary/10 text-primary border-primary/40'
+              : 'bg-transparent text-foreground border-border hover:bg-muted'
+              }`}
+          >
+            {f.label}
+          </button>
+        ))}
       </div>
 
-      {/* Data Table */}
-      <DataTable
-        data={data}
-        columns={columns}
-        isLoading={isLoading}
-        searchPlaceholder='Search clients by name or ID...'
-        createData={{
-          label: 'Create Client',
-          onClick: handleCreateClient,
-        }}
-        searchKeys={['name', 'client_id']}
-        enableSelection={true}
-        enableFilters={true}
-        filterFields={filterFields}
-        filters={filters}
-        onFiltersChange={onFiltersChange}
-        onRowClick={(client) => {
-          handleClickRow(client.id)
-        }}
-        onDeleteSelected={handleDeleteSelected}
-        rowActions={[
-          {
-            label: 'Edit',
-            icon: <Edit className='h-4 w-4' />,
-            onClick: (client) => handleClickRow(client.id),
-          },
-          {
-            label: 'View',
-            icon: <ExternalLink className='h-4 w-4' />,
-            onClick: (client) => handleClickRow(client.id),
-          },
-          {
-            label: 'Delete',
-            icon: <Trash2 className='h-4 w-4' />,
-            variant: 'destructive',
-            onClick: (client) => onRowDelete(client),
-          },
-        ]}
-      />
+      {/* Statistics Cards */}
+      <div>
+        <p className='text-xs text-muted-foreground mb-3'>Client overview</p>
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <StatisticsCard
+            title='Total clients'
+            value={totalClients}
+            isLoading={isLoading}
+            chart={!isLoading && <ClientTrendChart clients={data} days={7} color='hsl(200 76% 36%)' />}
+          />
+          <StatisticsCard
+            title='Active clients'
+            value={activeClients}
+            isLoading={isLoading}
+            chart={
+              !isLoading && (
+                <ClientTrendChart clients={data.filter((c) => c.enabled)} days={7} color='hsl(142 76% 36%)' />
+              )
+            }
+          />
+          <StatisticsCard
+            title='Public clients'
+            value={publicClients}
+            isLoading={isLoading}
+            chart={
+              !isLoading && (
+                <ClientTrendChart clients={data.filter((c) => c.public_client)} days={7} color='hsl(30 100% 50%)' />
+              )
+            }
+          />
+          <StatisticsCard
+            title='Confidential'
+            value={confidentialClients}
+            isLoading={isLoading}
+            chart={
+              !isLoading && (
+                <ClientTrendChart clients={data.filter((c) => !c.public_client)} days={7} color='hsl(262 83% 58%)' />
+              )
+            }
+          />
+        </div>
+      </div>
+
+      {/* Client List */}
+      <div>
+        {/* List header */}
+        <div className='flex items-center justify-between mb-3'>
+          <h2 className='text-base font-semibold'>
+            Clients ({filteredData.length})
+          </h2>
+          <div className='flex items-center gap-2'>
+            <div className='relative'>
+              <Search className='absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground' />
+              <Input
+                type='search'
+                placeholder='Search clients...'
+                className='pl-9 h-9 w-64 bg-background text-sm'
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value)
+                  setCurrentPage(1)
+                }}
+              />
+            </div>
+            <Button variant='ghost' size='icon' className='h-9 w-9'>
+              <SlidersHorizontal className='h-4 w-4' />
+            </Button>
+          </div>
+        </div>
+
+        {/* List body */}
+        <div className='-mx-8 border-t border-b overflow-hidden'>
+          {isLoading ? (
+            Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className='flex items-center justify-between px-8 py-4 border-b last:border-b-0'>
+                <div className='flex items-center gap-3'>
+                  <Skeleton className='h-10 w-10 rounded-lg' />
+                  <div className='space-y-2'>
+                    <Skeleton className='h-4 w-40' />
+                    <Skeleton className='h-3 w-32' />
+                  </div>
+                </div>
+                <Skeleton className='h-6 w-16 rounded-md' />
+              </div>
+            ))
+          ) : paginatedData.length === 0 ? (
+            <div className='flex items-center justify-center h-24 text-sm text-muted-foreground'>
+              No clients found.
+            </div>
+          ) : (
+            paginatedData.map((client) => (
+              <div
+                key={client.id}
+                onClick={() => handleClickRow(client.id)}
+                className='flex items-center justify-between px-8 py-4 border-b last:border-b-0 hover:bg-muted/40 cursor-pointer transition-colors'
+              >
+                {/* Left: avatar + name + client_id + type badge */}
+                <div className='flex items-center gap-4'>
+                  <ClientAvatar name={client.name} />
+                  <div>
+                    <div className='flex items-center gap-2.5'>
+                      <span className='text-base font-medium'>{client.name}</span>
+                      <TypeBadge isPublic={client.public_client} />
+                    </div>
+                    <div className='text-sm text-muted-foreground mt-0.5'>
+                      client_id: {client.client_id}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Right: status badge */}
+                <StatusBadge enabled={client.enabled} />
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className='flex items-center justify-between mt-4 px-1'>
+            <span className='text-sm text-muted-foreground'>
+              {rangeStart}-{rangeEnd} sur {filteredData.length}
+            </span>
+            <div className='flex items-center gap-1'>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
+                disabled={currentPage <= 1}
+                className='h-8'
+              >
+                Precedent
+              </Button>
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                <Button
+                  key={page}
+                  variant={page === currentPage ? 'default' : 'outline'}
+                  size='sm'
+                  onClick={() => setCurrentPage(page)}
+                  className='h-8 w-8 p-0'
+                >
+                  {page}
+                </Button>
+              ))}
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => setCurrentPage((p) => Math.min(p + 1, totalPages))}
+                disabled={currentPage >= totalPages}
+                className='h-8'
+              >
+                Suivant
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
       <ConfirmDeleteAlert
         title={confirm.title}
         description={confirm.description}

--- a/front/src/pages/role/components/statistics-card.tsx
+++ b/front/src/pages/role/components/statistics-card.tsx
@@ -1,37 +1,28 @@
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { cn } from '@/lib/utils'
-import { LucideIcon } from 'lucide-react'
 import { ReactNode } from 'react'
 
 interface StatisticsCardProps {
   title: string
   value: number | string
-  description: string | ReactNode
-  icon: LucideIcon
+  description?: string | ReactNode
   isLoading?: boolean
-  descriptionClassName?: string
 }
 
 export default function StatisticsCard({
   title,
   value,
   description,
-  icon: Icon,
   isLoading = false,
-  descriptionClassName,
 }: StatisticsCardProps) {
   if (isLoading) {
     return (
-      <Card>
-        <CardContent>
-          <div className='flex items-center justify-between'>
-            <Skeleton className='h-4 w-24' />
-            <Skeleton className='h-9 w-9 rounded-lg' />
-          </div>
-          <div className='mt-4'>
-            <Skeleton className='h-10 w-20' />
-            <Skeleton className='h-4 w-32 mt-2' />
+      <Card className='overflow-hidden'>
+        <CardContent className='p-6'>
+          <div className='space-y-3'>
+            <Skeleton className='h-4 w-32' />
+            <Skeleton className='h-10 w-24' />
+            <Skeleton className='h-3 w-36' />
           </div>
         </CardContent>
       </Card>
@@ -39,21 +30,16 @@ export default function StatisticsCard({
   }
 
   return (
-    <Card className='hover:shadow-md transition-shadow'>
-      <CardContent>
-        <div className='flex items-center justify-between'>
-          <div className='text-sm font-medium text-muted-foreground'>{title}</div>
-          <div className='rounded-lg bg-muted p-2'>
-            <Icon className='h-5 w-5 text-muted-foreground' />
-          </div>
-        </div>
-        <div className='mt-4'>
-          <div className='text-4xl font-bold'>{value}</div>
-          <div className={cn('text-sm mt-2', descriptionClassName || 'text-muted-foreground')}>
-            {description}
-          </div>
+    <Card className='overflow-hidden hover:shadow-lg transition-shadow duration-200'>
+      <CardContent className='p-6'>
+        <div className='space-y-3'>
+          <h3 className='text-sm font-medium text-muted-foreground'>{title}</h3>
+          <span className='text-4xl font-bold tracking-tight'>{value}</span>
+          {description && (
+            <p className='text-xs text-muted-foreground'>{description}</p>
+          )}
         </div>
       </CardContent>
-    </Card >
+    </Card>
   )
 }

--- a/front/src/pages/role/feature/page-roles-overview-feature.tsx
+++ b/front/src/pages/role/feature/page-roles-overview-feature.tsx
@@ -4,9 +4,11 @@ import { useDeleteRole, useGetRoles } from '../../../api/role.api'
 import PageRolesOverview from '../ui/page-roles-overview'
 import { ROLE_CREATE_URL, ROLE_SETTINGS_URL, ROLE_URL, ROLES_URL } from '@/routes/sub-router/role.router'
 import { Schemas } from '@/api/api.client'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { Filter, FilterFieldsConfig } from '@/components/ui/filters'
 import { useConfirmDeleteAlert } from '@/hooks/use-confirm-delete-alert'
+import { useOutletContext } from 'react-router'
+import { RolesLayoutContext } from '../layout/roles-layout'
 
 import Role = Schemas.Role
 
@@ -16,6 +18,12 @@ export default function PageRolesOverviewFeature() {
   const { data: rolesResponse, isLoading } = useGetRoles({ realm: realm_name ?? 'master' })
   const { mutate: deleteRole } = useDeleteRole()
   const { confirm, ask, close } = useConfirmDeleteAlert()
+  const { setPrimaryAction } = useOutletContext<RolesLayoutContext>()
+
+  useEffect(() => {
+    setPrimaryAction({ label: 'New Role', onClick: () => navigate(`${ROLES_URL(realm_name)}${ROLE_CREATE_URL}`) })
+    return () => setPrimaryAction(undefined)
+  }, [])
   const [filters, setFilters] = useState<Filter[]>([])
 
   const roles = useMemo(() => rolesResponse?.data || [], [rolesResponse])

--- a/front/src/pages/role/layout/roles-layout.tsx
+++ b/front/src/pages/role/layout/roles-layout.tsx
@@ -1,25 +1,58 @@
+import { OverviewHeader } from '@/components/ui/overview-header'
+import { useNavigate, useParams } from 'react-router'
+import { RouterParams } from '@/routes/router'
+import { USERS_URL } from '@/routes/sub-router/user.router'
+import { CLIENTS_URL } from '@/routes/sub-router/client.router'
+import { ROLES_URL } from '@/routes/sub-router/role.router'
+import { useLocation, Outlet } from 'react-router'
 import { useState } from 'react'
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import PageHeader from '@/components/ui/page-header'
-import PageContainer from '@/components/ui/page-container'
-import { Shield } from 'lucide-react'
+
+export type RolesLayoutContext = {
+  setPrimaryAction: (action: { label: string; onClick: () => void } | undefined) => void
+}
 
 export default function RolesLayout() {
-  const [tab, setTab] = useState('list')
+  const { realm_name } = useParams<RouterParams>()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [primaryAction, setPrimaryAction] = useState<{ label: string; onClick: () => void } | undefined>()
+
+  const tabs = [
+    {
+      key: 'clients',
+      label: 'Clients',
+      onClick: () => navigate(`${CLIENTS_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(CLIENTS_URL(realm_name)),
+    },
+    {
+      key: 'users',
+      label: 'Users',
+      onClick: () => navigate(`${USERS_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(USERS_URL(realm_name)),
+    },
+    {
+      key: 'roles',
+      label: 'Roles',
+      onClick: () => navigate(`${ROLES_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(ROLES_URL(realm_name)),
+    },
+    {
+      key: 'client-scopes',
+      label: 'Client Scopes',
+      onClick: () => {},
+      active: false,
+    },
+  ]
 
   return (
-    <PageContainer>
-      <PageHeader
-        icon={Shield}
-        title='Roles'
-        description='Manage and configure roles and permissions for your realm'
-      >
-        <Tabs defaultValue={tab} onValueChange={setTab}>
-          <TabsList>
-            <TabsTrigger value={'list'}>Roles list</TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </PageHeader>
-    </PageContainer>
+    <div className='flex flex-col gap-6 p-8'>
+      <OverviewHeader
+        title='Client and Access Administration'
+        description='Manage realm settings, users, and policy workflows'
+        primaryAction={primaryAction}
+        tabs={tabs}
+      />
+      <Outlet context={{ setPrimaryAction } satisfies RolesLayoutContext} />
+    </div>
   )
 }

--- a/front/src/pages/role/ui/page-roles-overview.tsx
+++ b/front/src/pages/role/ui/page-roles-overview.tsx
@@ -1,10 +1,9 @@
-import { DataTable } from '@/components/ui/data-table'
-import { Edit, ExternalLink, Trash2, Shield, ShieldCheck, ShieldAlert, Activity } from 'lucide-react'
-import { columns } from '../columns/list-client.column'
 import { Schemas } from '@/api/api.client'
 import { ConfirmDeleteAlert } from '@/components/confirm-delete-alert'
 import { Filter, FilterFieldsConfig } from '@/components/ui/filters'
 import StatisticsCard from '../components/statistics-card'
+import { OverviewList } from '@/components/ui/overview-list'
+import { EntityAvatar } from '@/components/ui/entity-avatar'
 
 import Role = Schemas.Role
 
@@ -38,106 +37,107 @@ export interface PageRolesOverviewProps {
   onRowDelete: (role: Role) => void
 }
 
+function RoleScopeBadge({ clientId }: { clientId?: string | null }) {
+  return clientId ? (
+    <span className='inline-flex items-center px-2.5 py-0.5 rounded-md border border-purple-300 text-purple-500 text-xs font-mono bg-purple-50 dark:bg-purple-500/10 dark:border-purple-400/40'>
+      client
+    </span>
+  ) : (
+    <span className='inline-flex items-center px-2.5 py-0.5 rounded-md border border-blue-300 text-blue-500 text-xs font-mono bg-blue-50 dark:bg-blue-500/10 dark:border-blue-400/40'>
+      realm
+    </span>
+  )
+}
+
+function PermissionsBadge({ count }: { count: number }) {
+  return (
+    <span className='inline-flex items-center px-3 py-1 rounded-md text-xs font-semibold border border-border text-muted-foreground bg-muted/50'>
+      {count} permission{count !== 1 ? 's' : ''}
+    </span>
+  )
+}
+
 export default function PageRolesOverview({
   data,
   isLoading,
   statistics,
-  filters,
-  filterFields,
-  onFiltersChange,
   confirm,
   onConfirmClose,
-  handleDeleteSelected,
   handleClickRow,
-  handleCreateRole,
-  onRowDelete,
 }: PageRolesOverviewProps) {
   const { totalRoles, realmRoles, clientRoles, rolesWithPermissions } = statistics
 
   return (
     <div className='flex flex-col gap-6'>
       {/* Statistics Cards */}
-      <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
-        <StatisticsCard
-          title='Total Roles'
-          value={totalRoles}
-          description='All registered roles'
-          icon={Shield}
-          isLoading={isLoading}
-        />
-
-        <StatisticsCard
-          title='Realm Roles'
-          value={realmRoles}
-          description={
-            realmRoles > 0 && totalRoles > 0 ? (
-              <span className='text-blue-600 font-medium'>
-                {((realmRoles / totalRoles) * 100).toFixed(0)}% of total
-              </span>
-            ) : (
-              'No realm roles'
-            )
-          }
-          icon={ShieldCheck}
-          isLoading={isLoading}
-        />
-
-        <StatisticsCard
-          title='Client Roles'
-          value={clientRoles}
-          description='Client-specific roles'
-          icon={ShieldAlert}
-          isLoading={isLoading}
-        />
-
-        <StatisticsCard
-          title='With Permissions'
-          value={rolesWithPermissions}
-          description='Roles with permissions'
-          icon={Activity}
-          isLoading={isLoading}
-        />
+      <div>
+        <p className='text-xs text-muted-foreground mb-3'>Role overview</p>
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <StatisticsCard
+            title='Total roles'
+            value={totalRoles}
+            description='All registered roles'
+            isLoading={isLoading}
+          />
+          <StatisticsCard
+            title='Realm roles'
+            value={realmRoles}
+            description={
+              realmRoles > 0 && totalRoles > 0 ? (
+                <span className='text-blue-600 font-medium'>
+                  {((realmRoles / totalRoles) * 100).toFixed(0)}% of total
+                </span>
+              ) : (
+                'No realm roles'
+              )
+            }
+            isLoading={isLoading}
+          />
+          <StatisticsCard
+            title='Client roles'
+            value={clientRoles}
+            description='Client-specific roles'
+            isLoading={isLoading}
+          />
+          <StatisticsCard
+            title='With permissions'
+            value={rolesWithPermissions}
+            description='Roles with permissions'
+            isLoading={isLoading}
+          />
+        </div>
       </div>
 
-      {/* Data Table */}
-      <DataTable
+      {/* Role List */}
+      <OverviewList
         data={data}
-        columns={columns}
         isLoading={isLoading}
-        searchPlaceholder='Search roles by name or description...'
-        createData={{
-          label: 'Create Role',
-          onClick: handleCreateRole,
-        }}
         searchKeys={['name', 'description']}
-        enableSelection={true}
-        enableFilters={true}
-        filterFields={filterFields}
-        filters={filters}
-        onFiltersChange={onFiltersChange}
-        onRowClick={(role) => {
-          handleClickRow(role.id)
-        }}
-        onDeleteSelected={handleDeleteSelected}
-        rowActions={[
-          {
-            label: 'Edit',
-            icon: <Edit className='h-4 w-4' />,
-            onClick: (role) => console.log('Edit', role),
-          },
-          {
-            label: 'View',
-            icon: <ExternalLink className='h-4 w-4' />,
-            onClick: (role) => console.log('View', role),
-          },
-          {
-            label: 'Delete',
-            icon: <Trash2 className='h-4 w-4' />,
-            variant: 'destructive',
-            onClick: (role) => onRowDelete(role),
-          },
-        ]}
+        searchPlaceholder='Search roles...'
+        title={(n) => `Roles (${n})`}
+        emptyLabel='No roles found.'
+        renderRow={(role) => (
+          <div
+            onClick={() => handleClickRow(role.id)}
+            className='flex items-center justify-between px-8 py-4 border-b last:border-b-0 hover:bg-muted/40 cursor-pointer transition-colors'
+          >
+            <div className='flex items-center gap-4'>
+              <EntityAvatar label={role.name} color='#6366F1' />
+              <div>
+                <div className='flex items-center gap-2.5'>
+                  <span className='text-base font-medium'>{role.name}</span>
+                  <RoleScopeBadge clientId={role.client_id} />
+                </div>
+                <div className='text-sm text-muted-foreground mt-0.5'>
+                  {role.description || `role_id: ${role.id}`}
+                </div>
+              </div>
+            </div>
+            <PermissionsBadge count={role.permissions.length} />
+          </div>
+        )}
       />
+
       <ConfirmDeleteAlert
         title={confirm.title}
         description={confirm.description}

--- a/front/src/pages/user/components/statistics-card.tsx
+++ b/front/src/pages/user/components/statistics-card.tsx
@@ -1,37 +1,28 @@
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { cn } from '@/lib/utils'
-import { LucideIcon } from 'lucide-react'
 import { ReactNode } from 'react'
 
 interface StatisticsCardProps {
   title: string
   value: number | string
-  description: string | ReactNode
-  icon: LucideIcon
+  description?: string | ReactNode
   isLoading?: boolean
-  descriptionClassName?: string
 }
 
 export default function StatisticsCard({
   title,
   value,
   description,
-  icon: Icon,
   isLoading = false,
-  descriptionClassName,
 }: StatisticsCardProps) {
   if (isLoading) {
     return (
-      <Card>
-        <CardContent>
-          <div className='flex items-center justify-between'>
-            <Skeleton className='h-4 w-24' />
-            <Skeleton className='h-9 w-9 rounded-lg' />
-          </div>
-          <div className='mt-4'>
-            <Skeleton className='h-10 w-20' />
-            <Skeleton className='h-4 w-32 mt-2' />
+      <Card className='overflow-hidden'>
+        <CardContent className='p-6'>
+          <div className='space-y-3'>
+            <Skeleton className='h-4 w-32' />
+            <Skeleton className='h-10 w-24' />
+            <Skeleton className='h-3 w-36' />
           </div>
         </CardContent>
       </Card>
@@ -39,19 +30,14 @@ export default function StatisticsCard({
   }
 
   return (
-    <Card className='hover:shadow-md transition-shadow'>
-      <CardContent>
-        <div className='flex items-center justify-between'>
-          <div className='text-sm font-medium text-muted-foreground'>{title}</div>
-          <div className='rounded-lg bg-muted p-2'>
-            <Icon className='h-5 w-5 text-muted-foreground' />
-          </div>
-        </div>
-        <div className='mt-4'>
-          <div className='text-4xl font-bold'>{value}</div>
-          <div className={cn('text-sm mt-2', descriptionClassName || 'text-muted-foreground')}>
-            {description}
-          </div>
+    <Card className='overflow-hidden hover:shadow-lg transition-shadow duration-200'>
+      <CardContent className='p-6'>
+        <div className='space-y-3'>
+          <h3 className='text-sm font-medium text-muted-foreground'>{title}</h3>
+          <span className='text-4xl font-bold tracking-tight'>{value}</span>
+          {description && (
+            <p className='text-xs text-muted-foreground'>{description}</p>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/front/src/pages/user/feature/page-users-overview-feature.tsx
+++ b/front/src/pages/user/feature/page-users-overview-feature.tsx
@@ -4,10 +4,12 @@ import { toast } from 'sonner'
 import { useBulkDeleteUser, useGetUsers } from '../../../api/user.api'
 import PageUsersOverview from '../ui/page-users-overview'
 import { USER_OVERVIEW_URL, USER_URL } from '@/routes/sub-router/user.router'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { Schemas } from '@/api/api.client.ts'
 import { Filter, FilterFieldsConfig } from '@/components/ui/filters'
 import { useConfirmDeleteAlert } from '@/hooks/use-confirm-delete-alert'
+import { useOutletContext } from 'react-router'
+import { UsersLayoutContext } from '../layouts/users-layout'
 
 import User = Schemas.User
 
@@ -17,6 +19,12 @@ export default function PageUsersOverviewFeature() {
   const { mutate: bulkDeleteUser } = useBulkDeleteUser()
   const [openCreateUserModal, setOpenCreateUserModal] = useState(false)
   const { confirm, ask, close } = useConfirmDeleteAlert()
+  const { setPrimaryAction } = useOutletContext<UsersLayoutContext>()
+
+  useEffect(() => {
+    setPrimaryAction({ label: 'New User', onClick: () => setOpenCreateUserModal(true) })
+    return () => setPrimaryAction(undefined)
+  }, [])
   const [filters, setFilters] = useState<Filter[]>([])
   const navigate = useNavigate()
 

--- a/front/src/pages/user/layouts/users-layout.tsx
+++ b/front/src/pages/user/layouts/users-layout.tsx
@@ -1,25 +1,58 @@
+import { OverviewHeader } from '@/components/ui/overview-header'
+import { useNavigate, useParams } from 'react-router'
+import { RouterParams } from '@/routes/router'
+import { USERS_URL } from '@/routes/sub-router/user.router'
+import { CLIENTS_URL } from '@/routes/sub-router/client.router'
+import { ROLES_URL } from '@/routes/sub-router/role.router'
+import { useLocation, Outlet } from 'react-router'
 import { useState } from 'react'
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import PageHeader from '@/components/ui/page-header'
-import PageContainer from '@/components/ui/page-container'
-import { Users } from 'lucide-react'
+
+export type UsersLayoutContext = {
+  setPrimaryAction: (action: { label: string; onClick: () => void } | undefined) => void
+}
 
 export default function UsersLayout() {
-  const [tab, setTab] = useState('list')
+  const { realm_name } = useParams<RouterParams>()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [primaryAction, setPrimaryAction] = useState<{ label: string; onClick: () => void } | undefined>()
+
+  const tabs = [
+    {
+      key: 'clients',
+      label: 'Clients',
+      onClick: () => navigate(`${CLIENTS_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(CLIENTS_URL(realm_name)),
+    },
+    {
+      key: 'users',
+      label: 'Users',
+      onClick: () => navigate(`${USERS_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(USERS_URL(realm_name)),
+    },
+    {
+      key: 'roles',
+      label: 'Roles',
+      onClick: () => navigate(`${ROLES_URL(realm_name)}/overview`),
+      active: location.pathname.startsWith(ROLES_URL(realm_name)),
+    },
+    {
+      key: 'client-scopes',
+      label: 'Client Scopes',
+      onClick: () => {},
+      active: false,
+    },
+  ]
 
   return (
-    <PageContainer>
-      <PageHeader
-        icon={Users}
-        title='Users'
-        description='Manage and configure users for your realm'
-      >
-        <Tabs defaultValue={tab} onValueChange={setTab}>
-          <TabsList>
-            <TabsTrigger value={'list'}>Users list</TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </PageHeader>
-    </PageContainer>
+    <div className='flex flex-col gap-6 p-8'>
+      <OverviewHeader
+        title='Client and Access Administration'
+        description='Manage realm settings, users, and policy workflows'
+        primaryAction={primaryAction}
+        tabs={tabs}
+      />
+      <Outlet context={{ setPrimaryAction } satisfies UsersLayoutContext} />
+    </div>
   )
 }

--- a/front/src/pages/user/ui/page-users-overview.tsx
+++ b/front/src/pages/user/ui/page-users-overview.tsx
@@ -1,13 +1,14 @@
-import { DataTable } from '@/components/ui/data-table'
-import { Edit, ExternalLink, Trash2, Users, UserCheck, UserX, Activity } from 'lucide-react'
 import { Fragment } from 'react/jsx-runtime'
-import { columns } from '../columns/list-user.column'
-import CreateUserModalFeature from '../feature/create-user-modal-feature.tsx'
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction, useState, useMemo } from 'react'
 import { Schemas } from '@/api/api.client.ts'
 import { ConfirmDeleteAlert } from '@/components/confirm-delete-alert'
 import { Filter, FilterFieldsConfig } from '@/components/ui/filters'
 import StatisticsCard from '../components/statistics-card'
+import { OverviewList } from '@/components/ui/overview-list'
+import { EntityAvatar } from '@/components/ui/entity-avatar'
+import CreateUserModalFeature from '../feature/create-user-modal-feature.tsx'
+import { AlertTriangle } from 'lucide-react'
+import { isServiceAccount } from '@/utils'
 
 import User = Schemas.User
 
@@ -42,112 +43,161 @@ export interface PageUsersOverviewOverviewProps {
   onRowDelete: (user: User) => void
 }
 
+function UserStatusBadge({ enabled }: { enabled: boolean }) {
+  if (!enabled) {
+    return (
+      <span className='inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-semibold border border-orange-400/50 text-orange-500 bg-orange-50 dark:bg-orange-500/10'>
+        <AlertTriangle className='h-3 w-3' />
+        INACTIVE
+      </span>
+    )
+  }
+  return (
+    <span className='inline-flex items-center px-3 py-1 rounded-md text-xs font-semibold border border-emerald-400/50 text-emerald-600 bg-emerald-50 dark:bg-emerald-500/10'>
+      ACTIVE
+    </span>
+  )
+}
+
+function UserTypeBadge({ isSA }: { isSA: boolean }) {
+  return isSA ? (
+    <span className='inline-flex items-center px-2.5 py-0.5 rounded-md border border-purple-300 text-purple-500 text-xs font-mono bg-purple-50 dark:bg-purple-500/10 dark:border-purple-400/40'>
+      service account
+    </span>
+  ) : (
+    <span className='inline-flex items-center px-2.5 py-0.5 rounded-md border border-blue-300 text-blue-500 text-xs font-mono bg-blue-50 dark:bg-blue-500/10 dark:border-blue-400/40'>
+      user account
+    </span>
+  )
+}
+
+type TypeFilter = 'all' | 'users' | 'service_accounts'
+
+const typeFilters: { key: TypeFilter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'users', label: 'Users' },
+  { key: 'service_accounts', label: 'Service Accounts' },
+]
+
 export default function PageUsersOverview({
   isLoading,
   data,
   realmName,
   statistics,
-  filters,
-  filterFields,
-  onFiltersChange,
   confirm,
   onConfirmClose,
   handleClickRow,
-  handleDeleteSelected,
   openCreateUserModal,
   setOpenCreateUserModal,
-  onRowDelete,
 }: PageUsersOverviewOverviewProps) {
   const { totalUsers, enabledUsers, disabledUsers, verifiedUsers } = statistics
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
+
+  const filteredData = useMemo(() => {
+    if (typeFilter === 'users') return data.filter((u) => !isServiceAccount(u))
+    if (typeFilter === 'service_accounts') return data.filter((u) => isServiceAccount(u))
+    return data
+  }, [data, typeFilter])
 
   return (
     <Fragment>
       <div className='flex flex-col gap-6'>
-        {/* Statistics Cards */}
-        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
-          <StatisticsCard
-            title='Total Users'
-            value={totalUsers}
-            description='All registered users'
-            icon={Users}
-            isLoading={isLoading}
-          />
-
-          <StatisticsCard
-            title='Enabled Users'
-            value={enabledUsers}
-            description={
-              enabledUsers > 0 && totalUsers > 0 ? (
-                <span className='text-emerald-600 font-medium'>
-                  {((enabledUsers / totalUsers) * 100).toFixed(0)}% active
-                </span>
-              ) : (
-                'No enabled users'
-              )
-            }
-            icon={UserCheck}
-            isLoading={isLoading}
-          />
-
-          <StatisticsCard
-            title='Disabled Users'
-            value={disabledUsers}
-            description='Inactive accounts'
-            icon={UserX}
-            isLoading={isLoading}
-          />
-
-          <StatisticsCard
-            title='Verified Users'
-            value={verifiedUsers}
-            description='Email verified accounts'
-            icon={Activity}
-            isLoading={isLoading}
-          />
+        {/* Quick Filters */}
+        <div className='flex items-center gap-2'>
+          {typeFilters.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => setTypeFilter(f.key)}
+              className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors border ${
+                typeFilter === f.key
+                  ? 'bg-primary/10 text-primary border-primary/40'
+                  : 'bg-transparent text-foreground border-border hover:bg-muted'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
         </div>
 
-        {/* Data Table */}
-        <DataTable
-          data={data}
-          columns={columns}
+        {/* Statistics Cards */}
+        <div>
+          <p className='text-xs text-muted-foreground mb-3'>User overview</p>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            <StatisticsCard
+              title='Total users'
+              value={totalUsers}
+              description='All registered users'
+              isLoading={isLoading}
+            />
+            <StatisticsCard
+              title='Enabled users'
+              value={enabledUsers}
+              description={
+                enabledUsers > 0 && totalUsers > 0 ? (
+                  <span className='text-emerald-600 font-medium'>
+                    {((enabledUsers / totalUsers) * 100).toFixed(0)}% active
+                  </span>
+                ) : (
+                  'No enabled users'
+                )
+              }
+              isLoading={isLoading}
+            />
+            <StatisticsCard
+              title='Disabled users'
+              value={disabledUsers}
+              description='Inactive accounts'
+              isLoading={isLoading}
+            />
+            <StatisticsCard
+              title='Verified users'
+              value={verifiedUsers}
+              description='Email verified accounts'
+              isLoading={isLoading}
+            />
+          </div>
+        </div>
+
+        {/* User List */}
+        <OverviewList
+          data={filteredData}
           isLoading={isLoading}
-          searchPlaceholder='Search users by username or email...'
-          searchKeys={['username', 'email', 'id']}
-          enableSelection={true}
-          enableFilters={true}
-          filterFields={filterFields}
-          filters={filters}
-          onFiltersChange={onFiltersChange}
-          onRowClick={(user) => {
-            handleClickRow(user.id)
+          searchKeys={['username', 'email', 'firstname', 'lastname']}
+          searchPlaceholder='Search users...'
+          title={(n) => `Users (${n})`}
+          emptyLabel='No users found.'
+          renderRow={(user) => {
+            const isSA = isServiceAccount(user)
+            const displayName = isSA
+              ? 'Service Account'
+              : [user.firstname, user.lastname].filter(Boolean).join(' ') || user.username
+            return (
+              <div
+                onClick={() => handleClickRow(user.id)}
+                className='flex items-center justify-between px-8 py-4 border-b last:border-b-0 hover:bg-muted/40 cursor-pointer transition-colors'
+              >
+                <div className='flex items-center gap-4'>
+                  <EntityAvatar
+                    label={isSA ? 'S' : (user.firstname || user.username || 'U')}
+                    color={isSA ? '#8B5CF6' : '#F97316'}
+                  />
+                  <div>
+                    <div className='flex items-center gap-2.5'>
+                      <span className='text-base font-medium'>{displayName}</span>
+                      <UserTypeBadge isSA={isSA} />
+                    </div>
+                    <div className='text-sm text-muted-foreground mt-0.5'>
+                      {user.email || user.username}
+                    </div>
+                  </div>
+                </div>
+                <UserStatusBadge enabled={user.enabled ?? true} />
+              </div>
+            )
           }}
-          onDeleteSelected={handleDeleteSelected}
-          createData={{
-            label: 'Create User',
-            onClick: () => {
-              setOpenCreateUserModal(true)
-            },
-          }}
-          rowActions={[
-            {
-              label: 'Edit',
-              icon: <Edit className='h-4 w-4' />,
-              onClick: (user) => console.log('Edit', user),
-            },
-            {
-              label: 'View',
-              icon: <ExternalLink className='h-4 w-4' />,
-              onClick: (user) => console.log('View details for user:', user.id),
-            },
-            {
-              label: 'Delete',
-              icon: <Trash2 className='h-4 w-4' />,
-              variant: 'destructive',
-              onClick: (user) => onRowDelete(user),
-            },
-          ]}
         />
       </div>
+
       <CreateUserModalFeature
         realm={realmName}
         open={openCreateUserModal}


### PR DESCRIPTION
Add Google Fonts preconnect and IBM Plex Sans and set --font-sans CSS variable. Introduce OverviewHeader, OverviewList and EntityAvatar components and wire them into clients, users and roles layouts/pages. Refactor statistics cards styling, add list search/pagination and small UI fixes (icons, buttons, french pagination labels).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Upgraded typography to IBM Plex Sans font system-wide for improved readability.
  * Redesigned client, user, and role overview pages with integrated search, quick filtering, and pagination.
  * Enhanced visual status and type indicators using semantic badges with icons.
  * Unified header navigation with dynamic tabs and action buttons across overview pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->