### PR TITLE
fix: update utoipa path for client scopes endpoints

### DIFF
--- a/api/src/application/http/aegis/handlers/create_client_scope.rs
+++ b/api/src/application/http/aegis/handlers/create_client_scope.rs
@@ -19,7 +19,7 @@ use ferriskey_core::domain::authentication::value_objects::Identity;
 
 #[utoipa::path(
     post,
-    path = "",
+    path = "/client-scopes",
     summary = "Create a new client scope",
     description = "Creates a new client scope within the specified realm.",
     responses(

--- a/api/src/application/http/aegis/handlers/create_protocol_mapper.rs
+++ b/api/src/application/http/aegis/handlers/create_protocol_mapper.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 #[utoipa::path(
     post,
-    path = "/{scope_id}/protocol-mappers",
+    path = "/client-scopes/{scope_id}/protocol-mappers",
     summary = "Create a protocol mapper",
     description = "Creates a new protocol mapper for the specified client scope.",
     responses(

--- a/api/src/application/http/aegis/handlers/delete_client_scope.rs
+++ b/api/src/application/http/aegis/handlers/delete_client_scope.rs
@@ -20,7 +20,7 @@ pub struct DeleteClientScopeResponse {
 
 #[utoipa::path(
     delete,
-    path = "/{scope_id}",
+    path = "/client-scopes/{scope_id}",
     summary = "Delete a client scope",
     description = "Deletes a client scope from the specified realm. This action is irreversible.",
     params(

--- a/api/src/application/http/aegis/handlers/delete_protocol_mapper.rs
+++ b/api/src/application/http/aegis/handlers/delete_protocol_mapper.rs
@@ -20,7 +20,7 @@ pub struct DeleteProtocolMapperResponse {
 
 #[utoipa::path(
     delete,
-    path = "/{scope_id}/protocol-mappers/{mapper_id}",
+    path = "/client-scopes/{scope_id}/protocol-mappers/{mapper_id}",
     summary = "Delete a protocol mapper",
     description = "Deletes a protocol mapper from the specified client scope.",
     params(

--- a/api/src/application/http/aegis/handlers/get_client_scope.rs
+++ b/api/src/application/http/aegis/handlers/get_client_scope.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 #[utoipa::path(
     get,
-    path = "/{scope_id}",
+    path = "/client-scopes/{scope_id}",
     summary = "Get a client scope",
     description = "Retrieves a client scope from the specified realm by its ID.",
     params(

--- a/api/src/application/http/aegis/handlers/get_client_scopes.rs
+++ b/api/src/application/http/aegis/handlers/get_client_scopes.rs
@@ -20,7 +20,7 @@ pub struct ClientScopesResponse {
 
 #[utoipa::path(
     get,
-    path = "",
+    path = "/client-scopes",
     summary = "Get client scopes in a realm",
     description = "Retrieves all client scopes associated with a specific realm.",
     params(

--- a/api/src/application/http/aegis/handlers/update_client_scope.rs
+++ b/api/src/application/http/aegis/handlers/update_client_scope.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 #[utoipa::path(
     patch,
-    path = "/{scope_id}",
+    path = "/client-scopes/{scope_id}",
     summary = "Update a client scope",
     description = "Updates an existing client scope in the specified realm.",
     responses(

--- a/api/src/application/http/aegis/handlers/update_protocol_mapper.rs
+++ b/api/src/application/http/aegis/handlers/update_protocol_mapper.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 #[utoipa::path(
     patch,
-    path = "/{scope_id}/protocol-mappers/{mapper_id}",
+    path = "/client-scopes/{scope_id}/protocol-mappers/{mapper_id}",
     summary = "Update a protocol mapper",
     description = "Updates an existing protocol mapper for the specified client scope.",
     responses(

--- a/api/src/application/http/server/openapi.rs
+++ b/api/src/application/http/server/openapi.rs
@@ -23,7 +23,7 @@ use utoipa::OpenApi;
         (path = "/realms/{realm_name}", api = SeawatchApiDoc),
         (path = "/realms/{realm_name}", api = AbyssApiDoc),
         (path = "/realms/{realm_name}", api = BrokerApiDoc),
-        (path = "/realms/{realm_name}/client-scopes", api = AegisApiDoc)
+        (path = "/realms/{realm_name}", api = AegisApiDoc)
     )
 )]
 pub struct ApiDoc;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized API endpoint paths for all client scope operations with explicit route prefixes for improved clarity.
  * Updated protocol mapper endpoints to include consistent path structures aligned with the new routing scheme.
  * Reorganized API documentation and specification hierarchy to improve consistency and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->