### PR TITLE
feat: bump project version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferriskey-abyss"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "ferriskey-domain",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-aegis"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "ferriskey-domain",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-api"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-compass"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "ferriskey-domain",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-core"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-domain"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-mail"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "lettre",
  "thiserror 2.0.18",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-migrate"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "mockall 0.13.1",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-operator"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-organization"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "ferriskey-domain",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-security"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "ferriskey-trident"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "base32",
  "chrono",
@@ -2921,7 +2921,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maskass"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["core", "api", "operator","client", "libs/maskass", "libs/ferriskey-s
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.5.0"
 authors = ["nathaelb <pro.nathaelbonnal@gmail.com>", "Baptiste Parmantier <baptiste.parmantier.pro@gmail.com>"]
 edition = "2024"

--- a/charts/ferriskey/Chart.yaml
+++ b/charts/ferriskey/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ferriskey
 description: A Helm chart for Ferriskey
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"

--- a/charts/ferriskey/README.md
+++ b/charts/ferriskey/README.md
@@ -1,6 +1,6 @@
 # ferriskey
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 A Helm chart for Ferriskey
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped workspace package version to 0.5.0.
  * Bumped Helm chart and app versions to 0.5.0 for deployment consistency.

* **Documentation**
  * Updated chart README badges to reflect version 0.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->