### PR TITLE
chore: group realm role follow-up tooling changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ src/
 - **Server state:** React Query (TanStack Query)
 - **Client state:** Zustand (auth, realm context)
 - **Forms:** react-hook-form + Zod validation
+- **Frontend API calls:** Prefer the generated `createApiClient` / `window.tanstackApi` client and TanStack Query hooks or mutations over direct `axios` calls. Use `axios` only when a flow cannot be expressed through the generated client.
 
 ## Database & Migrations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "ferriskey-domain",
+ "mockall 0.14.0",
  "serde",
  "tokio",
  "tracing",

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -163,6 +163,7 @@ src/
 - **Server state:** React Query (TanStack Query)
 - **Client state:** Zustand (auth, realm context)
 - **Forms:** react-hook-form + Zod validation
+- **Frontend API calls:** Prefer the generated `createApiClient` / `window.tanstackApi` client and TanStack Query hooks or mutations over direct `axios` calls. Use `axios` only when a flow cannot be expressed through the generated client.
 
 ## Database & Migrations
 

--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 #        just dev
 #   3) Run frontend dev server (Node/pnpm):
 #        just web
+#        just dev-web (local)
 #
 # Notes:
 # - Some recipes may prompt to install missing tools (Docker, Node, pnpm, etc).
@@ -212,6 +213,10 @@ dev-test-down: _ensure-docker-running
 dev-test-rm: _ensure-docker-running
   @# Tear down docker compose build profile containers and volumes and remove images.
   @{{compose}} --profile build down -v --rmi local
+
+# Run frontend dev server locally (Node/pnpm)
+dev-web: _ensure-pnpm
+  @cd front && pnpm install && pnpm run dev
 
 web: _ensure-pnpm
   @# Run the frontend server inside container.

--- a/libs/ferriskey-compass/Cargo.toml
+++ b/libs/ferriskey-compass/Cargo.toml
@@ -12,3 +12,6 @@ tokio = { version = "1", features = ["sync"] }
 tracing = "0.1.44"
 utoipa = { version = "5.4.0", features = ["uuid", "chrono"] }
 uuid = { version = "1.21.0", features = ["serde"] }
+
+[dev-dependencies]
+mockall = "0.14.0"


### PR DESCRIPTION
## Summary
Groups the remaining follow-up changes that are not part of the main backend/frontend feature split.

## Changes
- add `just dev-web` for local frontend development
- add `mockall` as a dev dependency for `ferriskey-compass`
- document the generated TanStack frontend client preference in agent guidance files

## Benefit
This keeps the main realm-role PRs focused while preserving the related tooling and documentation cleanups in a separate review.

## Validation
- `cargo check -p ferriskey-compass --tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated frontend development guidelines to recommend the generated API client and TanStack Query hooks for API interactions.

* **Chores**
  * Added local development server tooling for frontend development.
  * Enhanced container management setup for the development environment.
  * Added testing dependencies to support quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->