### PR TITLE
fix(webapp): use nginx html root in frontend runtime

### DIFF
--- a/front/docker-entrypoint.sh
+++ b/front/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-HTML_DIR=/usr/share/angie/html
+HTML_DIR=/usr/share/nginx/html
 SRC_DIR=/usr/local/src/ferriskey
 CONFIG_FILE="$HTML_DIR/config.json"
 

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -21,7 +21,7 @@ server {
   add_header X-Content-Type-Options nosniff;
 
   location / {
-    root /usr/share/angie/html;
+    root /usr/share/nginx/html;
     try_files $uri $uri/ /index.html;
   }
 }


### PR DESCRIPTION
## Summary

This fixes a mismatch in the frontend runtime image configuration.

The `webapp` stage in `Dockerfile` uses the `nginx` base image, but the frontend entrypoint script and nginx config were still pointing to Angie-specific paths under `/usr/share/angie/html`. As a result, the web container exited on startup because that directory does not exist in the nginx image.

This PR updates the frontend runtime paths to `/usr/share/nginx/html` so they match the actual container base image.

## Changes

- update `front/docker-entrypoint.sh`
  - `/usr/share/angie/html` -> `/usr/share/nginx/html`
- update `front/nginx.conf`
  - `root /usr/share/angie/html;` -> `root /usr/share/nginx/html;`

## Reproduction

Before this change, starting the frontend container could fail with errors like:

cp: can't create directory '/usr/share/angie/html/assets': No such file or directory
cp: can't create '/usr/share/angie/html/index.html': No such file or directory

<img width="1888" height="666" alt="image" src="https://github.com/user-attachments/assets/7dd98d34-1a66-4919-ac3e-3fc85c315ff4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Web server configuration updated to use the standard static assets location for serving files and reading the config file.
  * No user-facing behavioral changes; existing static content and headers remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->