### PR TITLE
feature: return OAuth2 error for invalid scope

### DIFF
--- a/api/src/application/http/error.rs
+++ b/api/src/application/http/error.rs
@@ -198,7 +198,10 @@ impl From<CoreError> for ApiError {
             CoreError::HintsNotFound => {
                 Self::NotFound("Account hints not found".to_string())
             }
-            CoreError::InvalidScope => Self::BadRequest("invalid_scope".to_string()),
+            CoreError::InvalidScope(description) => Self::OAuthError {
+                error: "invalid_scope".to_string(),
+                error_description: description,
+            },
             CoreError::UserDisabled => Self::Forbidden("User account is disabled".to_string()),
         }
     }

--- a/api/src/application/http/server/api_entities/api_error.rs
+++ b/api/src/application/http/server/api_entities/api_error.rs
@@ -32,6 +32,11 @@ pub enum ApiError {
     Forbidden(String),
     BadRequest(String),
     ServiceUnavailable(String),
+    /// RFC 6749 §5.2 OAuth2 error response
+    OAuthError {
+        error: String,
+        error_description: String,
+    },
 }
 
 impl ApiError {
@@ -176,6 +181,13 @@ pub struct ApiErrorResponse {
     pub message: String,
 }
 
+/// RFC 6749 §5.2 OAuth2 error response body
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+pub struct OAuth2ErrorResponse {
+    pub error: String,
+    pub error_description: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ValidationErrorResponse {
     pub errors: Vec<ValidationError>,
@@ -240,6 +252,17 @@ impl IntoResponse for ApiError {
                     code: "E_SERVICE_UNAVAILABLE".to_string(),
                     status: 503,
                     message,
+                }),
+            )
+                .into_response(),
+            ApiError::OAuthError {
+                error,
+                error_description,
+            } => (
+                StatusCode::BAD_REQUEST,
+                Json(OAuth2ErrorResponse {
+                    error,
+                    error_description,
                 }),
             )
                 .into_response(),

--- a/core/src/domain/authentication/scope.rs
+++ b/core/src/domain/authentication/scope.rs
@@ -352,4 +352,62 @@ mod tests {
         let scopes = ScopeManager::parse_scopes("openid profile email");
         assert_eq!(scopes, vec!["openid", "profile", "email"]);
     }
+
+    // --- Scope validation (RFC 6749 §3.3) ---
+
+    #[test]
+    fn test_is_standard_recognizes_all_oidc_scopes() {
+        use super::OidcScope;
+        for scope in OidcScope::all() {
+            assert!(
+                OidcScope::is_standard(scope.as_str()),
+                "Expected '{}' to be a standard scope",
+                scope.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_standard_rejects_unknown_scope() {
+        use super::OidcScope;
+        assert!(!OidcScope::is_standard("custom_scope"));
+        assert!(!OidcScope::is_standard("read:data"));
+        assert!(!OidcScope::is_standard(""));
+        assert!(!OidcScope::is_standard("PROFILE")); // case-sensitive
+    }
+
+    #[test]
+    fn test_offline_access_is_standard_scope() {
+        // offline_access is a standard OIDC scope — the client_credentials guard
+        // must be enforced explicitly in the grant handler, not here.
+        use super::OidcScope;
+        assert!(OidcScope::is_standard(super::SCOPE_OFFLINE_ACCESS));
+    }
+
+    #[test]
+    fn test_validate_and_filter_drops_unknown_scope() {
+        let manager = ScopeManager::new();
+        // Unknown scope is silently dropped by validate_and_filter (used for
+        // authorize endpoint); the token endpoint uses resolve_scopes_for_client
+        // which errors instead.
+        let result = manager.validate_and_filter(Some("profile unknown_custom_scope".to_string()));
+        assert!(result.contains("profile"));
+        assert!(!result.contains("unknown_custom_scope"));
+    }
+
+    #[test]
+    fn test_with_custom_scopes_allows_registered_custom_scope() {
+        let manager = ScopeManager::new().with_custom_scopes(vec!["my_api".to_string()]);
+        let result = manager.validate_and_filter(Some("profile my_api".to_string()));
+        assert!(result.contains("profile"));
+        assert!(result.contains("my_api"));
+    }
+
+    #[test]
+    fn test_with_custom_scopes_still_rejects_unregistered_scope() {
+        let manager = ScopeManager::new().with_custom_scopes(vec!["my_api".to_string()]);
+        let result = manager.validate_and_filter(Some("profile other_scope".to_string()));
+        assert!(result.contains("profile"));
+        assert!(!result.contains("other_scope"));
+    }
 }

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -569,7 +569,10 @@ where
                     // Already present as a default scope — no-op
                 } else {
                     // Scope is not assigned to this client
-                    return Err(CoreError::InvalidScope);
+                    return Err(CoreError::InvalidScope(format!(
+                        "Scope '{}' is not assigned to this client",
+                        scope
+                    )));
                 }
             }
         }
@@ -694,6 +697,17 @@ where
 
         if !Self::verify_client_secret(client.secret.as_deref(), params.client_secret.as_deref()) {
             return Err(CoreError::InvalidClientSecret);
+        }
+
+        if let Some(ref scope_str) = params.scope {
+            for scope in scope_str.split_whitespace() {
+                if scope == OidcScope::OfflineAccess.as_str() {
+                    return Err(CoreError::InvalidScope(
+                        "Scope 'offline_access' is not allowed for client credentials grant"
+                            .to_string(),
+                    ));
+                }
+            }
         }
 
         info!("try to fetch user client, client id: {}", client.id);

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -250,8 +250,8 @@ pub enum CoreError {
     #[error("Account hints not found")]
     HintsNotFound,
 
-    #[error("Invalid scope")]
-    InvalidScope,
+    #[error("Invalid scope: {0}")]
+    InvalidScope(String),
 
     #[error("User account is disabled")]
     UserDisabled,


### PR DESCRIPTION
Change CoreError::InvalidScope to carry a descriptive message. Add ApiError::OAuthError and OAuth2ErrorResponse JSON per RFC 6749 §5.2. Map InvalidScope to OAuthError and update services to return detailed messages.
Add scope validation tests and disallow offline_access for client_credentials grant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scope validation now returns descriptive error messages indicating which scopes are not assigned to clients
  * Client credentials grant now properly rejects offline_access scope requests

* **New Features**
  * Implemented OAuth2-compliant error response format for authentication failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->