### PR TITLE
perf(role): drop redundant to_string in permission mapper

### DIFF
--- a/core/src/infrastructure/role/mapper.rs
+++ b/core/src/infrastructure/role/mapper.rs
@@ -10,7 +10,7 @@ impl From<Model> for Role {
         let permissions = Permissions::from_bitfield(model.permissions as u64);
         let permissions = permissions
             .iter()
-            .map(|p| p.name().to_string())
+            .map(|p| p.name())
             .collect::<Vec<String>>();
 
         Role {


### PR DESCRIPTION
## Summary

Closes #944.

`Permissions::name()` already returns an owned `String` (see `core/src/domain/role/entities/permission.rs:85`), so `.to_string()` on the result was cloning each permission name a second time. Dropping the `.to_string()` keeps the same `Vec<String>` shape without the extra allocation.

## Changes

`core/src/infrastructure/role/mapper.rs` - one-line change inside `impl From<Model> for Role`:

```rust
-            .map(|p| p.name().to_string())
+            .map(|p| p.name())
```

## Verification

- `cargo check -p ferriskey-core` - clean
- `.collect::<Vec<String>>()` type still matches because `name()` returns `String`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to permission handling that improves code efficiency without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->