### PR TITLE
fix: run database migrations as Helm hooks

### DIFF
--- a/charts/ferriskey/README.md
+++ b/charts/ferriskey/README.md
@@ -17,6 +17,8 @@ helm repo add ferriskey oci://ghcr.io/ferriskey/charts
 helm install ferriskey ferriskey/ferriskey
 ```
 
+With Helm, the database migrations job is executed as a `post-install` and `pre-upgrade` hook, so it is recreated on each upgrade instead of being patched in place.
+
 #### ArgoCD
 
 If you're using ArgoCD, you need to set the following values:
@@ -55,6 +57,8 @@ helm install ferriskey ferriskey/ferriskey \
     --set database.passwordSecret.name=$SECRET_NAME \
     --set postgresql.enabled=false
 ```
+
+With Helm, the database migrations job is executed as a `post-install` and `pre-upgrade` hook, so it is recreated on each upgrade instead of being patched in place.
 
 #### ArgoCD
 

--- a/charts/ferriskey/README.md.gotmpl
+++ b/charts/ferriskey/README.md.gotmpl
@@ -20,6 +20,8 @@ helm repo add ferriskey oci://ghcr.io/ferriskey/charts
 helm install ferriskey ferriskey/ferriskey
 ```
 
+With Helm, the database migrations job is executed as a `post-install` and `pre-upgrade` hook, so it is recreated on each upgrade instead of being patched in place.
+
 #### ArgoCD
 
 If you're using ArgoCD, you need to set the following values:
@@ -58,6 +60,8 @@ helm install ferriskey ferriskey/ferriskey \
     --set database.passwordSecret.name=$SECRET_NAME \
     --set postgresql.enabled=false
 ```
+
+With Helm, the database migrations job is executed as a `post-install` and `pre-upgrade` hook, so it is recreated on each upgrade instead of being patched in place.
 
 #### ArgoCD
 

--- a/charts/ferriskey/templates/database-migrations/job.yaml
+++ b/charts/ferriskey/templates/database-migrations/job.yaml
@@ -20,10 +20,13 @@
 kind: Job
 metadata:
   name: {{ include "ferriskey.databaseMigrations.name" . }}
-  {{- with $annotations }}
   annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "1"
+    {{- with $annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
   labels:
     {{- include "ferriskey.databaseMigrations.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Add Helm hook annotations to the database-migrations Job (post-install, pre-upgrade) and set hook-delete-policy and hook-weight so the job is recreated on upgrades. Update README and template README to document this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides to clarify that when using Helm, database migrations run as post-install and pre-upgrade hooks, resulting in job recreation rather than in-place patching during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->