### PR TITLE
ci: add cargo audit workflow for dependency vulnerability scanning

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,31 @@
+name: security
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+
+      - name: install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: run cargo audit
+        run: cargo audit


### PR DESCRIPTION
## Summary

- Adds a new `security.yaml` GitHub Actions workflow that runs `cargo audit` on every PR and push to main
- Uses `taiki-e/install-action@v2` for fast pre-built binary installation (no compile-from-source overhead)
- Declares minimal `permissions: contents: read` for least-privilege

## Changes

- **New file**: `.github/workflows/security.yaml`
  - Triggers on push to `main` and PRs targeting `main`
  - Installs `cargo-audit` via pre-built binary
  - Runs `cargo audit` against `Cargo.lock` — fails on any advisory

## Notes

- `cargo audit` exits non-zero on **any** vulnerability, which is stricter than "CVSS >= high" — this is the right default for an IAM project
- `cargo deny check` was intentionally omitted since no `deny.toml` config exists yet (can be added as a follow-up)

Closes #930

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning to the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->