### PR TITLE
feat: add rate limiting middleware to auth endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1550,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1785,6 +1800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1827,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1919,6 +1950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2037,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,7 +2127,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2075,6 +2135,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3161,6 +3226,18 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4966,6 +5043,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5562,8 +5648,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -5572,6 +5660,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -5643,6 +5732,23 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tonic",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0.148"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros"] }
 tower-http = { version = "0.6.8", features = ["cors", "trace"] }
+tower_governor = "0.8.0"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "json"] }
 utoipa = { version = "5.4.0", features = ["chrono", "uuid"] }

--- a/api/src/application/http/authentication/router.rs
+++ b/api/src/application/http/authentication/router.rs
@@ -37,6 +37,14 @@ use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 ))]
 pub struct AuthenticationApiDoc;
 
+/// Build the authentication router with optional per-IP rate limiting on
+/// sensitive endpoints (token, introspect, auth, authenticate).
+///
+/// **Proxy note:** The default key extractor uses the TCP peer IP
+/// (`ConnectInfo<SocketAddr>`). Behind a reverse proxy all clients appear as
+/// the proxy's IP, effectively creating a single global bucket. For
+/// proxy-aware rate limiting, consider switching to `SmartIpKeyExtractor`
+/// which reads `X-Forwarded-For` / `X-Real-Ip` headers.
 pub fn authentication_routes(state: AppState, root_path: &str) -> Router<AppState> {
     let rate_limit_args = &state.args.rate_limit;
 

--- a/api/src/application/http/authentication/router.rs
+++ b/api/src/application/http/authentication/router.rs
@@ -18,6 +18,7 @@ use super::handlers::{
     userinfo::{__path_get_userinfo, get_userinfo},
 };
 use crate::application::{auth::auth, http::server::app_state::AppState};
+use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 
 #[derive(OpenApi)]
 #[openapi(paths(
@@ -37,7 +38,10 @@ use crate::application::{auth::auth, http::server::app_state::AppState};
 pub struct AuthenticationApiDoc;
 
 pub fn authentication_routes(state: AppState, root_path: &str) -> Router<AppState> {
-    Router::new()
+    let rate_limit_args = &state.args.rate_limit;
+
+    // Non-rate-limited routes: userinfo (behind auth middleware), certs, jwks, well-known, logout, revoke, registrations
+    let non_rate_limited = Router::new()
         .route(
             &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/userinfo"),
             get(get_userinfo),
@@ -47,14 +51,6 @@ pub fn authentication_routes(state: AppState, root_path: &str) -> Router<AppStat
             post(get_userinfo),
         )
         .layer(middleware::from_fn_with_state(state.clone(), auth))
-        .route(
-            &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/token"),
-            post(exchange_token),
-        )
-        .route(
-            &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/token/introspect"),
-            post(introspect_token),
-        )
         .route(
             &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/revoke"),
             post(revoke_token),
@@ -68,16 +64,8 @@ pub fn authentication_routes(state: AppState, root_path: &str) -> Router<AppStat
             post(logout_post),
         )
         .route(
-            &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/auth"),
-            get(auth_handler),
-        )
-        .route(
             &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/registrations"),
             post(registration_handler),
-        )
-        .route(
-            &format!("{root_path}/realms/{{realm_name}}/login-actions/authenticate"),
-            post(authenticate),
         )
         .route(
             &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/certs"),
@@ -94,5 +82,40 @@ pub fn authentication_routes(state: AppState, root_path: &str) -> Router<AppStat
         .route(
             &format!("{root_path}/realms/{{realm_name}}/.well-known/openid-configuration"),
             get(get_openid_configuration),
+        );
+
+    // Rate-limited routes: token, introspect, auth, authenticate
+    let rate_limited = Router::new()
+        .route(
+            &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/token"),
+            post(exchange_token),
         )
+        .route(
+            &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/token/introspect"),
+            post(introspect_token),
+        )
+        .route(
+            &format!("{root_path}/realms/{{realm_name}}/protocol/openid-connect/auth"),
+            get(auth_handler),
+        )
+        .route(
+            &format!("{root_path}/realms/{{realm_name}}/login-actions/authenticate"),
+            post(authenticate),
+        );
+
+    // Apply governor layer only if rate limiting is enabled (per_minute > 0)
+    let rate_limited = if rate_limit_args.auth_rate_limit_per_minute > 0 {
+        let replenish_interval_ms =
+            (60_000u64 / rate_limit_args.auth_rate_limit_per_minute).max(1);
+        let config = GovernorConfigBuilder::default()
+            .per_millisecond(replenish_interval_ms)
+            .burst_size(rate_limit_args.auth_rate_limit_burst)
+            .finish()
+            .expect("invariant: replenish_interval_ms >= 1 and burst_size > 0");
+        rate_limited.layer(GovernorLayer::new(config))
+    } else {
+        rate_limited
+    };
+
+    non_rate_limited.merge(rate_limited)
 }

--- a/api/src/args.rs
+++ b/api/src/args.rs
@@ -379,7 +379,8 @@ pub struct RateLimitArgs {
         env = "AUTH_RATE_LIMIT_BURST",
         default_value_t = 10,
         name = "AUTH_RATE_LIMIT_BURST",
-        long_help = "Maximum burst size for rate-limited auth endpoints"
+        long_help = "Maximum burst size for rate-limited auth endpoints",
+        value_parser = clap::value_parser!(u32).range(1..),
     )]
     pub auth_rate_limit_burst: u32,
 }

--- a/api/src/args.rs
+++ b/api/src/args.rs
@@ -72,6 +72,8 @@ pub struct Args {
     pub webapp_url: String,
     #[command(flatten)]
     pub observability: ObservabilityArgs,
+    #[command(flatten)]
+    pub rate_limit: RateLimitArgs,
     #[command(subcommand)]
     pub command: Option<Command>,
 }
@@ -86,6 +88,7 @@ impl Default for Args {
             server: ServerArgs::default(),
             webapp_url: "http://localhost:5555".to_string(),
             observability: ObservabilityArgs::default(),
+            rate_limit: RateLimitArgs::default(),
             command: None,
         }
     }
@@ -357,6 +360,35 @@ impl Default for ObservabilityArgs {
             active_observability: false,
             otlp_endpoint: Some("http://localhost:4317".to_string()),
             metrics_endpoint: Some("http://localhost:4317".to_string()),
+        }
+    }
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct RateLimitArgs {
+    #[arg(
+        long = "auth-rate-limit-per-minute",
+        env = "AUTH_RATE_LIMIT_PER_MINUTE",
+        default_value_t = 30,
+        name = "AUTH_RATE_LIMIT_PER_MINUTE",
+        long_help = "Maximum number of requests per minute for rate-limited auth endpoints"
+    )]
+    pub auth_rate_limit_per_minute: u64,
+    #[arg(
+        long = "auth-rate-limit-burst",
+        env = "AUTH_RATE_LIMIT_BURST",
+        default_value_t = 10,
+        name = "AUTH_RATE_LIMIT_BURST",
+        long_help = "Maximum burst size for rate-limited auth endpoints"
+    )]
+    pub auth_rate_limit_burst: u32,
+}
+
+impl Default for RateLimitArgs {
+    fn default() -> Self {
+        Self {
+            auth_rate_limit_per_minute: 30,
+            auth_rate_limit_burst: 10,
         }
     }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -191,12 +191,12 @@ async fn main() -> Result<(), anyhow::Error> {
         let tls_cfg = RustlsConfig::from_pem_file(tls.cert.clone(), tls.key.clone()).await?;
         info!("listening on {addr}");
         axum_server::bind_rustls(addr, tls_cfg)
-            .serve(router.into_make_service())
+            .serve(router.into_make_service_with_connect_info::<SocketAddr>())
             .await?;
     } else {
         info!("listening on {addr}");
         axum_server::bind(addr)
-            .serve(router.into_make_service())
+            .serve(router.into_make_service_with_connect_info::<SocketAddr>())
             .await?;
     }
     Ok(())

--- a/api/tests/rate_limit_test.rs
+++ b/api/tests/rate_limit_test.rs
@@ -1,0 +1,305 @@
+/// Integration tests for rate limiting on authentication endpoints.
+///
+/// These tests require a running PostgreSQL instance.  They are marked `#[ignore]`
+/// so they do not block regular `cargo test` runs.  Run them explicitly with:
+///
+///   cargo test -p ferriskey-api -- --ignored
+///
+/// Environment variables (defaults shown):
+///   DATABASE_HOST     = localhost
+///   DATABASE_PORT     = 5432
+///   DATABASE_NAME     = ferriskey
+///   DATABASE_USER     = ferriskey
+///   DATABASE_PASSWORD = ferriskey
+#[cfg(test)]
+mod tests {
+    use std::{env, net::SocketAddr, sync::Arc};
+
+    use axum_test::TestServer;
+    use ferriskey_api::{
+        application::http::server::{app_state::AppState, http_server::router},
+        args::{Args, RateLimitArgs},
+    };
+    use ferriskey_core::{
+        application::create_service,
+        domain::common::{
+            DatabaseConfig, FerriskeyConfig, entities::StartupConfig, ports::CoreService,
+        },
+    };
+    use sqlx::Executor;
+    use uuid::Uuid;
+
+    fn env_or(key: &str, default: &str) -> String {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+
+    fn env_u16_or(key: &str, default: u16) -> u16 {
+        env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    struct TestContext {
+        server: TestServer,
+        realm_name: String,
+    }
+
+    /// Build a test server with a very low rate limit so we can trigger 429
+    /// responses quickly. The `auth_rate_limit_per_minute` is set to 2 and
+    /// `auth_rate_limit_burst` to 1, meaning the second rapid-fire request
+    /// to a rate-limited endpoint should already be rejected.
+    async fn setup_with_rate_limit() -> TestContext {
+        let db_host = env_or("DATABASE_HOST", "localhost");
+        let db_port = env_u16_or("DATABASE_PORT", 5432);
+        let db_name = env_or("DATABASE_NAME", "ferriskey");
+        let db_user = env_or("DATABASE_USER", "ferriskey");
+        let db_password = env_or("DATABASE_PASSWORD", "ferriskey");
+
+        let schema = format!("rl_test_{}", Uuid::new_v4().simple());
+
+        let admin_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+
+        let admin_pool = sqlx::PgPool::connect(&admin_url)
+            .await
+            .expect("connect admin pool");
+
+        admin_pool
+            .execute(sqlx::query(&format!(
+                "CREATE SCHEMA IF NOT EXISTS \"{}\"",
+                schema
+            )))
+            .await
+            .expect("create schema");
+
+        let schema_url = format!(
+            "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
+            db_user,
+            db_password,
+            db_host,
+            db_port,
+            db_name,
+            urlencoding::encode(&schema)
+        );
+
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+
+        sqlx::migrate!("../core/migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let service = create_service(FerriskeyConfig {
+            database: DatabaseConfig {
+                host: db_host,
+                port: db_port,
+                username: db_user,
+                password: db_password,
+                name: db_name,
+                schema: schema.clone(),
+            },
+        })
+        .await
+        .expect("create service");
+
+        let realm_name = format!("realm-{}", Uuid::new_v4().simple());
+
+        service
+            .initialize_application(StartupConfig {
+                master_realm_name: realm_name.clone(),
+                admin_username: "admin".to_string(),
+                admin_password: "admin".to_string(),
+                admin_email: "admin@test.local".to_string(),
+                default_client_id: "admin-cli".to_string(),
+            })
+            .await
+            .expect("initialize application");
+
+        let args = Arc::new(Args {
+            rate_limit: RateLimitArgs {
+                auth_rate_limit_per_minute: 2,
+                auth_rate_limit_burst: 1,
+            },
+            ..Args::default()
+        });
+
+        let state = AppState::new(args, service);
+        let app = router(state).expect("build router");
+        let server = TestServer::builder()
+            .http_transport()
+            .build(app.into_make_service_with_connect_info::<SocketAddr>())
+            .expect("create test server");
+
+        TestContext { server, realm_name }
+    }
+
+    // ── Rate-limited endpoint: POST /realms/{realm}/protocol/openid-connect/token ──
+
+    #[tokio::test]
+    #[ignore]
+    async fn token_endpoint_returns_429_when_rate_limit_exceeded() {
+        let ctx = setup_with_rate_limit().await;
+
+        let token_url = format!(
+            "/realms/{}/protocol/openid-connect/token",
+            ctx.realm_name
+        );
+
+        // The first request should succeed (or fail with 400/401 due to missing
+        // credentials — the important thing is it is NOT 429).
+        let first = ctx
+            .server
+            .post(&token_url)
+            .form(&[
+                ("grant_type", "password"),
+                ("client_id", "admin-cli"),
+                ("username", "admin"),
+                ("password", "admin"),
+            ])
+            .await;
+
+        assert_ne!(
+            first.status_code().as_u16(),
+            429,
+            "first request should not be rate-limited"
+        );
+
+        // Fire additional requests to exceed the burst limit. With burst=1 and
+        // rate=2/min the second or third request must be rejected.
+        let mut saw_429 = false;
+        for _ in 0..5 {
+            let resp = ctx
+                .server
+                .post(&token_url)
+                .form(&[
+                    ("grant_type", "password"),
+                    ("client_id", "admin-cli"),
+                    ("username", "admin"),
+                    ("password", "admin"),
+                ])
+                .await;
+
+            if resp.status_code().as_u16() == 429 {
+                saw_429 = true;
+                break;
+            }
+        }
+
+        assert!(
+            saw_429,
+            "expected at least one 429 response after exceeding rate limit"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn token_endpoint_429_includes_retry_after_header() {
+        let ctx = setup_with_rate_limit().await;
+
+        let token_url = format!(
+            "/realms/{}/protocol/openid-connect/token",
+            ctx.realm_name
+        );
+
+        // Exhaust the rate limit.
+        for _ in 0..5 {
+            ctx.server
+                .post(&token_url)
+                .form(&[
+                    ("grant_type", "password"),
+                    ("client_id", "admin-cli"),
+                    ("username", "admin"),
+                    ("password", "admin"),
+                ])
+                .await;
+        }
+
+        // Send one more request that should definitely be rate-limited.
+        let resp = ctx
+            .server
+            .post(&token_url)
+            .form(&[
+                ("grant_type", "password"),
+                ("client_id", "admin-cli"),
+                ("username", "admin"),
+                ("password", "admin"),
+            ])
+            .await;
+
+        assert_eq!(
+            resp.status_code().as_u16(),
+            429,
+            "expected 429 after exhausting rate limit"
+        );
+
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .expect("429 response must include a Retry-After header");
+
+        let retry_secs: u64 = retry_after
+            .to_str()
+            .expect("Retry-After should be valid UTF-8")
+            .parse()
+            .expect("Retry-After should be a numeric value in seconds");
+
+        assert!(
+            retry_secs > 0,
+            "Retry-After must be a positive number of seconds, got {}",
+            retry_secs
+        );
+    }
+
+    // ── Non-rate-limited endpoints ────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[ignore]
+    async fn certs_endpoint_is_not_rate_limited() {
+        let ctx = setup_with_rate_limit().await;
+
+        let certs_url = format!(
+            "/realms/{}/protocol/openid-connect/certs",
+            ctx.realm_name
+        );
+
+        // Fire many requests — they should ALL succeed (200). None should be 429.
+        for i in 0..20 {
+            let resp = ctx.server.get(&certs_url).await;
+            assert_eq!(
+                resp.status_code().as_u16(),
+                200,
+                "certs request #{} was unexpectedly rate-limited or failed with status {}",
+                i + 1,
+                resp.status_code()
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn well_known_openid_configuration_is_not_rate_limited() {
+        let ctx = setup_with_rate_limit().await;
+
+        let well_known_url = format!(
+            "/realms/{}/.well-known/openid-configuration",
+            ctx.realm_name
+        );
+
+        // Fire many requests — they should ALL succeed (200). None should be 429.
+        for i in 0..20 {
+            let resp = ctx.server.get(&well_known_url).await;
+            assert_eq!(
+                resp.status_code().as_u16(),
+                200,
+                "well-known request #{} was unexpectedly rate-limited or failed with status {}",
+                i + 1,
+                resp.status_code()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add per-IP rate limiting via `tower-governor` to sensitive auth endpoints (`/token`, `/token/introspect`, `/auth`, `/login-actions/authenticate`)
- Non-sensitive endpoints (`/certs`, `/jwks.json`, `/.well-known/openid-configuration`) remain unbounded
- Configurable via `AUTH_RATE_LIMIT_PER_MINUTE` (default: 30) and `AUTH_RATE_LIMIT_BURST` (default: 10) env vars
- Returns `429 Too Many Requests` with `Retry-After` header when limit exceeded
- Set `AUTH_RATE_LIMIT_PER_MINUTE=0` to disable rate limiting entirely

## Changes

### `api/Cargo.toml`
- Added `tower_governor = "0.8.0"` dependency

### `api/src/args.rs`
- Added `RateLimitArgs` struct with `auth_rate_limit_per_minute` and `auth_rate_limit_burst` fields
- Wired into `Args` via `#[command(flatten)]`

### `api/src/application/http/authentication/router.rs`
- Split auth router into rate-limited and non-rate-limited sub-groups
- Rate-limited group gets `GovernorLayer` applied; non-rate-limited group remains unbounded
- Governor config uses `per_millisecond` for precise rate calculation with `.max(1)` safety guard

### `api/src/main.rs`
- Changed both TLS and non-TLS serve paths from `into_make_service()` to `into_make_service_with_connect_info::<SocketAddr>()` for peer IP extraction

### `api/tests/rate_limit_test.rs` (new)
- 4 integration tests: 429 enforcement, Retry-After header, certs not rate-limited, well-known not rate-limited

## Testing

- All 4 integration tests compile and list correctly
- Full unit test suite: 182 passed, 2 pre-existing failures (unrelated mock expectations on main)
- `cargo clippy -p ferriskey-api -- -D warnings` passes

Closes #933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to authentication endpoints to manage traffic and protect against abuse.

* **Configuration**
  * New CLI flags/env vars to configure auth rate limit and burst (defaults: 30 requests/minute, burst size 10).

* **Tests**
  * Added integration tests verifying rate limiting behavior and ensuring non-rate-limited endpoints remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->