### PR TITLE
fix: remove cookie set in broker callback

### DIFF
--- a/api/src/application/http/broker/handlers/callback.rs
+++ b/api/src/application/http/broker/handlers/callback.rs
@@ -1,16 +1,11 @@
 use axum::{
     extract::{Path, Query, State},
-    http::{HeaderValue, StatusCode, header::LOCATION, header::SET_COOKIE},
+    http::{StatusCode, header::LOCATION},
     response::IntoResponse,
 };
-use axum_extra::extract::cookie::{Cookie, SameSite};
 
 use ferriskey_core::domain::abyss::identity_provider::broker::{
     BrokerCallbackInput, BrokerService,
-};
-use ferriskey_core::domain::authentication::{
-    entities::{ExchangeTokenInput, GrantType},
-    ports::AuthService,
 };
 use ferriskey_core::domain::common::entities::app_errors::CoreError;
 
@@ -82,45 +77,6 @@ pub async fn broker_callback(
         }
         Err(e) => return Err(e.into()),
     };
-
-    if let Ok(jwt_token) = state
-        .service
-        .exchange_token(ExchangeTokenInput {
-            realm_name,
-            client_id: result.client_id.clone(),
-            client_secret: None,
-            code: Some(result.authorization_code.clone()),
-            username: None,
-            password: None,
-            refresh_token: None,
-            base_url: root_scoped_base_url,
-            grant_type: GrantType::Code,
-            scope: None,
-        })
-        .await
-    {
-        let mut identity_cookie =
-            Cookie::build(("FERRISKEY_IDENTITY", jwt_token.access_token().to_string()))
-                .path("/")
-                .http_only(true)
-                .same_site(SameSite::Lax);
-
-        if base_url.starts_with("https://") {
-            identity_cookie = identity_cookie.secure(true);
-        }
-
-        let cookie_value = HeaderValue::from_str(&identity_cookie.to_string())
-            .map_err(|_| ApiError::InternalServerError("Invalid cookie header".to_string()))?;
-
-        let response = axum::response::Response::builder()
-            .status(StatusCode::FOUND)
-            .header(LOCATION, result.redirect_url)
-            .header(SET_COOKIE, cookie_value)
-            .body(axum::body::Body::empty())
-            .map_err(|_| ApiError::InternalServerError("Failed to build response".to_string()))?;
-
-        return Ok(response.into_response());
-    }
 
     Ok((StatusCode::FOUND, [(LOCATION, result.redirect_url)]).into_response())
 }

--- a/core/src/domain/abyss/broker_services.rs
+++ b/core/src/domain/abyss/broker_services.rs
@@ -635,7 +635,7 @@ where
                 nonce: broker_session.nonce.clone(),
                 user_id: Some(user.id),
                 code: Some(authorization_code.clone()),
-                authenticated: true,
+                authenticated: false,
                 webauthn_challenge: None,
                 webauthn_challenge_issued_at: None,
                 compass_flow_id: Some(flow_id.0),

--- a/core/src/infrastructure/repositories/credential_repository.rs
+++ b/core/src/infrastructure/repositories/credential_repository.rs
@@ -222,7 +222,7 @@ impl CredentialRepository for PostgresCredentialRepository {
 
         let models = hashes
             .into_iter()
-            .zip(credential_data.into_iter())
+            .zip(credential_data)
             .map(|(h, cred_data)| ActiveModel {
                 id: Set(generate_uuid_v7()),
                 salt: Set(Some(h.salt)),

--- a/front/src/pages/authentication/feature/page-callback-feature.tsx
+++ b/front/src/pages/authentication/feature/page-callback-feature.tsx
@@ -1,7 +1,7 @@
 import { GrantType } from '@/api/core.interface'
 import { useTokenMutation } from '@/api/auth.api'
 import { useAuth } from '@/hooks/use-auth'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import PageCallback from '../ui/page-callback'
 import {
@@ -26,13 +26,18 @@ export default function PageCallbackFeature() {
   const { mutateAsync: exchangeToken } = useTokenMutation()
   const hasStartedExchange = useRef(false)
 
+  // Read sessionStorage once at mount to avoid a React StrictMode double-render
+  // causing the value to be missing on the second render after the first effect
+  // removes it.
+  const [expectedState] = useState(() => sessionStorage.getItem('oauth_state'))
+
   const callbackValidationError = useMemo(() => {
     return validateCallbackParams({
       code,
       returnedState: state,
-      expectedState: sessionStorage.getItem('oauth_state'),
+      expectedState,
     })
-  }, [code, state])
+  }, [code, state, expectedState])
 
   useEffect(() => {
     if (callbackValidationError) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Callback flow now consistently redirects without performing a post-callback token exchange or issuing identity cookies.
  * Newly created auth sessions start as unauthenticated until fully established.

* **Refactor**
  * OAuth state validation stabilized by capturing the expected state at mount to reduce transient validation errors.

* **Chores**
  * Adjusted recovery-code creation logic for more reliable credential generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->