### PR TITLE
feat(trident): add autofill and improve the auth flow for passkey

### DIFF
--- a/api/src/application/auth.rs
+++ b/api/src/application/auth.rs
@@ -155,3 +155,25 @@ pub async fn auth(
 
     Ok(next.run(req).await)
 }
+
+pub async fn auth_login_actions(
+    State(state): State<AppState>,
+    jwt: Jwt,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let claims = jwt.claims;
+
+    let output = state
+        .service
+        .authorize_login_action_request(AuthorizeRequestInput {
+            claims,
+            token: jwt.token,
+        })
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+    req.extensions_mut().insert(output.identity);
+
+    Ok(next.run(req).await)
+}

--- a/api/src/application/http/trident/router.rs
+++ b/api/src/application/http/trident/router.rs
@@ -5,7 +5,7 @@ use axum::{
 use utoipa::OpenApi;
 
 use crate::application::{
-    auth::auth,
+    auth::{auth, auth_login_actions},
     http::{
         server::app_state::AppState,
         trident::handlers::{
@@ -117,8 +117,8 @@ pub fn trident_routes(state: AppState) -> Router<AppState> {
             post(passkey_authenticate),
         );
 
-    // Authenticated routes
-    let protected_routes = Router::new()
+    // Login action routes (protected by temporary token)
+    let login_action_routes = Router::new()
         .route(
             &format!(
                 "{}/realms/{{realm_name}}/login-actions/setup-otp",
@@ -142,10 +142,10 @@ pub fn trident_routes(state: AppState) -> Router<AppState> {
         )
         .route(
             &format!(
-                "{}/realms/{{realm_name}}/login-actions/webauthn-public-key-create",
+                "{}/realms/{{realm_name}}/login-actions/update-password",
                 state.args.server.root_path
             ),
-            post(webauthn_public_key_create),
+            post(update_password),
         )
         .route(
             &format!(
@@ -154,6 +154,20 @@ pub fn trident_routes(state: AppState) -> Router<AppState> {
             ),
             post(webauthn_public_key_create_options),
         )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/login-actions/webauthn-public-key-create",
+                state.args.server.root_path
+            ),
+            post(webauthn_public_key_create),
+        )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_login_actions,
+        ));
+
+    // Bearer authenticated routes
+    let bearer_protected_routes = Router::new()
         .route(
             &format!(
                 "{}/realms/{{realm_name}}/login-actions/webauthn-public-key-request-options",
@@ -167,13 +181,6 @@ pub fn trident_routes(state: AppState) -> Router<AppState> {
                 state.args.server.root_path
             ),
             post(webauthn_public_key_authenticate),
-        )
-        .route(
-            &format!(
-                "{}/realms/{{realm_name}}/login-actions/update-password",
-                state.args.server.root_path
-            ),
-            post(update_password),
         )
         .route(
             &format!(
@@ -191,6 +198,8 @@ pub fn trident_routes(state: AppState) -> Router<AppState> {
         )
         .layer(middleware::from_fn_with_state(state.clone(), auth));
 
-    // Merge both router
-    public_routes.merge(protected_routes)
+    // Merge all routers
+    public_routes
+        .merge(login_action_routes)
+        .merge(bearer_protected_routes)
 }

--- a/core/src/application/auth/mod.rs
+++ b/core/src/application/auth/mod.rs
@@ -38,6 +38,15 @@ impl AuthService for ApplicationService {
         self.auth_service.authorize_request(input).await
     }
 
+    async fn authorize_login_action_request(
+        &self,
+        input: AuthorizeRequestInput,
+    ) -> Result<AuthorizeRequestOutput, CoreError> {
+        self.auth_service
+            .authorize_login_action_request(input)
+            .await
+    }
+
     async fn exchange_token(&self, input: ExchangeTokenInput) -> Result<JwtToken, CoreError> {
         self.auth_service.exchange_token(input).await
     }

--- a/core/src/domain/authentication/ports.rs
+++ b/core/src/domain/authentication/ports.rs
@@ -121,6 +121,10 @@ pub trait AuthService: Send + Sync {
         &self,
         input: AuthorizeRequestInput,
     ) -> impl Future<Output = Result<AuthorizeRequestOutput, CoreError>> + Send;
+    fn authorize_login_action_request(
+        &self,
+        input: AuthorizeRequestInput,
+    ) -> impl Future<Output = Result<AuthorizeRequestOutput, CoreError>> + Send;
     fn authenticate(
         &self,
         input: AuthenticateInput,

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -1296,7 +1296,7 @@ This is a server error that should be investigated. Do not forward back this mes
             user.username.clone(),
             iss,
             vec![format!("{}-realm", realm.name), "account".to_string()],
-            ClaimsTyp::Bearer,
+            ClaimsTyp::Temporary,
             client_id.clone(),
             Some(user.email.clone()),
             Some(auth_session.scope),
@@ -1781,6 +1781,23 @@ where
         };
 
         Ok(AuthorizeRequestOutput { identity })
+    }
+
+    async fn authorize_login_action_request(
+        &self,
+        input: AuthorizeRequestInput,
+    ) -> Result<AuthorizeRequestOutput, CoreError> {
+        if input.claims.typ != ClaimsTyp::Temporary {
+            return Err(CoreError::InvalidToken);
+        }
+
+        let user = self.user_repository.get_by_id(input.claims.sub).await?;
+
+        self.verify_token(input.token, user.realm_id).await?;
+
+        Ok(AuthorizeRequestOutput {
+            identity: Identity::User(user),
+        })
     }
 
     async fn authenticate(

--- a/front/src/pages/authentication/feature/page-login-feature.tsx
+++ b/front/src/pages/authentication/feature/page-login-feature.tsx
@@ -74,6 +74,7 @@ export default function PageLoginFeature() {
   const { mutateAsync: requestPasskeyOptionsAsync, mutate: requestPasskeyOptions } = usePasskeyRequestOptionsMutation()
   const { mutateAsync: authenticatePasskeyAsync, mutate: authenticatePasskey } = usePasskeyAuthenticateMutation()
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false)
+  const [conditionalUIVersion, setConditionalUIVersion] = useState(0)
   const conditionalAbortRef = useRef<AbortController | null>(null)
 
   // Conditional UI: autofill passkeys in the username field (Apple Passkeys, Chrome, etc.)
@@ -123,7 +124,7 @@ export default function PageLoginFeature() {
       abortController.abort()
       conditionalAbortRef.current = null
     }
-  }, [loginSettings?.passkey_enabled, isAuthInitiated, realm_name, requestPasskeyOptionsAsync, authenticatePasskeyAsync])
+  }, [loginSettings?.passkey_enabled, isAuthInitiated, realm_name, requestPasskeyOptionsAsync, authenticatePasskeyAsync, conditionalUIVersion])
 
   const scheduleSessionExpirationBar = useCallback(() => {
     if (timerRef.current) {
@@ -249,6 +250,7 @@ export default function PageLoginFeature() {
                 onError: () => {
                   toast.error('Passkey authentication failed')
                   setIsPasskeyLoading(false)
+                  setConditionalUIVersion(v => v + 1)
                 },
               }
             )
@@ -259,6 +261,7 @@ export default function PageLoginFeature() {
         onError: () => {
           toast.error('Failed to start passkey authentication')
           setIsPasskeyLoading(false)
+          setConditionalUIVersion(v => v + 1)
         },
       }
     )

--- a/front/src/pages/authentication/feature/page-required-action-feature.tsx
+++ b/front/src/pages/authentication/feature/page-required-action-feature.tsx
@@ -1,20 +1,10 @@
 import { useSearchParams } from 'react-router'
 import PageRequiredAction from '../ui/page-required-action'
-import { useAuth } from '@/hooks/use-auth'
-import { useEffect } from 'react'
 
 export default function PageRequiredActionFeature() {
   const [searchParams] = useSearchParams()
-  const { setAuthToken } = useAuth()
   const execution = searchParams.get('execution')
   const token = searchParams.get('client_data')
-
-  useEffect(() => {
-    if (token) {
-      setAuthToken(token)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token])
 
   if (!token) {
     return <div>Loading ...</div>


### PR DESCRIPTION
Add auth_login_actions middleware and a new
authorize_login_action_request
in core to handle temporary tokens for login actions. Rewire trident router
into public, login-action (temporary token) and bearer-protected routes, and set issued claims to Temporary where appropriate.

Frontend: add conditionalUIVersion to re-trigger conditional passkey UI on
errors and remove an unnecessary auth token side-effect from the required
action page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated authentication pathway for login-action requests with separate route configuration.

* **Bug Fixes**
  * Implemented automatic retry mechanism for passkey authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->