### PR TITLE
feat: include ID token fields and refresh metadata

### DIFF
--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine as _};
 use chrono::{TimeZone, Utc};
 use ferriskey_security::jwt::ports::KeyStoreRepository;
 use jsonwebtoken::{Header, Validation};
@@ -366,6 +367,13 @@ where
                     .apply_mappers(&all_mappers, &context, TokenType::IdToken)?;
 
             let aud = claims.azp.clone();
+
+            // at_hash = base64url(left-half of SHA-256(access_token))
+            let at_hash = {
+                let digest = Sha256::digest(jwt.token.as_bytes());
+                Some(BASE64_URL_SAFE_NO_PAD.encode(&digest[..digest.len() / 2]))
+            };
+
             // Identity claims (preferred_username, email, email_verified) are injected
             // into `additional_claims` by the protocol mappers attached to the `profile`
             // and `email` scopes.  The dedicated struct fields are intentionally left as
@@ -379,8 +387,12 @@ where
                 email_verified: None,
                 exp,
                 iat,
+                jti: Uuid::new_v4(),
+                sid: None,
+                at_hash,
                 preferred_username: None,
                 sub: claims.sub,
+                typ: ClaimsTyp::Id,
                 additional_claims: id_mapper_output.claims,
             };
             let t = Self::encode_token_with_key(&id_claims, id_claims.exp, &jwt_key_pair)?;
@@ -684,6 +696,8 @@ where
             "Bearer".to_string(),
             refresh_token.token,
             Self::expires_in_from(jwt.expires_at),
+            Self::expires_in_from(refresh_token.expires_at),
+            None,
             id_token_value,
         ))
     }
@@ -749,6 +763,8 @@ where
             "Bearer".to_string(),
             refresh_token.token,
             Self::expires_in_from(jwt.expires_at),
+            Self::expires_in_from(refresh_token.expires_at),
+            None,
             id_token_value,
         ))
     }
@@ -841,6 +857,8 @@ where
             "Bearer".to_string(),
             refresh_token.token,
             Self::expires_in_from(jwt.expires_at),
+            Self::expires_in_from(refresh_token.expires_at),
+            None,
             id_token_value,
         ))
     }
@@ -906,6 +924,8 @@ where
             "Bearer".to_string(),
             refresh_token.token,
             Self::expires_in_from(jwt.expires_at),
+            Self::expires_in_from(refresh_token.expires_at),
+            None,
             id_token_value,
         ))
     }
@@ -1347,6 +1367,7 @@ This is a server error that should be investigated. Do not forward back this mes
                 ClaimsTyp::Bearer => "Bearer".to_string(),
                 ClaimsTyp::Refresh => "Refresh".to_string(),
                 ClaimsTyp::Temporary => "Temporary".to_string(),
+                ClaimsTyp::Id => "ID".to_string(),
             }),
             exp: claims.exp,
             iat: Some(claims.iat),
@@ -1804,6 +1825,8 @@ where
             "Bearer".to_string(),
             refresh_token.token,
             Self::expires_in_from(jwt.expires_at),
+            Self::expires_in_from(refresh_token.expires_at),
+            None,
             None,
         ))
     }
@@ -1974,6 +1997,7 @@ where
                     .map_err(|_| CoreError::InternalServerError)?;
             }
             ClaimsTyp::Temporary => {}
+            ClaimsTyp::Id => {}
         }
 
         Ok(())

--- a/libs/ferriskey-domain/src/authentication/entities.rs
+++ b/libs/ferriskey-domain/src/authentication/entities.rs
@@ -8,6 +8,9 @@ pub struct JwtToken {
     token_type: String,
     refresh_token: String,
     expires_in: u32,
+    refresh_expires_in: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     id_token: Option<String>,
 }
@@ -18,6 +21,8 @@ impl JwtToken {
         token_type: String,
         refresh_token: String,
         expires_in: u32,
+        refresh_expires_in: u32,
+        session_state: Option<String>,
         id_token: Option<String>,
     ) -> Self {
         Self {
@@ -25,6 +30,8 @@ impl JwtToken {
             token_type,
             refresh_token,
             expires_in,
+            refresh_expires_in,
+            session_state,
             id_token,
         }
     }

--- a/libs/ferriskey-security/src/jwt/entities.rs
+++ b/libs/ferriskey-security/src/jwt/entities.rs
@@ -18,6 +18,8 @@ pub enum ClaimsTyp {
     Refresh,
     Bearer,
     Temporary,
+    #[serde(rename = "ID")]
+    Id,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -38,6 +40,7 @@ pub struct JwtClaim {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_id: Option<String>,
 
     /// Dynamic claims injected by protocol mappers.
@@ -55,11 +58,19 @@ pub struct IdTokenClaims {
     pub iss: String,
     pub sub: Uuid,
     pub aud: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub azp: Option<String>,
     pub exp: i64,
     pub iat: i64,
+    pub jti: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub at_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_time: Option<i64>,
+    pub typ: ClaimsTyp,
 
     // Identity claims — absent when the respective scope is not active
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Add at_hash calculation (left-half SHA256 base64url) to ID tokens. Populate jti and optional sid and typ claims in IdTokenClaims. Expose refresh_expires_in and optional session_state in JwtToken and propagate refresh token expiry into token responses. Add ClaimsTyp::Id variant and adjust serde attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ID token generation with additional security and session management fields, improving OpenID Connect compliance.
  * Added session state tracking and extended refresh token expiration information to token responses.

* **Improvements**
  * Strengthened authentication token handling with additional standard claim fields for improved security and interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->