### PR TITLE
feat: add client scope edit and delete UI

### DIFF
--- a/front/src/api/client-scope.api.ts
+++ b/front/src/api/client-scope.api.ts
@@ -125,5 +125,61 @@ export const useDeleteProtocolMapper = () => {
   })
 }
 
+export const useUpdateClientScope = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...window.tanstackApi.mutation(
+      'patch',
+      '/realms/{realm_name}/client-scopes/{scope_id}',
+      async (res) => res.json()
+    ).mutationOptions,
+    onSuccess: async (_, variables) => {
+      const { queryKey: scopeKey } = window.tanstackApi.get(
+        '/realms/{realm_name}/client-scopes/{scope_id}',
+        {
+          path: {
+            realm_name: variables.path.realm_name,
+            scope_id: variables.path.scope_id,
+          },
+        }
+      )
+      const { queryKey: listKey } = window.tanstackApi.get('/realms/{realm_name}/client-scopes', {
+        path: { realm_name: variables.path.realm_name },
+      })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: scopeKey }),
+        queryClient.invalidateQueries({ queryKey: listKey }),
+      ])
+      toast.success('Client scope updated successfully')
+    },
+    onError: (error) => {
+      toast.error('Failed to update client scope', { description: error.message })
+    },
+  })
+}
+
+export const useDeleteClientScope = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...window.tanstackApi.mutation(
+      'delete',
+      '/realms/{realm_name}/client-scopes/{scope_id}',
+      async (res) => res.json()
+    ).mutationOptions,
+    onSuccess: async (_, variables) => {
+      const { queryKey } = window.tanstackApi.get('/realms/{realm_name}/client-scopes', {
+        path: { realm_name: variables.path.realm_name },
+      })
+      await queryClient.invalidateQueries({ queryKey })
+      toast.success('Client scope deleted successfully')
+    },
+    onError: (error) => {
+      toast.error('Failed to delete client scope', { description: error.message })
+    },
+  })
+}
+
 // Re-export type for use in feature files
 export type { ProtocolMapperQuery }

--- a/front/src/pages/client-scope/feature/page-client-scope-detail-feature.tsx
+++ b/front/src/pages/client-scope/feature/page-client-scope-detail-feature.tsx
@@ -1,15 +1,84 @@
-import { useGetClientScope } from '@/api/client-scope.api'
+import { useDeleteClientScope, useGetClientScope, useUpdateClientScope } from '@/api/client-scope.api'
+import { Form } from '@/components/ui/form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
 import { RouterParams } from '@/routes/router'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import PageClientScopeDetail from '../ui/page-client-scope-detail'
+import {
+  UpdateClientScopeSchema,
+  updateClientScopeSchema,
+} from '../schemas/update-client-scope.schema'
+import { CLIENT_SCOPES_OVERVIEW_URL, CLIENT_SCOPES_URL } from '@/routes/sub-router/client-scope.router'
 
 export default function PageClientScopeDetailFeature() {
   const { realm_name, scope_id } = useParams<RouterParams>()
+  const navigate = useNavigate()
 
   const { data: scope, isLoading } = useGetClientScope({
     realm: realm_name ?? 'master',
     scopeId: scope_id,
   })
+
+  const { mutate: updateClientScope, isPending } = useUpdateClientScope()
+  const { mutate: deleteClientScope, isPending: isDeleting } = useDeleteClientScope()
+
+  const form = useForm<UpdateClientScopeSchema>({
+    resolver: zodResolver(updateClientScopeSchema),
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+      description: '',
+      scopeType: 'optional',
+    },
+  })
+
+  useEffect(() => {
+    if (scope) {
+      form.reset({
+        name: scope.name,
+        description: scope.description ?? '',
+        scopeType: scope.default_scope_type === 'DEFAULT' ? 'default' : 'optional',
+      })
+    }
+  }, [scope, form])
+
+  const handleSubmit = form.handleSubmit((values) => {
+    if (!realm_name || !scope_id) return
+
+    updateClientScope({
+      path: { realm_name, scope_id },
+      body: {
+        name: values.name,
+        description: values.description?.trim() || null,
+        protocol: scope?.protocol,
+        is_default: values.scopeType === 'default',
+      },
+    })
+  })
+
+  const handleReset = () => {
+    if (scope) {
+      form.reset({
+        name: scope.name,
+        description: scope.description ?? '',
+        scopeType: scope.default_scope_type === 'DEFAULT' ? 'default' : 'optional',
+      })
+    }
+  }
+
+  const handleDelete = () => {
+    if (!realm_name || !scope_id) return
+    deleteClientScope(
+      { path: { realm_name, scope_id } },
+      {
+        onSuccess: () => {
+          navigate(`${CLIENT_SCOPES_URL(realm_name)}${CLIENT_SCOPES_OVERVIEW_URL}`)
+        },
+      }
+    )
+  }
 
   if (!scope) {
     return (
@@ -19,5 +88,21 @@ export default function PageClientScopeDetailFeature() {
     )
   }
 
-  return <PageClientScopeDetail scope={scope} isLoading={isLoading} />
+  const formIsValid = form.formState.isValid && form.formState.isDirty && !isPending
+
+  return (
+    <Form {...form}>
+      <PageClientScopeDetail
+        scope={scope}
+        isLoading={isLoading}
+        form={form}
+        formIsValid={formIsValid}
+        isPending={isPending}
+        handleSubmit={handleSubmit}
+        handleReset={handleReset}
+        handleDelete={handleDelete}
+        isDeleting={isDeleting}
+      />
+    </Form>
+  )
 }

--- a/front/src/pages/client-scope/feature/page-client-scopes-overview-feature.tsx
+++ b/front/src/pages/client-scope/feature/page-client-scopes-overview-feature.tsx
@@ -1,4 +1,4 @@
-import { useGetClientScopes } from '@/api/client-scope.api'
+import { useDeleteClientScope, useGetClientScopes } from '@/api/client-scope.api'
 import { RouterParams } from '@/routes/router'
 import { useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router'
@@ -12,6 +12,7 @@ export default function PageClientScopesOverviewFeature() {
   const { realm_name } = useParams<RouterParams>()
   const navigate = useNavigate()
   const { data: response, isLoading } = useGetClientScopes({ realm: realm_name ?? 'master' })
+  const { mutate: deleteClientScope, isPending: isDeleting } = useDeleteClientScope()
 
   const scopes = useMemo(() => response?.data ?? [], [response])
 
@@ -28,12 +29,19 @@ export default function PageClientScopesOverviewFeature() {
     navigate(`${CLIENT_SCOPE_URL(realm_name, scopeId)}${CLIENT_SCOPE_DETAILS_URL}`)
   }
 
+  const handleDeleteScope = (scopeId: string) => {
+    if (!realm_name) return
+    deleteClientScope({ path: { realm_name, scope_id: scopeId } })
+  }
+
   return (
     <PageClientScopesOverview
       data={scopes}
       isLoading={isLoading}
       statistics={statistics}
       handleClickRow={handleClickRow}
+      handleDeleteScope={handleDeleteScope}
+      isDeleting={isDeleting}
     />
   )
 }

--- a/front/src/pages/client-scope/schemas/update-client-scope.schema.ts
+++ b/front/src/pages/client-scope/schemas/update-client-scope.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const updateClientScopeSchema = z.object({
+  name: z.string().min(1, { message: 'The client scope name is required' }),
+  description: z.string().optional(),
+  scopeType: z.enum(['optional', 'default']),
+})
+
+export type UpdateClientScopeSchema = z.infer<typeof updateClientScopeSchema>

--- a/front/src/pages/client-scope/ui/page-client-scope-detail.tsx
+++ b/front/src/pages/client-scope/ui/page-client-scope-detail.tsx
@@ -1,32 +1,54 @@
 import { Schemas } from '@/api/api.client'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { FormControl, FormField, FormItem } from '@/components/ui/form'
+import { InputText } from '@/components/ui/input-text'
+import FloatingActionBar from '@/components/ui/floating-action-bar'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { UseFormReturn } from 'react-hook-form'
+import { UpdateClientScopeSchema } from '../schemas/update-client-scope.schema'
 
 import ClientScope = Schemas.ClientScope
 
 interface PageClientScopeDetailProps {
   scope: ClientScope
   isLoading?: boolean
+  form: UseFormReturn<UpdateClientScopeSchema>
+  formIsValid: boolean
+  isPending: boolean
+  handleSubmit: () => void
+  handleReset: () => void
+  handleDelete: () => void
+  isDeleting?: boolean
 }
 
-function ValueRow({
-  label,
-  value,
-}: {
-  label: string
-  value: string
-}) {
-  return (
-    <div className='flex items-start justify-between py-4 border-t'>
-      <div className='w-1/3'>
-        <p className='text-sm font-medium'>{label}</p>
-      </div>
-      <div className='w-1/2'>
-        <p className='text-sm text-foreground break-words'>{value}</p>
-      </div>
-    </div>
-  )
-}
-
-export default function PageClientScopeDetail({ scope, isLoading }: PageClientScopeDetailProps) {
+export default function PageClientScopeDetail({
+  scope,
+  isLoading,
+  form,
+  formIsValid,
+  isPending,
+  handleSubmit,
+  handleReset,
+  handleDelete,
+  isDeleting,
+}: PageClientScopeDetailProps) {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   if (isLoading) {
     return <div className='text-sm text-muted-foreground'>Loading...</div>
   }
@@ -38,12 +60,94 @@ export default function PageClientScopeDetail({ scope, isLoading }: PageClientSc
           <p className='text-xs text-muted-foreground mb-0.5'>Client scope details</p>
           <h2 className='text-base font-semibold'>General Information</h2>
         </div>
-        <ValueRow label='Name' value={scope.name} />
-        <ValueRow label='Description' value={scope.description || '-'} />
-        <ValueRow label='Protocol' value={scope.protocol} />
-        <ValueRow label='Type' value={scope.default_scope_type === 'DEFAULT' ? 'Default' : scope.default_scope_type === 'OPTIONAL' ? 'Optional' : 'None'} />
-        <ValueRow label='Created At' value={new Date(scope.created_at).toLocaleString()} />
-        <ValueRow label='Updated At' value={new Date(scope.updated_at).toLocaleString()} />
+
+        <FormField
+          control={form.control}
+          name='name'
+          render={({ field }) => (
+            <div className='flex items-start justify-between py-4 border-t'>
+              <div className='w-1/3'>
+                <p className='text-sm font-medium'>Name</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>Unique name for this client scope.</p>
+              </div>
+              <div className='w-1/2'>
+                <InputText label='Name' {...field} error={form.formState.errors.name?.message} />
+              </div>
+            </div>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='description'
+          render={({ field }) => (
+            <div className='flex items-start justify-between py-4 border-t'>
+              <div className='w-1/3'>
+                <p className='text-sm font-medium'>Description</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>Optional description for this client scope.</p>
+              </div>
+              <div className='w-1/2'>
+                <InputText label='Description' {...field} />
+              </div>
+            </div>
+          )}
+        />
+
+        <div className='flex items-start justify-between py-4 border-t'>
+          <div className='w-1/3'>
+            <p className='text-sm font-medium'>Protocol</p>
+            <p className='text-sm text-muted-foreground mt-0.5'>Only OpenID Connect is currently supported.</p>
+          </div>
+          <div className='w-1/2'>
+            <InputText label='Protocol' name='protocol' value={scope.protocol} disabled />
+          </div>
+        </div>
+
+        <FormField
+          control={form.control}
+          name='scopeType'
+          render={({ field }) => (
+            <div className='flex items-start justify-between py-4 border-t'>
+              <div className='w-1/3'>
+                <p className='text-sm font-medium'>Type</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>Define how this scope is assigned to clients.</p>
+              </div>
+              <div className='w-1/2'>
+                <FormItem>
+                  <FormControl>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select type' />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value='optional'>Optional</SelectItem>
+                        <SelectItem value='default'>Default</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                </FormItem>
+              </div>
+            </div>
+          )}
+        />
+
+        <div className='flex items-start justify-between py-4 border-t'>
+          <div className='w-1/3'>
+            <p className='text-sm font-medium'>Created At</p>
+          </div>
+          <div className='w-1/2'>
+            <p className='text-sm text-foreground'>{new Date(scope.created_at).toLocaleString()}</p>
+          </div>
+        </div>
+
+        <div className='flex items-start justify-between py-4 border-t'>
+          <div className='w-1/3'>
+            <p className='text-sm font-medium'>Updated At</p>
+          </div>
+          <div className='w-1/2'>
+            <p className='text-sm text-foreground'>{new Date(scope.updated_at).toLocaleString()}</p>
+          </div>
+        </div>
       </div>
 
       <div className='flex flex-col gap-1'>
@@ -88,6 +192,70 @@ export default function PageClientScopeDetail({ scope, isLoading }: PageClientSc
           ))
         )}
       </div>
+
+      {/* Danger Zone */}
+      <div className='rounded-lg border border-destructive/40 bg-destructive/5'>
+        <div className='px-6 py-4 border-b border-destructive/40'>
+          <p className='text-xs text-destructive/70 mb-0.5 font-medium uppercase tracking-wide'>Danger Zone</p>
+          <h2 className='text-base font-semibold text-destructive'>Delete Client Scope</h2>
+        </div>
+        <div className='px-6 py-4 flex items-center justify-between gap-4'>
+          <div>
+            <p className='text-sm font-medium'>Delete this client scope</p>
+            <p className='text-sm text-muted-foreground mt-0.5'>
+              Once deleted, all associated protocol mappers and client mappings will be permanently removed. This action cannot be undone.
+            </p>
+          </div>
+          <Button
+            variant='destructive'
+            size='sm'
+            onClick={() => setDeleteDialogOpen(true)}
+            className='shrink-0 flex items-center gap-1.5'
+          >
+            <Trash2 className='h-3.5 w-3.5' />
+            Delete scope
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Client Scope</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <p className='text-sm text-muted-foreground'>
+              Are you sure you want to delete{' '}
+              <span className='font-semibold text-foreground'>{scope.name}</span>? This action is
+              irreversible and will remove all associated protocol mappers and client mappings.
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant='outline' onClick={() => setDeleteDialogOpen(false)} disabled={isDeleting}>
+              Cancel
+            </Button>
+            <Button
+              variant='destructive'
+              onClick={() => {
+                handleDelete()
+                setDeleteDialogOpen(false)
+              }}
+              disabled={isDeleting}
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <FloatingActionBar
+        show={formIsValid}
+        title='Unsaved Changes'
+        description='You have unsaved changes to this client scope.'
+        onCancel={handleReset}
+        cancelLabel='Discard'
+        actions={[{ label: isPending ? 'Saving...' : 'Save Changes', onClick: handleSubmit }]}
+      />
     </div>
   )
 }

--- a/front/src/pages/client-scope/ui/page-client-scopes-overview.tsx
+++ b/front/src/pages/client-scope/ui/page-client-scopes-overview.tsx
@@ -5,6 +5,16 @@ import StatisticsCard from '../components/statistics-card'
 
 import ClientScope = Schemas.ClientScope
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Trash2 } from 'lucide-react'
+import { useState } from 'react'
 
 interface Statistics {
   totalScopes: number
@@ -18,6 +28,8 @@ export interface PageClientScopesOverviewProps {
   data: ClientScope[]
   statistics: Statistics
   handleClickRow: (scopeId: string) => void
+  handleDeleteScope: (scopeId: string) => void
+  isDeleting?: boolean
 }
 
 function ScopeTypeBadge({ scopeType }: { scopeType: string }) {
@@ -45,8 +57,17 @@ export default function PageClientScopesOverview({
   isLoading,
   statistics,
   handleClickRow,
+  handleDeleteScope,
+  isDeleting,
 }: PageClientScopesOverviewProps) {
   const { totalScopes, defaultScopes, optionalScopes, withProtocolMappers } = statistics
+  const [pendingDelete, setPendingDelete] = useState<ClientScope | null>(null)
+
+  const handleConfirmDelete = () => {
+    if (!pendingDelete) return
+    handleDeleteScope(pendingDelete.id)
+    setPendingDelete(null)
+  }
 
   return (
     <div className='flex flex-col gap-6'>
@@ -88,28 +109,68 @@ export default function PageClientScopesOverview({
         title={(n) => `Client Scopes (${n})`}
         emptyLabel='No client scopes found.'
         renderRow={(scope) => (
-          <Button
-            type='button'
-            variant='ghost'
-            onClick={() => handleClickRow(scope.id)}
-            className='flex items-center justify-between px-8 py-4 hover:bg-muted/40 transition-colors cursor-pointer w-full h-full'
-          >
-            <div className='flex items-center gap-4'>
-              <EntityAvatar label={scope.name} color='#0EA5E9' />
-              <div>
-                <div className='flex items-center gap-2.5'>
-                  <span className='text-base font-medium'>{scope.name}</span>
-                  <ScopeTypeBadge scopeType={scope.default_scope_type} />
-                </div>
-                <div className='text-sm text-muted-foreground mt-0.5'>
-                  {scope.description || `scope_id: ${scope.id}`}
+          <div className='flex items-center w-full'>
+            <Button
+              type='button'
+              variant='ghost'
+              onClick={() => handleClickRow(scope.id)}
+              className='flex items-center justify-between px-8 py-4 hover:bg-muted/40 transition-colors cursor-pointer flex-1 h-full'
+            >
+              <div className='flex items-center gap-4'>
+                <EntityAvatar label={scope.name} color='#0EA5E9' />
+                <div>
+                  <div className='flex items-center gap-2.5'>
+                    <span className='text-base font-medium'>{scope.name}</span>
+                    <ScopeTypeBadge scopeType={scope.default_scope_type} />
+                  </div>
+                  <div className='text-sm text-muted-foreground mt-0.5'>
+                    {scope.description || `scope_id: ${scope.id}`}
+                  </div>
                 </div>
               </div>
+              <ProtocolBadge protocol={scope.protocol} />
+            </Button>
+            <div className='pr-4'>
+              <Button
+                type='button'
+                variant='ghost'
+                size='sm'
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setPendingDelete(scope)
+                }}
+                className='text-muted-foreground hover:text-destructive hover:bg-destructive/10'
+              >
+                <Trash2 className='h-4 w-4' />
+              </Button>
             </div>
-            <ProtocolBadge protocol={scope.protocol} />
-          </Button>
+          </div>
         )}
       />
+
+      <Dialog open={!!pendingDelete} onOpenChange={(open) => !open && setPendingDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Client Scope</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <p className='text-sm text-muted-foreground'>
+              Are you sure you want to delete{' '}
+              <span className='font-semibold text-foreground'>{pendingDelete?.name}</span>? This
+              action is irreversible and will remove all associated protocol mappers and client
+              mappings.
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant='outline' onClick={() => setPendingDelete(null)} disabled={isDeleting}>
+              Cancel
+            </Button>
+            <Button variant='destructive' onClick={handleConfirmDelete} disabled={isDeleting}>
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
Implement update and delete mutations/hooks (useUpdateClientScope, useDeleteClientScope), add zod form schema and react-hook-form integration for client scope detail, confirmation dialogs for deletion, FloatingActionBar for unsaved changes, and enable deleting scopes from the overview. Invalidate related queries and show toast notifications on success/error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full editing capability for client scope details including name, description, and scope type selection.
  * Delete client scopes with built-in confirmation workflow to prevent accidental removal.
  * Unsaved changes indicator to track and manage pending modifications before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->