### PR TITLE
ci: add cargo test workflow with PostgreSQL service container

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,73 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+
+      - name: set up rust toolchain
+        id: rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: cache rust build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: test-${{ runner.arch }}-${{ steps.rust.outputs.cachekey }}-${{ hashFiles('Cargo.*', '**/*.rs') }}
+          restore-keys: |
+            test-${{ runner.arch }}-${{ steps.rust.outputs.cachekey }}-
+
+      - name: run unit tests
+        run: cargo test
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: ferriskey
+          POSTGRES_PASSWORD: ferriskey
+          POSTGRES_DB: ferriskey
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+
+      - name: set up rust toolchain
+        id: rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: cache rust build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: test-integration-${{ runner.arch }}-${{ steps.rust.outputs.cachekey }}-${{ hashFiles('Cargo.*', '**/*.rs') }}
+          restore-keys: |
+            test-integration-${{ runner.arch }}-${{ steps.rust.outputs.cachekey }}-
+
+      - name: run integration tests
+        run: cargo test -p ferriskey-api -- --ignored


### PR DESCRIPTION
## Summary

- Adds a new `test.yaml` GitHub Actions workflow that runs `cargo test` on every PR and push to main
- Two parallel jobs: unit tests (no DB) and integration tests (with Postgres service container)
- Integration tests scoped to `ferriskey-api` package with `-- --ignored` flag

## Changes

- **New file**: `.github/workflows/test.yaml`
  - `unit-tests` job: runs `cargo test` (all non-ignored tests)
  - `integration-tests` job: starts PostgreSQL 17 service container, runs `cargo test -p ferriskey-api -- --ignored`
  - Health checks on Postgres container before test execution
  - Build artifact caching via `actions/cache@v4` keyed on toolchain + source hash
  - `permissions: contents: read` for least-privilege

## Notes

- Used `postgres:17` (latest stable) instead of `postgres:18` (not released) from the issue template
- Integration tests use default env vars (DATABASE_HOST=localhost, etc.) which match the Postgres service container config
- Depends on #929 (tests must compile first)

Closes #931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated testing pipeline that runs unit and integration tests on code changes targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->