### PR TITLE
refactor: change RealmRepository query methods from String to &str

### DIFF
--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -363,7 +363,7 @@ impl ApplicationService {
         let realm = self
             .realm_service
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -383,7 +383,7 @@ impl ApplicationService {
         let realm = self
             .realm_service
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 

--- a/core/src/domain/abyss/broker_services.rs
+++ b/core/src/domain/abyss/broker_services.rs
@@ -345,7 +345,7 @@ where
     ) -> Result<BrokerLoginOutput, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 

--- a/core/src/domain/abyss/federation/services.rs
+++ b/core/src/domain/abyss/federation/services.rs
@@ -84,7 +84,7 @@ where
     ) -> Result<FederationProvider, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         let realm_id = realm.id;
@@ -111,7 +111,7 @@ where
     ) -> Result<FederationProvider, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -145,7 +145,7 @@ where
     ) -> Result<FederationProvider, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -178,7 +178,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -213,7 +213,7 @@ where
     ) -> Result<Vec<FederationProvider>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 

--- a/core/src/domain/abyss/identity_provider_services.rs
+++ b/core/src/domain/abyss/identity_provider_services.rs
@@ -82,7 +82,7 @@ where
         // Resolve realm by name
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -142,7 +142,7 @@ where
         // Resolve realm by name
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -180,7 +180,7 @@ where
         // Resolve realm by name
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -223,7 +223,7 @@ where
         // Resolve realm by name
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -277,7 +277,7 @@ where
         // Resolve realm by name
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 

--- a/core/src/domain/aegis/services/client_scope_service.rs
+++ b/core/src/domain/aegis/services/client_scope_service.rs
@@ -87,7 +87,7 @@ where
     ) -> Result<ClientScope, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -127,7 +127,7 @@ where
     ) -> Result<ClientScope, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -167,7 +167,7 @@ where
     ) -> Result<Vec<ClientScope>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -209,7 +209,7 @@ where
     ) -> Result<ClientScope, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -243,7 +243,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/domain/aegis/services/protocol_mapper_service.rs
+++ b/core/src/domain/aegis/services/protocol_mapper_service.rs
@@ -78,7 +78,7 @@ where
     ) -> Result<ProtocolMapper, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -113,7 +113,7 @@ where
     ) -> Result<ProtocolMapper, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -143,7 +143,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/domain/aegis/services/scope_mapping_service.rs
+++ b/core/src/domain/aegis/services/scope_mapping_service.rs
@@ -89,7 +89,7 @@ where
     ) -> Result<ClientScopeMapping, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -134,7 +134,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -167,7 +167,7 @@ where
     ) -> Result<Vec<ClientScope>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -1299,7 +1299,7 @@ where
     ) -> Result<AuthenticationResult, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -1764,7 +1764,7 @@ where
     async fn auth(&self, input: AuthInput) -> Result<AuthOutput, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -1852,7 +1852,7 @@ where
     async fn get_certs(&self, realm_name: String) -> Result<Vec<JwkKey>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -1889,7 +1889,7 @@ where
 
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .instrument(info_span!("auth.exchange_token.realm_lookup"))
             .await?
             .ok_or(CoreError::InvalidRealm)?;
@@ -2064,7 +2064,7 @@ where
 
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -2096,7 +2096,7 @@ where
     ) -> Result<JwtToken, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -2188,7 +2188,7 @@ where
 
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -2259,7 +2259,7 @@ where
     async fn revoke_token(&self, input: RevokeTokenInput) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -2313,7 +2313,7 @@ where
     async fn end_session(&self, input: EndSessionInput) -> Result<EndSessionOutput, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 

--- a/core/src/domain/client/services.rs
+++ b/core/src/domain/client/services.rs
@@ -135,7 +135,7 @@ where
     ) -> Result<Client, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -229,7 +229,7 @@ where
     ) -> Result<RedirectUri, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -267,7 +267,7 @@ where
     ) -> Result<RedirectUri, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -305,7 +305,7 @@ where
     ) -> Result<Role, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -358,7 +358,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -408,7 +408,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -445,7 +445,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -482,7 +482,7 @@ where
     ) -> Result<Client, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -505,7 +505,7 @@ where
     ) -> Result<Vec<Role>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -528,7 +528,7 @@ where
     ) -> Result<Vec<Client>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -552,7 +552,7 @@ where
     ) -> Result<Vec<RedirectUri>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -575,7 +575,7 @@ where
     ) -> Result<Vec<RedirectUri>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -598,7 +598,7 @@ where
     ) -> Result<Client, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -636,7 +636,7 @@ where
     ) -> Result<RedirectUri, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -674,7 +674,7 @@ where
     ) -> Result<RedirectUri, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/domain/common/services.rs
+++ b/core/src/domain/common/services.rs
@@ -105,7 +105,7 @@ where
     ) -> Result<InitializationResult, CoreError> {
         let realm = match self
             .realm_repository
-            .get_by_name(config.master_realm_name.clone())
+            .get_by_name(&config.master_realm_name)
             .await
         {
             Ok(Some(realm)) => {

--- a/core/src/domain/compass/services.rs
+++ b/core/src/domain/compass/services.rs
@@ -74,7 +74,7 @@ where
     ) -> Result<Vec<CompassFlow>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -101,7 +101,7 @@ where
     ) -> Result<CompassFlow, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -134,7 +134,7 @@ where
     ) -> Result<FlowStats, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/domain/credential/services.rs
+++ b/core/src/domain/credential/services.rs
@@ -66,7 +66,7 @@ where
     ) -> Result<Vec<CredentialOverview>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -95,7 +95,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/domain/email_template/services.rs
+++ b/core/src/domain/email_template/services.rs
@@ -77,7 +77,7 @@ where
     ) -> Result<Vec<EmailTemplate>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -98,7 +98,7 @@ where
     ) -> Result<EmailTemplate, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -120,7 +120,7 @@ where
     ) -> Result<EmailTemplate, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -156,7 +156,7 @@ where
     ) -> Result<EmailTemplate, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -192,7 +192,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 

--- a/core/src/domain/maintenance/services.rs
+++ b/core/src/domain/maintenance/services.rs
@@ -104,7 +104,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -234,7 +234,7 @@ where
     ) -> Result<MaintenanceWhitelistEntry, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         ensure_policy(
@@ -255,7 +255,7 @@ where
     ) -> Result<MaintenanceWhitelistEntry, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         ensure_policy(
@@ -276,7 +276,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         ensure_policy(
@@ -294,7 +294,7 @@ where
     ) -> Result<Vec<MaintenanceWhitelistEntry>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         ensure_policy(
@@ -314,7 +314,7 @@ where
     ) -> Result<RealmMaintenanceWhitelistEntry, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         ensure_policy(
@@ -334,7 +334,7 @@ where
     ) -> Result<RealmMaintenanceWhitelistEntry, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         ensure_policy(
@@ -354,7 +354,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         ensure_policy(
@@ -373,7 +373,7 @@ where
     ) -> Result<Vec<RealmMaintenanceWhitelistEntry>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
         ensure_policy(

--- a/core/src/domain/organization/services.rs
+++ b/core/src/domain/organization/services.rs
@@ -77,7 +77,7 @@ where
         realm_name: String,
     ) -> Result<crate::domain::realm::entities::Realm, CoreError> {
         self.realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)

--- a/core/src/domain/realm/ports.rs
+++ b/core/src/domain/realm/ports.rs
@@ -117,7 +117,7 @@ pub trait RealmRepository: Send + Sync {
 
     fn get_by_name(
         &self,
-        name: String,
+        name: &str,
     ) -> impl Future<Output = Result<Option<Realm>, CoreError>> + Send;
 
     fn get_by_id(
@@ -132,7 +132,7 @@ pub trait RealmRepository: Send + Sync {
         realm_name: String,
         name: String,
     ) -> impl Future<Output = Result<Realm, CoreError>> + Send;
-    fn delete_by_name(&self, name: String) -> impl Future<Output = Result<(), CoreError>> + Send;
+    fn delete_by_name(&self, name: &str) -> impl Future<Output = Result<(), CoreError>> + Send;
 
     fn create_realm_settings(
         &self,

--- a/core/src/domain/realm/services.rs
+++ b/core/src/domain/realm/services.rs
@@ -292,7 +292,7 @@ where
     ) -> Result<Realm, CoreError> {
         let realm_master = self
             .realm_repository
-            .get_by_name("master".to_string())
+            .get_by_name("master")
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -456,7 +456,7 @@ where
 
         let realm_master = self
             .realm_repository
-            .get_by_name("master".to_string())
+            .get_by_name("master")
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -518,13 +518,13 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
         let realm_master = self
             .realm_repository
-            .get_by_name("master".into())
+            .get_by_name("master")
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -552,7 +552,7 @@ where
             .await?;
 
         self.realm_repository
-            .delete_by_name(input.realm_name)
+            .delete_by_name(&input.realm_name)
             .await?;
 
         self.client_repository.delete_by_id(client.id).await?;
@@ -575,7 +575,7 @@ where
     ) -> Result<Realm, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -603,7 +603,7 @@ where
     ) -> Result<RealmSetting, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -638,7 +638,7 @@ where
 
         let realm = user.realm.clone().ok_or(CoreError::InternalServerError)?;
         self.realm_repository
-            .get_by_name(realm.name)
+            .get_by_name(&realm.name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -701,7 +701,7 @@ where
     ) -> Result<Realm, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name.clone())
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -745,7 +745,7 @@ where
     ) -> Result<Realm, CoreError> {
         let mut realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -801,7 +801,7 @@ where
     async fn get_login_settings(&self, realm_name: String) -> Result<RealmLoginSetting, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -884,7 +884,7 @@ where
     ) -> Result<SmtpConfig, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -914,7 +914,7 @@ where
     ) -> Result<SmtpConfig, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -955,7 +955,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -1036,7 +1036,7 @@ mod tests {
             Arc::get_mut(&mut self.realm_repo)
                 .unwrap()
                 .expect_get_by_name()
-                .with(mockall::predicate::eq("master".to_string()))
+                .with(mockall::predicate::eq("master"))
                 .times(1)
                 .return_once(move |_| Box::pin(async move { Ok(Some(master_realm)) }));
             self
@@ -1047,7 +1047,7 @@ mod tests {
             Arc::get_mut(&mut self.realm_repo)
                 .unwrap()
                 .expect_get_by_name()
-                .with(mockall::predicate::eq("master".to_string()))
+                .with(mockall::predicate::eq("master"))
                 .times(2)
                 .returning(move |_| {
                     let realm = master_realm_clone.clone();

--- a/core/src/domain/role/services.rs
+++ b/core/src/domain/role/services.rs
@@ -87,7 +87,7 @@ where
     ) -> Result<Role, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -141,7 +141,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InternalServerError)?;
@@ -182,7 +182,7 @@ where
     ) -> Result<Role, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InternalServerError)?;
@@ -206,7 +206,7 @@ where
     ) -> Result<Vec<Role>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InternalServerError)?;
@@ -230,7 +230,7 @@ where
     ) -> Result<Vec<Role>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InternalServerError)?;
@@ -253,7 +253,7 @@ where
     ) -> Result<Role, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InternalServerError)?;
@@ -299,7 +299,7 @@ where
     ) -> Result<Role, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InternalServerError)?;
@@ -392,7 +392,7 @@ mod tests {
             Arc::get_mut(&mut self.realm_repo)
                 .unwrap()
                 .expect_get_by_name()
-                .with(eq(realm_name.to_string()))
+                .with(eq(realm_name))
                 .times(1)
                 .return_once(move |_| Box::pin(async move { Ok(Some(realm)) }));
 
@@ -403,7 +403,7 @@ mod tests {
             Arc::get_mut(&mut self.realm_repo)
                 .unwrap()
                 .expect_get_by_name()
-                .with(eq(realm_name.to_string()))
+                .with(eq(realm_name))
                 .times(1)
                 .return_once(move |_| Box::pin(async move { Ok(None) }));
 

--- a/core/src/domain/seawatch/services.rs
+++ b/core/src/domain/seawatch/services.rs
@@ -65,7 +65,7 @@ where
     ) -> Result<Vec<SecurityEvent>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -730,7 +730,7 @@ where
 
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -810,7 +810,7 @@ where
 
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -1091,7 +1091,7 @@ where
     async fn generate_magic_link(&self, input: MagicLinkInput) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -1386,7 +1386,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/domain/user/services.rs
+++ b/core/src/domain/user/services.rs
@@ -133,7 +133,7 @@ where
     ) -> Result<u64, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -181,7 +181,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -244,7 +244,7 @@ where
     ) -> Result<User, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -306,7 +306,7 @@ where
     ) -> Result<Vec<User>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -330,7 +330,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -384,7 +384,7 @@ where
     ) -> Result<u64, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -434,7 +434,7 @@ where
     ) -> Result<User, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -489,7 +489,7 @@ where
     async fn get_user(&self, identity: Identity, input: GetUserInput) -> Result<User, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -511,7 +511,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -565,7 +565,7 @@ where
     ) -> Result<Vec<Permissions>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -604,7 +604,7 @@ where
     ) -> Result<Vec<UserAttribute>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -635,7 +635,7 @@ where
 
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
@@ -662,7 +662,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 

--- a/core/src/domain/user/services/user_role_service.rs
+++ b/core/src/domain/user/services/user_role_service.rs
@@ -69,7 +69,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(realm_name)
+            .get_by_name(&realm_name)
             .await
             .map_err(|_| CoreError::InternalServerError)?
             .ok_or(CoreError::InternalServerError)?;

--- a/core/src/domain/webhook/services.rs
+++ b/core/src/domain/webhook/services.rs
@@ -71,7 +71,7 @@ where
     ) -> Result<Vec<Webhook>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -97,7 +97,7 @@ where
     ) -> Result<Vec<Webhook>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -123,7 +123,7 @@ where
     ) -> Result<Option<Webhook>, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -149,7 +149,7 @@ where
     ) -> Result<Webhook, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -194,7 +194,7 @@ where
     ) -> Result<Webhook, CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;
@@ -239,7 +239,7 @@ where
     ) -> Result<(), CoreError> {
         let realm = self
             .realm_repository
-            .get_by_name(input.realm_name)
+            .get_by_name(&input.realm_name)
             .await
             .map_err(|_| CoreError::InvalidRealm)?
             .ok_or(CoreError::InvalidRealm)?;

--- a/core/src/infrastructure/realm/repositories/realm_postgres_repository.rs
+++ b/core/src/infrastructure/realm/repositories/realm_postgres_repository.rs
@@ -41,7 +41,7 @@ impl RealmRepository for PostgresRealmRepository {
         Ok(realms)
     }
 
-    async fn get_by_name(&self, name: String) -> Result<Option<Realm>, CoreError> {
+    async fn get_by_name(&self, name: &str) -> Result<Option<Realm>, CoreError> {
         info_span!("Fetching realm by name", name = name);
         let realm_model = RealmEntity::find()
             .filter(crate::entity::realms::Column::Name.eq(name))
@@ -126,7 +126,7 @@ impl RealmRepository for PostgresRealmRepository {
         Ok(updated_realm)
     }
 
-    async fn delete_by_name(&self, name: String) -> Result<(), CoreError> {
+    async fn delete_by_name(&self, name: &str) -> Result<(), CoreError> {
         let res = RealmEntity::delete_many()
             .filter(crate::entity::realms::Column::Name.eq(name))
             .exec(&self.db)


### PR DESCRIPTION
## Summary

`RealmRepository::get_by_name` and `delete_by_name` accepted owned `String`. Every caller was forced to allocate even when a `&str` was already available. This PR changes both signatures to `&str`, removing the allocation requirement across 12 domain modules.

## Why this matters

The issue (#943) identified unnecessary allocations in query-path methods. `get_by_name` is called on nearly every authenticated request to resolve the realm. Accepting `&str` lets callers pass borrowed strings directly (most already had a `String` field they were moving into the call). SQLx's `.bind()` accepts `&str` natively, so the Postgres implementation needs no internal conversion.

## Changes

- `core/src/domain/realm/ports.rs` - trait signatures
- `core/src/infrastructure/realm/repositories/realm_postgres_repository.rs` - implementation
- 22 caller files across application, authentication, client, credential, organization, webhook, role, user, maintenance, aegis, abyss, compass, email_template, seawatch, and trident service modules
- Mock expectations updated for `&str` matchers in realm and role service tests

24 files changed, 123 insertions(+), 123 deletions(-). Pure refactor, no behavioral changes.

## Testing

`cargo check -p ferriskey-core` passes with zero errors. All mock expectations updated to match `&str` parameter type.

Fixes #943

This contribution was developed with AI assistance (Codex).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized core application services for improved efficiency through enhanced parameter handling across realm operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->