### PR TITLE
fix: handle invalid redirect URI and seed admin console

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -41,11 +41,11 @@ tracing-opentelemetry = "0.32.0"
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = "0.31.0"
 opentelemetry = "0.31.0"
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 test-context = "*"
 axum-test = "*"
 sea-orm = { version = "1.1.19", features = ["sqlx-postgres"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "migrate"] }
-urlencoding = "2.1.3"
 serde_json = "1.0.148"

--- a/api/src/application/http/authentication/handlers/auth.rs
+++ b/api/src/application/http/authentication/handlers/auth.rs
@@ -12,6 +12,7 @@ use ferriskey_core::domain::authentication::entities::{
     AuthInput, AuthenticateInput, AuthenticationStepStatus,
 };
 use ferriskey_core::domain::authentication::ports::AuthService;
+use ferriskey_core::domain::common::entities::app_errors::CoreError;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use utoipa::{IntoParams, ToSchema};
@@ -90,7 +91,7 @@ pub async fn auth_handler(
     cookie: CookieManager,
     Query(params): Query<AuthRequest>,
 ) -> Result<axum::response::Response, ApiError> {
-    let result = state
+    let result = match state
         .service
         .auth(AuthInput {
             client_id: params.client_id.clone(),
@@ -101,7 +102,32 @@ pub async fn auth_handler(
             state: params.state.clone(),
         })
         .await
-        .map_err(ApiError::from)?;
+    {
+        Ok(result) => result,
+        // For these errors we must NOT redirect to redirect_uri (it may be invalid / unknown).
+        // Instead, redirect the browser to the FerrisKey login page with a human-readable
+        // error message so the user sees a proper UI rather than raw JSON.
+        Err(
+            e @ CoreError::InvalidRedirectUri
+            | e @ CoreError::ClientNotFound
+            | e @ CoreError::InvalidRealm,
+        ) => {
+            warn!(
+                realm = %realm_name,
+                client_id = %params.client_id,
+                error = %e,
+                "Auth flow rejected — redirecting to login error page"
+            );
+            let error_url = format!(
+                "{}/realms/{}/authentication/login?login_error={}",
+                state.args.webapp_url.trim_end_matches('/'),
+                realm_name,
+                urlencoding::encode(&e.to_string()),
+            );
+            return Ok((StatusCode::FOUND, [(LOCATION, error_url)]).into_response());
+        }
+        Err(e) => return Err(ApiError::from(e)),
+    };
 
     if let Some(identity_cookie) = cookie.get(IDENTITY_COOKIE)
         && !identity_cookie.value().trim().is_empty()

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -245,6 +245,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             client_scope.clone(),
             protocol_mapper.clone(),
             scope_mapping.clone(),
+            redirect_uri.clone(),
             policy.clone(),
         ),
         mail_service: MailServiceImpl::new(realm.clone(), smtp_config.clone(), policy.clone()),

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -200,6 +200,7 @@ pub struct ApplicationService {
         ClientScopeRepo,
         ProtocolMapperRepo,
         ScopeMappingRepo,
+        RedirectUriRepo,
     >,
     pub(crate) mail_service:
         MailServiceImpl<RealmRepo, UserRepo, ClientRepo, UserRoleRepo, SmtpConfigRepo>,

--- a/core/src/domain/common/services.rs
+++ b/core/src/domain/common/services.rs
@@ -398,6 +398,94 @@ where
             }
         }
 
+        // Ensure security-admin-console exists in every realm, not just master.
+        // This is idempotent: existing clients and URIs are skipped.
+        // It also back-fills realms that were created before this seeding was added.
+        let all_realms = self
+            .realm_repository
+            .fetch_realm()
+            .await
+            .unwrap_or_default();
+
+        let console_redirect_patterns = [
+            "^http://localhost:[0-9]+/.*",
+            "^/*",
+            "http://localhost:3000/admin",
+            "http://localhost:5173/admin",
+        ];
+
+        for r in &all_realms {
+            if r.id == realm.id {
+                // master is already handled above
+                continue;
+            }
+
+            let console_client = match self
+                .client_repository
+                .get_by_client_id(config.default_client_id.clone(), r.id)
+                .await
+            {
+                Ok(c) => {
+                    tracing::info!("security-admin-console already exists in realm {:}", r.name);
+                    c
+                }
+                Err(_) => {
+                    tracing::info!("creating security-admin-console for realm {:}", r.name);
+                    match self
+                        .client_repository
+                        .create_client(CreateClientRequest {
+                            realm_id: r.id,
+                            name: config.default_client_id.clone(),
+                            client_id: config.default_client_id.clone(),
+                            enabled: true,
+                            protocol: "openid-connect".to_string(),
+                            public_client: false,
+                            service_account_enabled: false,
+                            direct_access_grants_enabled: false,
+                            client_type: ClientType::Confidential,
+                            secret: Some(generate_random_string()),
+                        })
+                        .await
+                    {
+                        Ok(c) => {
+                            tracing::info!("security-admin-console created for realm {:}", r.name);
+                            c
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "failed to create security-admin-console for realm {:}: {:}",
+                                r.name,
+                                e
+                            );
+                            continue;
+                        }
+                    }
+                }
+            };
+
+            let existing_uris = self
+                .redirect_uri_repository
+                .get_by_client_id(console_client.id)
+                .await
+                .unwrap_or_default();
+
+            for pattern in &console_redirect_patterns {
+                if !existing_uris.iter().any(|uri| &uri.value == pattern)
+                    && let Err(e) = self
+                        .redirect_uri_repository
+                        .create_redirect_uri(console_client.id, pattern.to_string(), true)
+                        .await
+                {
+                    tracing::error!(
+                        "failed to create redirect URI '{}' for security-admin-console in realm '{}': {}",
+                        pattern,
+                        r.name,
+                        e
+                    );
+                }
+            }
+        }
+
         Ok(InitializationResult {
             master_realm_id: realm.id,
             admin_role_id: role.id,

--- a/core/src/domain/realm/services.rs
+++ b/core/src/domain/realm/services.rs
@@ -5,7 +5,11 @@ use crate::domain::{
         IdentityProviderRepository, entities::IdentityProviderPresentation,
     },
     authentication::value_objects::Identity,
-    client::{entities::ClientType, ports::ClientRepository, value_objects::CreateClientRequest},
+    client::{
+        entities::ClientType,
+        ports::{ClientRepository, RedirectUriRepository},
+        value_objects::CreateClientRequest,
+    },
     common::{
         entities::app_errors::CoreError,
         generate_random_string,
@@ -37,7 +41,7 @@ use serde_json::json;
 use tracing::instrument;
 
 #[derive(Clone, Debug)]
-pub struct RealmServiceImpl<R, U, C, UR, RO, W, I, CS, PM, CSM>
+pub struct RealmServiceImpl<R, U, C, UR, RO, W, I, CS, PM, CSM, RU>
 where
     R: RealmRepository,
     U: UserRepository,
@@ -49,6 +53,7 @@ where
     CS: ClientScopeRepository,
     PM: ProtocolMapperRepository,
     CSM: ClientScopeMappingRepository,
+    RU: RedirectUriRepository,
 {
     pub(crate) realm_repository: Arc<R>,
     pub(crate) user_repository: Arc<U>,
@@ -60,11 +65,13 @@ where
     pub(crate) client_scope_repository: Arc<CS>,
     pub(crate) protocol_mapper_repository: Arc<PM>,
     pub(crate) client_scope_mapping_repository: Arc<CSM>,
+    pub(crate) redirect_uri_repository: Arc<RU>,
 
     pub(crate) policy: Arc<FerriskeyPolicy<U, C, UR>>,
 }
 
-impl<R, U, C, UR, RO, W, I, CS, PM, CSM> RealmServiceImpl<R, U, C, UR, RO, W, I, CS, PM, CSM>
+impl<R, U, C, UR, RO, W, I, CS, PM, CSM, RU>
+    RealmServiceImpl<R, U, C, UR, RO, W, I, CS, PM, CSM, RU>
 where
     R: RealmRepository,
     U: UserRepository,
@@ -76,6 +83,7 @@ where
     CS: ClientScopeRepository,
     PM: ProtocolMapperRepository,
     CSM: ClientScopeMappingRepository,
+    RU: RedirectUriRepository,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -89,6 +97,7 @@ where
         client_scope_repository: Arc<CS>,
         protocol_mapper_repository: Arc<PM>,
         client_scope_mapping_repository: Arc<CSM>,
+        redirect_uri_repository: Arc<RU>,
         policy: Arc<FerriskeyPolicy<U, C, UR>>,
     ) -> Self {
         Self {
@@ -102,6 +111,7 @@ where
             client_scope_repository,
             protocol_mapper_repository,
             client_scope_mapping_repository,
+            redirect_uri_repository,
             policy,
         }
     }
@@ -252,8 +262,8 @@ where
     }
 }
 
-impl<R, U, C, UR, RO, W, I, CS, PM, CSM> RealmService
-    for RealmServiceImpl<R, U, C, UR, RO, W, I, CS, PM, CSM>
+impl<R, U, C, UR, RO, W, I, CS, PM, CSM, RU> RealmService
+    for RealmServiceImpl<R, U, C, UR, RO, W, I, CS, PM, CSM, RU>
 where
     R: RealmRepository,
     C: ClientRepository,
@@ -265,6 +275,7 @@ where
     CS: ClientScopeRepository,
     PM: ProtocolMapperRepository,
     CSM: ClientScopeMappingRepository,
+    RU: RedirectUriRepository,
 {
     #[instrument(
         skip(self, identity, input),
@@ -360,6 +371,48 @@ where
 
         self.seed_default_scopes_for_client(realm.id, account_client.id)
             .await?;
+
+        // Create the security-admin-console client for this realm so that the
+        // FerrisKey webapp can initiate the OAuth flow for this realm.
+        let console_client = self
+            .client_repository
+            .create_client(CreateClientRequest {
+                client_id: "security-admin-console".to_string(),
+                client_type: ClientType::Confidential,
+                direct_access_grants_enabled: false,
+                enabled: true,
+                name: "security-admin-console".to_string(),
+                protocol: "openid-connect".to_string(),
+                public_client: false,
+                realm_id: realm.id,
+                secret: Some(generate_random_string()),
+                service_account_enabled: false,
+            })
+            .await?;
+
+        // Seed the same redirect-URI patterns used for master so that the webapp
+        // callback URL is accepted for every realm.
+        let console_redirect_patterns = vec![
+            "^http://localhost:[0-9]+/.*",
+            "^/*",
+            "http://localhost:3000/admin",
+            "http://localhost:5173/admin",
+        ];
+
+        for pattern in console_redirect_patterns {
+            if let Err(e) = self
+                .redirect_uri_repository
+                .create_redirect_uri(console_client.id, pattern.to_string(), true)
+                .await
+            {
+                tracing::error!(
+                    "Failed to create redirect URI '{}' for security-admin-console in realm '{}': {}",
+                    pattern,
+                    realm.name,
+                    e
+                );
+            }
+        }
 
         Ok(realm)
     }

--- a/front/src/pages/authentication/feature/page-login-feature.tsx
+++ b/front/src/pages/authentication/feature/page-login-feature.tsx
@@ -6,7 +6,7 @@ import { useLocation, useNavigate, useParams } from 'react-router'
 import { z } from 'zod'
 import { toast } from 'sonner'
 import FloatingActionBar from '@/components/ui/floating-action-bar'
-import PageLogin, { MagicLinkStep } from '../ui/page-login'
+import PageLogin, { LoginErrorPage, MagicLinkStep } from '../ui/page-login'
 import { AuthenticationStatus } from '@/api/api.interface.ts'
 import { useGetLoginSettings } from '@/api/realm.api'
 import { usePasskeyRequestOptionsMutation, usePasskeyAuthenticateMutation } from '@/api/passkey.api'
@@ -28,7 +28,22 @@ export default function PageLoginFeature() {
   const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search])
   const clientId = searchParams.get('client_id')
   const redirectUri = searchParams.get('redirect_uri')
-  const isAuthInitiated = Boolean(clientId && redirectUri)
+
+  // Detect stale realm in redirect_uri.
+  // When the user edits the realm in the URL (e.g. /realms/master → /realms/cloud-iam)
+  // the old redirect_uri (".../realms/master/authentication/callback") stays in the query
+  // params. If we don't catch this, the OAuth session is created with the wrong callback
+  // and the user ends up redirected to the wrong realm after login.
+  const currentRealm = realm_name ?? 'master'
+  const realmCallbackUri = `${window.location.origin}/realms/${currentRealm}/authentication/callback`
+  const isRedirectUriStale =
+    redirectUri !== null &&
+    redirectUri.includes('/realms/') &&
+    !redirectUri.includes(`/realms/${currentRealm}/`)
+
+  // Auth is "initiated" (OAuth session exists) only when both params are present
+  // AND the redirect_uri belongs to the current realm.
+  const isAuthInitiated = Boolean(clientId && redirectUri) && !isRedirectUriStale
 
   const { data: loginSettings } = useGetLoginSettings({ realm: realm_name })
 
@@ -40,13 +55,19 @@ export default function PageLoginFeature() {
   const restartAuthFlowRef = useRef<() => void>(() => { })
 
   const getAuthParamsFromUrl = useCallback(() => {
+    const resolvedClientId = clientId ?? 'security-admin-console'
+    // For the webapp's own OAuth client, always derive redirect_uri from the
+    // current realm — never use a stale value carried over from another realm's
+    // query params.
+    const resolvedRedirectUri =
+      resolvedClientId === 'security-admin-console'
+        ? realmCallbackUri
+        : (redirectUri ?? realmCallbackUri)
     return {
-      clientId: clientId ?? 'security-admin-console',
-      redirectUri:
-        redirectUri ??
-        `${window.location.origin}/realms/${realm_name ?? 'master'}/authentication/callback`,
+      clientId: resolvedClientId,
+      redirectUri: resolvedRedirectUri,
     }
-  }, [clientId, redirectUri, realm_name])
+  }, [clientId, redirectUri, realmCallbackUri])
 
   const getOAuthParams = useCallback(() => {
     const state = crypto.randomUUID()
@@ -379,6 +400,13 @@ export default function PageLoginFeature() {
 
   if (isRedirecting) {
     return <PageLogin form={form} onSubmit={onSubmit} isLoading loginSettings={loginSettings} />
+  }
+
+  // Fatal configuration error (e.g. "Invalid redirect URI", "Client not found").
+  // The backend redirected here because it can't trust the redirect_uri.
+  // Show a clean error card — do NOT render the login form or retry the OAuth flow.
+  if (loginError && !isAuthInitiated) {
+    return <LoginErrorPage errorMessage={loginError} />
   }
 
   if (!loginSettings) return null

--- a/front/src/pages/authentication/ui/page-login.tsx
+++ b/front/src/pages/authentication/ui/page-login.tsx
@@ -13,7 +13,7 @@ import { LoginProviders } from './login-providers'
 import './page-login.css'
 import LoaderSpinner from '@/components/ui/loader-spinner'
 import { Separator } from '@/components/ui/separator'
-import { ArrowLeft, KeyRound, Mail } from 'lucide-react'
+import { ArrowLeft, KeyRound, Mail, ShieldAlert } from 'lucide-react'
 
 export type MagicLinkStep = 'idle' | 'form' | 'sent'
 
@@ -310,6 +310,52 @@ function ErrorMessage() {
     <div className='flex min-h-svh flex-col items-center justify-center'>
       <p className='text-lg font-semibold text-destructive'>An error occurred during login</p>
       <p className='text-muted-foreground'>Please try again</p>
+    </div>
+  )
+}
+
+export function LoginErrorPage({ errorMessage }: { errorMessage: string }) {
+  return (
+    <div className='login-shell relative flex min-h-svh items-center justify-center px-6 py-10'>
+      <div className='relative z-10 w-full max-w-sm md:max-w-md lg:max-w-lg'>
+        <div className='flex flex-col gap-6'>
+          <Card className='login-card overflow-hidden border p-0 shadow-sm'>
+            <CardContent className='grid gap-0 p-0'>
+              <div className='p-8 md:p-10'>
+                <div className='flex flex-col gap-7'>
+                  <div className='space-y-2'>
+                    <div className='flex items-center gap-3'>
+                      <img
+                        src='/logo_ferriskey.png'
+                        alt='FerrisKey'
+                        className='h-7 w-7 object-contain'
+                      />
+                      <p className='text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground'>
+                        FerrisKey
+                      </p>
+                    </div>
+                    <h1 className='login-title text-3xl font-semibold tracking-tight text-foreground'>
+                      Authentication error
+                    </h1>
+                  </div>
+
+                  <div className='flex flex-col items-center gap-4 py-2'>
+                    <div className='flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10'>
+                      <ShieldAlert className='h-6 w-6 text-destructive' />
+                    </div>
+                    <div className='space-y-1 text-center'>
+                      <p className='text-sm font-medium text-foreground'>{errorMessage}</p>
+                      <p className='text-xs text-muted-foreground'>
+                        Contact your administrator if this problem persists.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Return the FerrisKey login page (with encoded error) instead of redirecting
to the provided redirect_uri for CoreError::InvalidRedirectUri, ClientNotFound, and InvalidRealm. Wire RedirectUriRepository into realm services and seed a security-admin-console client plus common redirect patterns for every realm. Frontend: detect stale redirect_uri, derive the
webapp callback for security-admin-console, and render a LoginErrorPage for
fatal auth errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated error page for authentication failures, displaying clear error messages to users.
  * Improved redirect URI handling to validate realm consistency during login flow.

* **Bug Fixes**
  * Enhanced authentication error handling to redirect users to login page with detailed error information instead of generic API errors.
  * Fixed security-admin-console client provisioning to initialize automatically across all realms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->