### PR TITLE
feat(front): add realm role creation flow

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -5,17 +5,23 @@ This project uses `typed-openapi` to automatically generate TypeScript types and
 
 ### Prerequisites
 
-Make sure you habe the OpenAPI specification file available (you can go to address API with `/swagger-ui` and downlaod the OpenAPI Document).
+Generate a fresh OpenAPI spec from the backend first:
+
+```bash
+cd ../api
+cargo run --bin ferriskey-api -- gen-api --output ../openapi.json
+cd ../front
+```
 
 ### Generating API Client and Types
 To generate the API client and TanStack Query hooks, run:
 
 ```bash
-pnpm typed-openapi openapi.yaml -o src/api/api.client.ts --tanstack=api.tanstack.ts
+pnpm typed-openapi ../openapi.json -o src/api/api.client.ts --tanstack=api.tanstack.ts
 ```
 
 **Command Breakdown:**
-- `openapi.yaml`: Path to your OpenAPI specification file
+- `../openapi.json`: Path to the generated OpenAPI specification file
 - `-o src/api/api.client.ts`: Output path for the generated TypeScript types and schemas
 - `--tanstack=api.tanstack.ts`: Generates TanStack Query hooks in the specified file
 

--- a/front/openapi.yaml
+++ b/front/openapi.yaml
@@ -629,7 +629,7 @@ paths:
       description: Creates a new role for a specific client within a realm. This
         endpoint allows you to define roles that can be assigned to users or
         groups in the context of a client application.
-      operationId: create_role
+      operationId: create_client_role
       parameters:
         - name: realm_name
           in: path
@@ -1097,6 +1097,50 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetRolesResponse"
+    post:
+      tags:
+        - role
+      summary: Create a new realm role
+      description: Creates a new realm-scoped role in the specified realm.
+      operationId: create_realm_role
+      parameters:
+        - name: realm_name
+          in: path
+          description: Realm name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRoleValidator"
+        required: true
+      responses:
+        "201":
+          description: Realm role created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateRoleResponse"
+        "400":
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        "403":
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
   /realms/{realm_name}/roles/{role_id}:
     get:
       tags:
@@ -1981,6 +2025,13 @@ components:
           type: array
           items:
             type: string
+    CreateRoleResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          $ref: "#/components/schemas/Role"
     CreateUserResponse:
       type: object
       required:

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -127,6 +127,7 @@ export namespace Schemas {
     name: string
     permissions: Array<string>
   }
+  export type CreateRoleResponse = { data: Role }
   export type RealmSetting = {
     default_signing_algorithm?: (string | null) | undefined
     forgot_password_enabled: boolean
@@ -987,7 +988,7 @@ export namespace Endpoints {
     }
     response: Schemas.GetClientRolesResponse
   }
-  export type post_Create_role = {
+  export type post_Create_client_role = {
     method: 'POST'
     path: '/realms/{realm_name}/clients/{client_id}/roles'
     requestFormat: 'json'
@@ -1373,6 +1374,17 @@ export namespace Endpoints {
     }
     response: Schemas.GetRolesResponse
   }
+  export type post_Create_realm_role = {
+    method: 'POST'
+    path: '/realms/{realm_name}/roles'
+    requestFormat: 'json'
+    parameters: {
+      path: { realm_name: string }
+
+      body: Schemas.CreateRoleValidator
+    }
+    response: Schemas.CreateRoleResponse
+  }
   export type get_Get_role = {
     method: 'GET'
     path: '/realms/{realm_name}/roles/{role_id}'
@@ -1645,7 +1657,7 @@ export type EndpointByMethod = {
     '/realms/{realm_name}/clients': Endpoints.post_Create_client
     '/realms/{realm_name}/clients/{client_id}/post-logout-redirects': Endpoints.post_Create_post_logout_redirect_uri
     '/realms/{realm_name}/clients/{client_id}/redirects': Endpoints.post_Create_redirect_uri
-    '/realms/{realm_name}/clients/{client_id}/roles': Endpoints.post_Create_role
+    '/realms/{realm_name}/clients/{client_id}/roles': Endpoints.post_Create_client_role
     '/realms/{realm_name}/federation/providers': Endpoints.post_Create_provider
     '/realms/{realm_name}/federation/providers/{id}/sync-users': Endpoints.post_Sync_users
     '/realms/{realm_name}/federation/providers/{id}/test-connection': Endpoints.post_Test_connection
@@ -1666,6 +1678,7 @@ export type EndpointByMethod = {
     '/realms/{realm_name}/protocol/openid-connect/revoke': Endpoints.post_Revoke_token
     '/realms/{realm_name}/protocol/openid-connect/token': Endpoints.post_Exchange_token
     '/realms/{realm_name}/protocol/openid-connect/token/introspect': Endpoints.post_Introspect_token
+    '/realms/{realm_name}/roles': Endpoints.post_Create_realm_role
     '/realms/{realm_name}/users': Endpoints.post_Create_user
     '/realms/{realm_name}/users/{user_id}/roles/{role_id}': Endpoints.post_Assign_role
     '/realms/{realm_name}/webhooks': Endpoints.post_Create_webhook

--- a/front/src/api/role.api.ts
+++ b/front/src/api/role.api.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { BaseQuery } from '.'
+import type { Schemas } from './api.client'
+
+type CreateRoleMutationResponse = {
+  data: Schemas.Role
+}
 
 export const useGetRoles = ({ realm = 'master' }: BaseQuery) => {
   return useQuery(
@@ -27,17 +32,67 @@ export const useGetRole = ({ realm, roleId }: BaseQuery & { roleId?: string }) =
 
 export const useCreateRole = () => {
   const queryClient = useQueryClient()
+  const createRealmRole = window.tanstackApi.mutation(
+    'post',
+    '/realms/{realm_name}/roles',
+    async (res): Promise<CreateRoleMutationResponse> => res.json()
+  )
+  const createClientRole = window.tanstackApi.mutation(
+    'post',
+    '/realms/{realm_name}/clients/{client_id}/roles',
+    async (res): Promise<CreateRoleMutationResponse> => {
+      const role = await res.json()
+
+      return { data: role }
+    }
+  )
 
   return useMutation({
-    ...window.tanstackApi.mutation(
-      'post',
-      '/realms/{realm_name}/clients/{client_id}/roles',
-      async (res) => {
-        return res.json()
+    mutationFn: async ({
+      realmName,
+      clientId,
+      body,
+    }: {
+      realmName: string
+      clientId?: string
+      body: Schemas.CreateRoleValidator
+    }) => {
+      if (clientId) {
+        return createClientRole.mutationOptions.mutationFn({
+          path: {
+            realm_name: realmName,
+            client_id: clientId,
+          },
+          body,
+        })
       }
-    ).mutationOptions,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['roles'] })
+
+      return createRealmRole.mutationOptions.mutationFn({
+        path: {
+          realm_name: realmName,
+        },
+        body,
+      })
+    },
+    onSuccess: async (_, variables) => {
+      const { queryKey } = window.tanstackApi.get('/realms/{realm_name}/roles', {
+        path: {
+          realm_name: variables.realmName,
+        },
+      })
+      await queryClient.invalidateQueries({ queryKey })
+
+      if (variables.clientId) {
+        const clientRolesQuery = window.tanstackApi.get('/realms/{realm_name}/clients/{client_id}/roles', {
+          path: {
+            realm_name: variables.realmName,
+            client_id: variables.clientId,
+          },
+        })
+
+        await queryClient.invalidateQueries({ queryKey: clientRolesQuery.queryKey })
+      }
+
       toast.success('Role created successfully')
     },
     onError(error) {

--- a/front/src/pages/role/feature/page-create-role-feature.tsx
+++ b/front/src/pages/role/feature/page-create-role-feature.tsx
@@ -3,7 +3,7 @@ import { useGetClients } from '@/api/client.api'
 import { useCreateRole } from '@/api/role.api'
 import { RouterParams } from '@/routes/router'
 import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { useNavigate, useParams } from 'react-router'
 import { createRoleSchema, CreateRoleSchema } from '../schemas/create-role.schema'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -16,7 +16,7 @@ export default function PageCreateRoleFeature() {
   const { realm_name } = useParams<RouterParams>()
   const navigate = useNavigate()
 
-  const { mutate: createRole, data } = useCreateRole()
+  const { mutate: createRole, isSuccess } = useCreateRole()
   const { data: clientsResponse } = useGetClients({ realm: realm_name || '' })
 
   const [selectedPermissions, setSelectedPermissions] = useState<Permissions[]>([])
@@ -32,7 +32,8 @@ export default function PageCreateRoleFeature() {
     mode: 'onChange',
     defaultValues: {
       name: '',
-      clientId: '',
+      scope: 'realm',
+      clientId: undefined,
       description: '',
       permissions: [],
     },
@@ -47,15 +48,18 @@ export default function PageCreateRoleFeature() {
       return
     }
 
+    if (values.scope === 'client' && !values.clientId) {
+      toast.error('Please select a client for a client role')
+      return
+    }
+
     createRole({
+      realmName: realm_name,
+      clientId: values.scope === 'client' ? values.clientId : undefined,
       body: {
         name: values.name,
         permissions: values.permissions,
         description: values.description,
-      },
-      path: {
-        client_id: values.clientId,
-        realm_name: realm_name,
       },
     })
   }
@@ -88,11 +92,22 @@ export default function PageCreateRoleFeature() {
     form.setValue('permissions', li)
   }, [selectedPermissions, form])
 
+  const roleScope = useWatch({
+    control: form.control,
+    name: 'scope',
+  }) ?? 'realm'
+
   useEffect(() => {
-    if (data) {
+    if (roleScope === 'realm') {
+      form.setValue('clientId', undefined, { shouldValidate: true, shouldDirty: true })
+    }
+  }, [form, roleScope])
+
+  useEffect(() => {
+    if (isSuccess) {
       navigate(`${ROLES_URL(realm_name)}${ROLE_OVERVIEW_URL}`)
     }
-  }, [data, navigate, realm_name])
+  }, [isSuccess, navigate, realm_name])
 
   return (
     <Form {...form}>
@@ -103,6 +118,7 @@ export default function PageCreateRoleFeature() {
         handleSubmit={handleSubmit}
         handlePermissionToggle={handlePermissionToggle}
         handleSelectAllInGroup={handleSelectAllInGroup}
+        roleScope={roleScope}
         selectedPermissions={selectedPermissions}
       />
     </Form>

--- a/front/src/pages/role/schemas/create-role.schema.ts
+++ b/front/src/pages/role/schemas/create-role.schema.ts
@@ -1,10 +1,21 @@
 import { z } from 'zod'
 
-export const createRoleSchema = z.object({
-  name: z.string().min(1, { message: 'Role name is required' }),
-  clientId: z.string().min(1, { message: 'Client ID is required' }),
-  description: z.string().optional(),
-  permissions: z.array(z.string()),
-})
+export const createRoleSchema = z
+  .object({
+    name: z.string().min(1, { message: 'Role name is required' }),
+    scope: z.enum(['realm', 'client']),
+    clientId: z.string().optional(),
+    description: z.string().optional(),
+    permissions: z.array(z.string()),
+  })
+  .superRefine((value, ctx) => {
+    if (value.scope === 'client' && (!value.clientId || value.clientId.trim().length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['clientId'],
+        message: 'Client ID is required for client roles',
+      })
+    }
+  })
 
 export type CreateRoleSchema = z.infer<typeof createRoleSchema>

--- a/front/src/pages/role/ui/page-create-role.tsx
+++ b/front/src/pages/role/ui/page-create-role.tsx
@@ -12,6 +12,7 @@ import { BadgeColorScheme } from '@/components/ui/badge-color.enum'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { Checkbox } from '@/components/ui/checkbox'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import SelectClientBox from './components/select-client-box'
 import { permissionGroups } from '@/pages/role/types/permission-groups.ts'
 import { Schemas } from '@/api/api.client.ts'
@@ -22,6 +23,7 @@ export interface PageCreateRoleProps {
   handleSubmit: () => void
   handleBack: () => void
   clients: Client[]
+  roleScope: 'realm' | 'client'
   selectedPermissions: Permissions[]
   handleSelectAllInGroup: (groupPermissions: Permissions[]) => void
   handlePermissionToggle: (permission: Permissions) => void
@@ -32,6 +34,7 @@ export default function PageCreateRole({
   handleSubmit,
   handleBack,
   clients,
+  roleScope,
   selectedPermissions,
   handleSelectAllInGroup,
   handlePermissionToggle,
@@ -99,19 +102,59 @@ export default function PageCreateRole({
         {/* Client */}
         <FormField
           control={form.control}
-          name='clientId'
+          name='scope'
           render={({ field }) => (
             <div className='flex items-start justify-between px-8 py-4 border-t'>
               <div className='w-1/3'>
-                <p className='text-sm font-medium'>Client</p>
-                <p className='text-sm text-muted-foreground mt-0.5'>Associate this role with a specific client.</p>
+                <p className='text-sm font-medium'>Role Scope</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>
+                  Choose whether this role is shared across the realm or attached to a specific client.
+                </p>
               </div>
               <div className='w-1/2'>
-                <SelectClientBox clients={clients} onValueChange={field.onChange} />
+                <RadioGroup
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  className='flex gap-6 pt-3'
+                >
+                  <div className='flex items-center space-x-2'>
+                    <RadioGroupItem value='realm' id='role-scope-realm' />
+                    <Label htmlFor='role-scope-realm'>Realm role</Label>
+                  </div>
+                  <div className='flex items-center space-x-2'>
+                    <RadioGroupItem value='client' id='role-scope-client' />
+                    <Label htmlFor='role-scope-client'>Client role</Label>
+                  </div>
+                </RadioGroup>
               </div>
             </div>
           )}
         />
+
+        {roleScope === 'client' && (
+          <FormField
+            control={form.control}
+            name='clientId'
+            render={({ field }) => (
+              <div className='flex items-start justify-between px-8 py-4 border-t'>
+                <div className='w-1/3'>
+                  <p className='text-sm font-medium'>Client</p>
+                  <p className='text-sm text-muted-foreground mt-0.5'>
+                    Associate this role with a specific client.
+                  </p>
+                </div>
+                <div className='w-1/2'>
+                  <SelectClientBox clients={clients} onValueChange={field.onChange} />
+                  {form.formState.errors.clientId?.message && (
+                    <p className='mt-2 text-sm text-red-500'>
+                      {form.formState.errors.clientId.message}
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+          />
+        )}
 
         {/* Permissions */}
         <div className='flex items-start justify-between px-8 py-4 border-t'>


### PR DESCRIPTION
## Summary
Adds the frontend flow for creating realm-scoped roles.

## Problem
The UI only supported client role creation, so realm role creation was incomplete from the console.

## Changes
- add a role scope selector for realm role vs client role
- require client selection only for client-scoped roles
- switch the role creation flow to the generated TanStack client
- normalize the create-role mutation result shape
- update the generated OpenAPI frontend client and frontend README

## Benefit
This completes the user-facing half of realm role creation and keeps the frontend aligned with the generated TanStack/OpenAPI client pattern.

## Dependency
Depends on: https://github.com/ferriskey/ferriskey/pull/806

## Validation
-  ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE  No package found in this workspace
-  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/var/tmp/vibe-kanban/worktrees/2317-office-review-br/ferriskey".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced role scope selector allowing users to create both realm-level and client-level roles
  * When creating client-scoped roles, users must select the target client application
  * Realm-level roles can now be created independently of clients

* **Documentation**
  * Updated setup guide for API client generation to use backend-generated OpenAPI specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->