### PR TITLE
feat: implement authentication callback handling and refresh token logic

### DIFF
--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -38,6 +38,7 @@ use crate::domain::{
     credential::{entities::CredentialData, ports::CredentialRepository},
     crypto::HasherRepository,
     jwt::{
+        JwtError,
         entities::{ClaimsTyp, IdTokenClaims, JwkKey, Jwt, JwtClaim, JwtKeyPair},
         ports::{AccessTokenRepository, RefreshTokenRepository},
     },
@@ -515,7 +516,10 @@ where
             .refresh_token_repository
             .get_by_jti(claims.jti)
             .await
-            .map_err(|_| CoreError::InternalServerError)?;
+            .map_err(|error| match error {
+                JwtError::InvalidToken | JwtError::ExpiredToken => CoreError::InvalidRefreshToken,
+                _ => CoreError::InternalServerError,
+            })?;
 
         if refresh_token.revoked {
             return Err(CoreError::ExpiredToken);

--- a/core/src/infrastructure/repositories/refresh_token_repository.rs
+++ b/core/src/infrastructure/repositories/refresh_token_repository.rs
@@ -67,7 +67,7 @@ impl RefreshTokenRepository for PostgresRefreshTokenRepository {
             .one(&self.db)
             .await
             .map_err(|e| JwtError::GenerationError(e.to_string()))?
-            .ok_or_else(|| JwtError::GenerationError("Refresh token not found".to_string()))?;
+            .ok_or(JwtError::InvalidToken)?;
 
         Ok(refresh_token.into())
     }

--- a/front/src/hooks/auth-refresh-controller.test.ts
+++ b/front/src/hooks/auth-refresh-controller.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createRefreshController } from './auth-refresh-controller'
+
+test('refresh controller coalesces concurrent requests', async () => {
+  const controller = createRefreshController()
+  let calls = 0
+
+  const factory = async () => {
+    calls += 1
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    return 'ok'
+  }
+
+  const [first, second] = await Promise.all([
+    controller.run('master', factory),
+    controller.run('master', factory),
+  ])
+
+  assert.equal(first, 'ok')
+  assert.equal(second, 'ok')
+  assert.equal(calls, 1)
+})
+
+test('refresh controller blocks retries during backoff window', async () => {
+  const controller = createRefreshController(() => 1_000)
+  let calls = 0
+
+  const factory = async () => {
+    calls += 1
+    throw new Error('refresh failed')
+  }
+
+  await assert.rejects(controller.run('master', factory), /refresh failed/)
+  await assert.rejects(controller.run('master', factory), /refresh temporarily blocked/)
+  assert.equal(calls, 1)
+})
+
+test('refresh controller retries after backoff expires', async () => {
+  let now = 1_000
+  const controller = createRefreshController(() => now)
+  let calls = 0
+
+  const factory = async () => {
+    calls += 1
+    if (calls === 1) {
+      throw new Error('refresh failed')
+    }
+
+    return 'ok'
+  }
+
+  await assert.rejects(controller.run('master', factory), /refresh failed/)
+
+  now = 20_000
+  const result = await controller.run('master', factory)
+
+  assert.equal(result, 'ok')
+  assert.equal(calls, 2)
+})

--- a/front/src/hooks/auth-refresh-controller.ts
+++ b/front/src/hooks/auth-refresh-controller.ts
@@ -1,0 +1,66 @@
+const DEFAULT_REFRESH_BACKOFF_MS = 15_000
+
+type RefreshControllerState<T> = {
+  blockedUntil: number
+  inFlight: Promise<T> | null
+}
+
+function getState<T>(
+  states: Map<string, RefreshControllerState<T>>,
+  key: string
+) {
+  let state = states.get(key)
+
+  if (!state) {
+    state = {
+      blockedUntil: 0,
+      inFlight: null,
+    }
+    states.set(key, state)
+  }
+
+  return state
+}
+
+export function createRefreshController(
+  now: () => number = () => Date.now(),
+  backoffMs: number = DEFAULT_REFRESH_BACKOFF_MS
+) {
+  const states = new Map<string, RefreshControllerState<unknown>>()
+
+  return {
+    async run<T>(key: string, factory: () => Promise<T>) {
+      const state = getState(states, key)
+
+      if (state.inFlight) {
+        return state.inFlight as Promise<T>
+      }
+
+      if (state.blockedUntil > now()) {
+        throw new Error('refresh temporarily blocked')
+      }
+
+      const promise = factory()
+        .then((result) => {
+          state.blockedUntil = 0
+          return result
+        })
+        .catch((error) => {
+          state.blockedUntil = now() + backoffMs
+          throw error
+        })
+        .finally(() => {
+          state.inFlight = null
+        })
+
+      state.inFlight = promise as Promise<unknown>
+
+      return promise
+    },
+    reset(key: string) {
+      states.delete(key)
+    },
+  }
+}
+
+export const authRefreshController = createRefreshController()

--- a/front/src/hooks/use-auth.ts
+++ b/front/src/hooks/use-auth.ts
@@ -6,6 +6,7 @@ import userStore from '@/store/user.store'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { IUser } from '@/contracts/states.interface'
+import { authRefreshController } from './auth-refresh-controller'
 
 type JwtPayload = {
   exp?: number
@@ -65,7 +66,7 @@ export function useAuth() {
     setUser,
     setExpiration,
   } = userStore()
-  const { mutate: exchangeToken, data: responseExchangeToken } = useTokenMutation()
+  const { mutateAsync: exchangeToken } = useTokenMutation()
   const { mutateAsync: revokeToken } = useRevokeTokenMutation()
   const { mutateAsync: remoteLogout } = useLogoutMutation()
   const [hasHydrated, setHasHydrated] = useState<boolean>(
@@ -82,6 +83,7 @@ export function useAuth() {
       const decoded = decodeJwt(access_token)
       const expiration = decoded?.exp ? decoded.exp * 1000 : null
 
+      authRefreshController.reset(realm_name)
       setTokens(access_token, refresh_token, id_token)
       setExpiration(expiration)
 
@@ -89,7 +91,33 @@ export function useAuth() {
         setAuthenticated(true)
       }
     },
-    [setAuthenticated, setTokens, setExpiration]
+    [realm_name, setAuthenticated, setTokens, setExpiration]
+  )
+
+  const clearAuthState = useCallback(
+    (redirectToLogin: boolean, errorMessage?: string) => {
+      authRefreshController.reset(realm_name)
+      authStore.persist?.clearStorage?.()
+      setTokens(null, null, null)
+      setUser(null)
+      setExpiration(null)
+      setAuthenticated(false)
+      setLoading(false)
+
+      if (redirectToLogin) {
+        const params = new URLSearchParams()
+        if (errorMessage) {
+          params.set('login_error', errorMessage)
+        }
+
+        const suffix = params.toString()
+        navigate(
+          `/realms/${realm_name}/authentication/login${suffix ? `?${suffix}` : ''}`,
+          { replace: true }
+        )
+      }
+    },
+    [navigate, realm_name, setAuthenticated, setExpiration, setLoading, setTokens, setUser]
   )
 
   function isTokenExpired(): boolean {
@@ -147,31 +175,47 @@ export function useAuth() {
     } catch (error) {
       console.error('Failed to clear server-side session cookies during logout:', error)
     } finally {
-      authStore.persist?.clearStorage?.()
-      setTokens(null, null, null)
-      setUser(null)
-      setExpiration(null)
-      setAuthenticated(false)
-      setLoading(false)
-      navigate(`/realms/${realm_name}/authentication/login`, { replace: true })
+      clearAuthState(true)
     }
   }
 
   const refreshAccessToken = useCallback(() => {
     if (!refreshToken) {
       setAuthenticated(false)
-      return
+      return Promise.resolve()
     }
 
-    exchangeToken({
-      realm: realm_name,
-      data: {
-        grant_type: GrantType.RefreshToken,
-        client_id: 'security-admin-console',
-        refresh_token: refreshToken,
-      },
+    return authRefreshController.run(realm_name, async () => {
+      const response = await exchangeToken({
+        realm: realm_name,
+        data: {
+          grant_type: GrantType.RefreshToken,
+          client_id: 'security-admin-console',
+          refresh_token: refreshToken,
+        },
+      })
+
+      setAuthTokensWrapper(
+        response.access_token,
+        response.refresh_token,
+        response.id_token ?? idToken
+      )
+    }).catch((error: unknown) => {
+      const message = error instanceof Error && error.message !== 'refresh temporarily blocked'
+        ? 'Your session expired. Please sign in again.'
+        : undefined
+
+      clearAuthState(Boolean(message), message)
     })
-  }, [refreshToken, exchangeToken, realm_name, setAuthenticated])
+  }, [
+    clearAuthState,
+    exchangeToken,
+    idToken,
+    realm_name,
+    refreshToken,
+    setAuthTokensWrapper,
+    setAuthenticated,
+  ])
 
   useEffect(() => {
     if (!authStore.persist?.onFinishHydration) return
@@ -198,16 +242,6 @@ export function useAuth() {
   }, [hasHydrated, navigate, realm_name, setAuthenticated])
 
   useEffect(() => {
-    if (responseExchangeToken?.access_token) {
-      setAuthTokensWrapper(
-        responseExchangeToken.access_token,
-        responseExchangeToken.refresh_token,
-        responseExchangeToken.id_token ?? idToken
-      )
-    }
-  }, [idToken, responseExchangeToken, setAuthTokensWrapper])
-
-  useEffect(() => {
     const interval = setInterval(() => {
       if (!isAuthenticated || !accessToken) return
       const payload = decodeJwt(accessToken)
@@ -226,7 +260,7 @@ export function useAuth() {
       const timeToExpiry = exp - currentTime
 
       if (timeToExpiry <= 5) {
-        refreshAccessToken()
+        void refreshAccessToken()
       }
     }, 1000 * 5)
 

--- a/front/src/pages/authentication/feature/callback-helpers.test.ts
+++ b/front/src/pages/authentication/feature/callback-helpers.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildLoginErrorRedirect,
+  validateCallbackParams,
+} from './callback-helpers'
+
+test('validateCallbackParams rejects missing authorization code', () => {
+  assert.equal(
+    validateCallbackParams({
+      code: null,
+      returnedState: 'state-1',
+      expectedState: 'state-1',
+    }),
+    'Missing authorization code. Please try again.'
+  )
+})
+
+test('validateCallbackParams rejects mismatched oauth state', () => {
+  assert.equal(
+    validateCallbackParams({
+      code: 'code-1',
+      returnedState: 'state-1',
+      expectedState: 'state-2',
+    }),
+    'Invalid login state. Please try signing in again.'
+  )
+})
+
+test('validateCallbackParams accepts a matching code and state', () => {
+  assert.equal(
+    validateCallbackParams({
+      code: 'code-1',
+      returnedState: 'state-1',
+      expectedState: 'state-1',
+    }),
+    null
+  )
+})
+
+test('buildLoginErrorRedirect encodes realm and login error', () => {
+  assert.equal(
+    buildLoginErrorRedirect('master', 'Token not found'),
+    '/realms/master/authentication/login?login_error=Token+not+found'
+  )
+})

--- a/front/src/pages/authentication/feature/callback-helpers.ts
+++ b/front/src/pages/authentication/feature/callback-helpers.ts
@@ -1,0 +1,38 @@
+const DEFAULT_REALM = 'master'
+
+export function validateCallbackParams({
+  code,
+  returnedState,
+  expectedState,
+}: {
+  code: string | null
+  returnedState: string | null
+  expectedState: string | null
+}) {
+  if (!code) {
+    return 'Missing authorization code. Please try again.'
+  }
+
+  if (!returnedState || !expectedState || returnedState !== expectedState) {
+    return 'Invalid login state. Please try signing in again.'
+  }
+
+  return null
+}
+
+export function buildLoginErrorRedirect(realmName: string | undefined, errorMessage: string) {
+  const realm = realmName ?? DEFAULT_REALM
+  const params = new URLSearchParams({
+    login_error: errorMessage,
+  })
+
+  return `/realms/${realm}/authentication/login?${params.toString()}`
+}
+
+export function getTokenExchangeErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message
+  }
+
+  return 'Unable to complete sign in. Please try again.'
+}

--- a/front/src/pages/authentication/feature/page-callback-feature.tsx
+++ b/front/src/pages/authentication/feature/page-callback-feature.tsx
@@ -4,51 +4,69 @@ import { useAuth } from '@/hooks/use-auth'
 import { useEffect, useMemo, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import PageCallback from '../ui/page-callback'
+import {
+  buildLoginErrorRedirect,
+  getTokenExchangeErrorMessage,
+  validateCallbackParams,
+} from './callback-helpers'
 
 export default function PageCallbackFeature() {
   const navigate = useNavigate()
 
+  const urlParams = useMemo(() => new URLSearchParams(window.location.search), [])
   const code = useMemo(() => {
-    const urlParams = new URLSearchParams(window.location.search)
     return urlParams.get('code')
-  }, [])
+  }, [urlParams])
+  const state = useMemo(() => urlParams.get('state'), [urlParams])
   const setup = true
 
   const { realm_name } = useParams()
   const { setAuthTokens } = useAuth()
 
-  const { mutate: exchangeToken, data, error } = useTokenMutation()
-  const hasProcessedToken = useRef(false)
+  const { mutateAsync: exchangeToken } = useTokenMutation()
+  const hasStartedExchange = useRef(false)
+
+  const callbackValidationError = useMemo(() => {
+    return validateCallbackParams({
+      code,
+      returnedState: state,
+      expectedState: sessionStorage.getItem('oauth_state'),
+    })
+  }, [code, state])
 
   useEffect(() => {
-    if (code && !hasProcessedToken.current) {
-      exchangeToken({
-        realm: realm_name ?? 'master',
-        data: {
-          client_id: 'security-admin-console',
-          code,
-          grant_type: GrantType.Code,
-        },
-      })
-    }
-  }, [code, exchangeToken, realm_name])
-
-  useEffect(() => {
-    if (data && !hasProcessedToken.current) {
-      hasProcessedToken.current = true
-
-      setAuthTokens(data.access_token, data.refresh_token, data.id_token ?? null)
-
-      navigate(`/realms/${realm_name ?? 'master'}/overview`, { replace: true })
-    }
-  }, [data, realm_name, navigate, setAuthTokens])
-
-  useEffect(() => {
-    if (error && !hasProcessedToken.current) {
+    if (callbackValidationError) {
+      sessionStorage.removeItem('oauth_state')
       document.cookie = 'FERRISKEY_SESSION=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;'
-      hasProcessedToken.current = true
+      navigate(buildLoginErrorRedirect(realm_name, callbackValidationError), { replace: true })
+      return
     }
-  }, [error, hasProcessedToken])
+
+    if (!code || hasStartedExchange.current) {
+      return
+    }
+
+    hasStartedExchange.current = true
+    sessionStorage.removeItem('oauth_state')
+
+    void exchangeToken({
+      realm: realm_name ?? 'master',
+      data: {
+        client_id: 'security-admin-console',
+        code,
+        grant_type: GrantType.Code,
+      },
+    })
+      .then((data) => {
+        setAuthTokens(data.access_token, data.refresh_token, data.id_token ?? null)
+        navigate(`/realms/${realm_name ?? 'master'}/overview`, { replace: true })
+      })
+      .catch((error: unknown) => {
+        const message = getTokenExchangeErrorMessage(error)
+        document.cookie = 'FERRISKEY_SESSION=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;'
+        navigate(buildLoginErrorRedirect(realm_name, message), { replace: true })
+      })
+  }, [callbackValidationError, code, exchangeToken, navigate, realm_name, setAuthTokens])
 
   return <PageCallback code={code} setup={setup} />
 }

--- a/front/src/pages/authentication/ui/page-callback.tsx
+++ b/front/src/pages/authentication/ui/page-callback.tsx
@@ -4,39 +4,36 @@ import { XCircle } from 'lucide-react'
 export interface PageCallbackProps {
   code?: string | null
   setup: boolean
+  errorMessage?: string | null
 }
 
-export default function PageCallback({ code, setup }: PageCallbackProps) {
+export default function PageCallback({ code, setup, errorMessage }: PageCallbackProps) {
+  if (errorMessage) {
+    return <ErrorState message={errorMessage} />
+  }
+
   if (setup && !code) {
-    return <ErrorCode />
+    return <ErrorState message='Missing authorization code. Please try again.' />
   }
 
   return (
-    <div>
+    <div className='flex min-h-svh items-center justify-center'>
       <LoaderSpinner />
     </div>
   )
 }
 
-function ErrorCode() {
+function ErrorState({ message }: { message: string }) {
   return (
-    <div className='rounded-md bg-red-50 p-4'>
-      <div className='flex'>
-        <div className='shrink-0'>
-          <XCircle aria-hidden='true' className='size-5 text-red-400' />
-        </div>
-        <div className='ml-3'>
-          <h3 className='text-sm font-medium text-red-800'>
-            There were 2 errors with your submission
-          </h3>
-          <div className='mt-2 text-sm text-red-700'>
-            <ul role='list' className='list-disc space-y-1 pl-5'>
-              <li>Your password must be at least 8 characters</li>
-              <li>
-                Your password must include at least one pro wrestling finishing
-                move
-              </li>
-            </ul>
+    <div className='flex min-h-svh items-center justify-center px-6'>
+      <div className='w-full max-w-md rounded-md border border-destructive/30 bg-destructive/10 p-4 text-destructive'>
+        <div className='flex gap-3'>
+          <div className='shrink-0 pt-0.5'>
+            <XCircle aria-hidden='true' className='size-5' />
+          </div>
+          <div className='space-y-1'>
+            <h3 className='text-sm font-medium'>Unable to complete sign in</h3>
+            <p className='text-sm'>{message}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

This PR fixes two related authentication regressions in the FerrisKey admin console:

1. The authentication callback page could get stuck on a blank loading screen when the authorization `code` was invalid, stale, or processed more than once.
2. Refresh token failures were surfaced as `500 Internal Server Error`, and the frontend could trigger repeated concurrent refresh requests, which eventually caused authenticated admin actions such as realm settings updates to fail with `401 Unauthorized`.

---

## Bug Description

### 1. Blank callback page after login
When the frontend landed on `/realms/:realm/authentication/callback`, it immediately exchanged the authorization `code` for tokens. If the `code` was invalid, stale, or reused, the backend returned an error, but the frontend stayed on the callback page and kept rendering a loading state instead of recovering gracefully.

This was especially easy to hit when:
- multiple browsers or tabs were involved,
- a stale callback URL was refreshed,
- React development mode triggered the callback effect more than once.

### 2. Refresh token failures caused broken admin sessions
When an access token expired, the frontend attempted to refresh it. If the refresh token was invalid or no longer present in storage, the backend mapped that condition to `500` instead of an authentication error. On the frontend side, multiple consumers could trigger refresh at the same time, causing repeated refresh attempts against the token endpoint.

Once refresh failed, protected admin requests such as `PUT /realms/master/settings` started failing with `401 Unauthorized`, which made it look like realm settings were broken even though the real issue was session recovery.

---

## How To Reproduce

### Repro A: blank callback page
1. Start the frontend and backend locally.
2. Sign in to the admin console.
3. Revisit a stale callback URL, or open an invalid one such as:
   - `/realms/master/authentication/callback?code=bogus123&state=test`
4. Observe that the frontend remains stuck on the callback/loading screen instead of returning to login with a usable error.

### Repro B: broken refresh flow / settings save fails
1. Sign in to the admin console.
2. Let the session age until token refresh is needed, or trigger refresh with an invalid refresh token.
3. Observe repeated `POST /realms/master/protocol/openid-connect/token` requests for the refresh flow.
4. Try saving realm settings.
5. Observe that protected requests eventually fail with `401`, while refresh requests may return `500`.

---

## Root Cause

### Callback flow
- The callback page did not validate the returned `state` against the stored OAuth state before proceeding.
- The authorization code exchange was not protected early enough against duplicate execution.
- On token exchange failure, the page did not redirect or render a recoverable error state.

### Refresh flow
- Invalid or missing refresh token records were treated as internal server errors in the backend.
- The frontend refresh logic was not coordinated across multiple hook consumers, so concurrent refresh attempts could be triggered for the same realm/session.

---

## Fix

### Frontend
- Added callback parameter validation for missing `code` and mismatched OAuth `state`.
- Added a one-shot guard so the callback page only attempts authorization code exchange once.
- Redirected failed callback flows back to the login page with a visible `login_error` message instead of leaving the user on a blank loading page.
- Added a shared refresh controller to coalesce concurrent refresh attempts into a single in-flight request.
- Added refresh backoff/reset behavior so repeated failures do not create a request storm.
- Cleared local auth state and redirected to login when refresh recovery fails.

### Backend
- Changed refresh token lookup failures to map to token validation errors instead of internal server errors.
- Invalid refresh token requests now return `401 Unauthorized` instead of `500 Internal Server Error`.

---

## Result

After this change:
- Invalid or stale callback URLs no longer trap the user on a blank screen.
- Callback failures send the user back to the login page with a clear error.
- Invalid refresh tokens now return the correct authentication error (`401`).
- Concurrent refresh attempts are collapsed on the frontend.
- Admin operations such as saving realm login settings work normally once the session is valid.

---

## Verification

Verified with:
- `cargo build --release --bin ferriskey-api`
- frontend unit tests for callback validation and refresh controller behavior
- frontend production build
- manual browser validation using the local admin console
- manual API verification that invalid refresh token requests now return `401`

### Manual checks performed
- Fresh login reaches the admin overview successfully.
- Invalid callback URL redirects to login with an error message.
- Realm login settings can be updated successfully (`PUT /realms/master/settings` returns `200`).
- Invalid refresh token exchange returns `401 Unauthorized`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise classification and messaging for refresh-token failures
  * Clearer user-facing messages for OAuth callback errors

* **New Features**
  * Client-side refresh controller with single in-flight/coalescing, backoff and retry behavior
  * Callback UI now displays a styled error state with contextual messages
  * Centralized auth-state clearing and more robust token refresh flow

* **Tests**
  * Added tests for the refresh controller and callback helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->