### PR TITLE
fix: replace .unwrap() with proper error handling in production code

### DIFF
--- a/core/src/domain/realm/services.rs
+++ b/core/src/domain/realm/services.rs
@@ -653,8 +653,11 @@ where
 
             let client_roles = user_roles
                 .iter()
-                .filter(|role| role.client.is_some())
-                .filter(|role| role.client.as_ref().unwrap().name == client_name)
+                .filter(|role| {
+                    role.client
+                        .as_ref()
+                        .is_some_and(|c| c.name == client_name)
+                })
                 .collect::<Vec<_>>();
 
             let mut permissions = HashSet::new();
@@ -932,7 +935,10 @@ where
             password: input.password,
             from_email: input.from_email,
             from_name: input.from_name,
-            encryption: input.encryption.parse().unwrap(),
+            encryption: input
+                .encryption
+                .parse()
+                .expect("invariant: SmtpEncryption FromStr is infallible"),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/core/src/infrastructure/realm/mappers/smtp_config_mapper.rs
+++ b/core/src/infrastructure/realm/mappers/smtp_config_mapper.rs
@@ -16,7 +16,10 @@ impl From<Model> for SmtpConfig {
             password: value.password,
             from_email: value.from_email,
             from_name: value.from_name,
-            encryption: value.encryption.parse().unwrap(),
+            encryption: value
+                .encryption
+                .parse()
+                .expect("invariant: SmtpEncryption FromStr is infallible"),
             created_at,
             updated_at,
         }


### PR DESCRIPTION
## Summary
- Replace 3 production `.unwrap()` calls in `core/src/` with proper alternatives
- Combined `.is_some()` + `.unwrap()` filter chain into `.is_some_and()` in realm services
- Replaced `.parse().unwrap()` with `.parse().expect("invariant: ...")` for infallible `SmtpEncryption` parsing

## Changes
- `core/src/domain/realm/services.rs` — 2 unwrap removals
- `core/src/infrastructure/realm/mappers/smtp_config_mapper.rs` — 1 unwrap removal

## Notes
The issue reports 166 `.unwrap()` calls, but 163 are inside `#[cfg(test)]` blocks (explicitly excluded by acceptance criteria). Only 3 are in production code.

The `SmtpEncryption::FromStr` implementation has `type Err = Infallible` (catch-all defaults to TLS), so `.expect()` documents the invariant rather than preventing a real panic.

## Testing
- All 182 existing unit tests pass (2 pre-existing failures on main unrelated to these changes)
- `cargo clippy -- -D warnings` passes
- `cargo check` passes

Closes #932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality and error handling in realm and SMTP configuration processing through optimized logic patterns and more informative diagnostic messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->