### PR TITLE
refactor(api): use Cow<'static, str> for ApiError static messages

### DIFF
--- a/api/src/application/http/abyss/federation/handlers/create_provider.rs
+++ b/api/src/application/http/abyss/federation/handlers/create_provider.rs
@@ -55,8 +55,9 @@ pub async fn create_provider(
         s => FederationType::Custom(s.to_string()),
     };
 
-    let _sync_mode = SyncMode::from_str(&payload.sync_mode)
-        .map_err(|_| ApiError::BadRequest(format!("Invalid sync mode: {}", payload.sync_mode)))?;
+    let _sync_mode = SyncMode::from_str(&payload.sync_mode).map_err(|_| {
+        ApiError::BadRequest(format!("Invalid sync mode: {}", payload.sync_mode).into())
+    })?;
 
     // 2. Construct Core Request
     let sync_settings = serde_json::json!({

--- a/api/src/application/http/abyss/federation/handlers/update_provider.rs
+++ b/api/src/application/http/abyss/federation/handlers/update_provider.rs
@@ -71,7 +71,7 @@ pub async fn update_provider(
         let mode_str = payload.sync_mode.clone().unwrap_or("LinkOnly".to_string()); // Clone because we consume payload
 
         let _ = SyncMode::from_str(&mode_str)
-            .map_err(|_| ApiError::BadRequest(format!("Invalid sync mode: {}", mode_str)))?;
+            .map_err(|_| ApiError::BadRequest(format!("Invalid sync mode: {}", mode_str).into()))?;
 
         let interval = payload.sync_interval_minutes; // Option<i32>
 

--- a/api/src/application/http/authentication/handlers/auth.rs
+++ b/api/src/application/http/authentication/handlers/auth.rs
@@ -184,7 +184,7 @@ pub async fn auth_handler(
     }
 
     let session_cookie_value = HeaderValue::from_str(&session_cookie.to_string())
-        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".to_string()))?;
+        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".into()))?;
 
     let mut headers = HeaderMap::new();
     headers.insert(SET_COOKIE, session_cookie_value);
@@ -202,7 +202,7 @@ pub async fn auth_handler(
         }
 
         let clear_identity_cookie_value = HeaderValue::from_str(&clear_identity_cookie.to_string())
-            .map_err(|_| ApiError::InternalServerError("Invalid cookie header".to_string()))?;
+            .map_err(|_| ApiError::InternalServerError("Invalid cookie header".into()))?;
         headers.append(SET_COOKIE, clear_identity_cookie_value);
     }
 
@@ -217,7 +217,7 @@ pub async fn auth_handler(
 
     let axum_response = response_builder
         .body(axum::body::Body::empty())
-        .map_err(|_| ApiError::InternalServerError("Failed to build response".to_string()))?;
+        .map_err(|_| ApiError::InternalServerError("Failed to build response".into()))?;
 
     Ok(axum_response.into_response())
 }

--- a/api/src/application/http/authentication/handlers/authentificate.rs
+++ b/api/src/application/http/authentication/handlers/authentificate.rs
@@ -118,12 +118,12 @@ pub async fn authenticate(
 ) -> Result<impl IntoResponse, ApiError> {
     let session_code = match cookie.get("FERRISKEY_SESSION") {
         Some(cookie) => cookie,
-        None => return Err(ApiError::Unauthorized("Missing session cookie".to_string())),
+        None => return Err(ApiError::Unauthorized("Missing session cookie".into())),
     };
     let session_code = session_code.value().to_string();
 
     let session_code = Uuid::parse_str(&session_code)
-        .map_err(|_| ApiError::BadRequest("Invalid session code in cookie".to_string()))?;
+        .map_err(|_| ApiError::BadRequest("Invalid session code in cookie".into()))?;
 
     let base_url = root_scoped_base_url(&base_url, &state.args.server.root_path);
 
@@ -139,11 +139,11 @@ pub async fn authenticate(
         let username = payload
             .username
             .clone()
-            .ok_or_else(|| ApiError::BadRequest("username is required".to_string()))?;
+            .ok_or_else(|| ApiError::BadRequest("username is required".into()))?;
         let password = payload
             .password
             .clone()
-            .ok_or_else(|| ApiError::BadRequest("password is required".to_string()))?;
+            .ok_or_else(|| ApiError::BadRequest("password is required".into()))?;
 
         AuthenticateInput::with_user_credentials(
             realm_name.clone(),

--- a/api/src/application/http/authentication/handlers/introspect.rs
+++ b/api/src/application/http/authentication/handlers/introspect.rs
@@ -64,12 +64,12 @@ pub async fn introspect_token(
     let (client_id, client_secret) = match try_parse_basic_client_credentials(&headers) {
         Some(creds) => creds,
         None => {
-            let client_id = payload.client_id.ok_or_else(|| {
-                ApiError::Unauthorized("Missing client authentication".to_string())
-            })?;
-            let client_secret = payload.client_secret.ok_or_else(|| {
-                ApiError::Unauthorized("Missing client authentication".to_string())
-            })?;
+            let client_id = payload
+                .client_id
+                .ok_or_else(|| ApiError::Unauthorized("Missing client authentication".into()))?;
+            let client_secret = payload
+                .client_secret
+                .ok_or_else(|| ApiError::Unauthorized("Missing client authentication".into()))?;
 
             (client_id, client_secret)
         }

--- a/api/src/application/http/authentication/handlers/logout.rs
+++ b/api/src/application/http/authentication/handlers/logout.rs
@@ -50,9 +50,9 @@ fn clear_session_cookies_headers(base_url: &str) -> Result<HeaderMap, ApiError> 
     }
 
     let clear_session_cookie_value = HeaderValue::from_str(&clear_session_cookie.to_string())
-        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".to_string()))?;
+        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".into()))?;
     let clear_identity_cookie_value = HeaderValue::from_str(&clear_identity_cookie.to_string())
-        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".to_string()))?;
+        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".into()))?;
 
     let mut headers = HeaderMap::new();
     headers.append(SET_COOKIE, clear_session_cookie_value);

--- a/api/src/application/http/authentication/handlers/registration.rs
+++ b/api/src/application/http/authentication/handlers/registration.rs
@@ -59,7 +59,7 @@ pub async fn registration_handler(
     let settings = state.service.get_login_settings(realm_name.clone()).await?;
 
     if !settings.user_registration_enabled {
-        return Err(ApiError::Forbidden("registration disabled".to_string()));
+        return Err(ApiError::Forbidden("registration disabled".into()));
     }
 
     let url = root_scoped_base_url(&url, &state.args.server.root_path);

--- a/api/src/application/http/authentication/handlers/token.rs
+++ b/api/src/application/http/authentication/handlers/token.rs
@@ -108,7 +108,7 @@ pub async fn exchange_token(
     }
 
     let cookie_value = HeaderValue::from_str(&identity_cookie.to_string())
-        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".to_string()))?;
+        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".into()))?;
 
     Ok((
         StatusCode::OK,

--- a/api/src/application/http/authentication/handlers/userinfo.rs
+++ b/api/src/application/http/authentication/handlers/userinfo.rs
@@ -37,7 +37,7 @@ pub async fn get_userinfo(
     Extension(identity): Extension<Identity>,
     OptionalToken(jwt): OptionalToken,
 ) -> Result<Response<UserInfoResponse>, ApiError> {
-    let jwt = jwt.ok_or(ApiError::Unauthorized("not authorized".to_string()))?;
+    let jwt = jwt.ok_or(ApiError::Unauthorized("not authorized".into()))?;
     let user_info = state
         .service
         .get_userinfo(

--- a/api/src/application/http/error.rs
+++ b/api/src/application/http/error.rs
@@ -6,223 +6,223 @@ use crate::application::http::server::api_entities::api_error::ApiError;
 impl From<CoreError> for ApiError {
     fn from(error: CoreError) -> Self {
         match error {
-            CoreError::NotFound => Self::NotFound("Resource not found".to_string()),
-            CoreError::AlreadyExists => Self::BadRequest("Resource already exists".to_string()),
+            CoreError::NotFound => Self::NotFound("Resource not found".into()),
+            CoreError::AlreadyExists => Self::BadRequest("Resource already exists".into()),
             CoreError::EmailAlreadyExists => {
-                Self::BadRequest("Email already exists in this realm".to_string())
+                Self::BadRequest("Email already exists in this realm".into())
             }
-            CoreError::Invalid => Self::BadRequest("Invalid resource".to_string()),
+            CoreError::Invalid => Self::BadRequest("Invalid resource".into()),
             CoreError::InvalidRequiredAction(action) => {
                 let allowed = RequiredAction::allowed_values().join(", ");
                 Self::BadRequest(format!(
                     "Invalid required action: {}. Allowed values: {}",
                     action, allowed
-                ))
+                ).into())
             }
-            CoreError::Forbidden(msg) => Self::Forbidden(msg),
+            CoreError::Forbidden(msg) => Self::Forbidden(msg.into()),
             CoreError::InternalServerError => {
-                        Self::InternalServerError("Internal server error".to_string())
+                        Self::InternalServerError("Internal server error".into())
                     }
-            CoreError::RedirectUriNotFound => Self::NotFound("Redirect URI not found".to_string()),
-            CoreError::InvalidRedirectUri => Self::BadRequest("Invalid redirect URI".to_string()),
-            CoreError::InvalidClient => Self::Unauthorized("Invalid client".to_string()),
-            CoreError::InvalidRealm => Self::Unauthorized("Invalid realm".to_string()),
-            CoreError::InvalidUser => Self::Unauthorized("Invalid user".to_string()),
-            CoreError::InvalidPassword => Self::Unauthorized("Invalid password".to_string()),
-            CoreError::InvalidState => Self::BadRequest("Invalid state".to_string()),
+            CoreError::RedirectUriNotFound => Self::NotFound("Redirect URI not found".into()),
+            CoreError::InvalidRedirectUri => Self::BadRequest("Invalid redirect URI".into()),
+            CoreError::InvalidClient => Self::Unauthorized("Invalid client".into()),
+            CoreError::InvalidRealm => Self::Unauthorized("Invalid realm".into()),
+            CoreError::InvalidUser => Self::Unauthorized("Invalid user".into()),
+            CoreError::InvalidPassword => Self::Unauthorized("Invalid password".into()),
+            CoreError::InvalidState => Self::BadRequest("Invalid state".into()),
             CoreError::InvalidRefreshToken => {
-                        Self::Unauthorized("Invalid refresh token".to_string())
+                        Self::Unauthorized("Invalid refresh token".into())
                     }
             CoreError::InvalidClientSecret => {
-                        Self::Unauthorized("Invalid client secret".to_string())
+                        Self::Unauthorized("Invalid client secret".into())
                     }
             CoreError::InvalidRequest => {
-                        Self::BadRequest("Invalid authorization request".to_string())
+                        Self::BadRequest("Invalid authorization request".into())
                     }
             CoreError::ServiceAccountNotFound => {
-                        Self::NotFound("Service account not found".to_string())
+                        Self::NotFound("Service account not found".into())
                     }
             CoreError::HashPasswordError(msg) => {
-                        Self::InternalServerError(format!("Hash password error: {}", msg))
+                        Self::InternalServerError(format!("Hash password error: {}", msg).into())
                     }
             CoreError::VerifyPasswordError(msg) => {
-                        Self::InternalServerError(format!("Verify password error: {}", msg))
+                        Self::InternalServerError(format!("Verify password error: {}", msg).into())
                     }
             CoreError::DeletePasswordCredentialError => {
-                        Self::InternalServerError("Failed to delete password credential".to_string())
+                        Self::InternalServerError("Failed to delete password credential".into())
                     }
             CoreError::CreateCredentialError => {
-                        Self::InternalServerError("Failed to create credential".to_string())
+                        Self::InternalServerError("Failed to create credential".into())
                     }
             CoreError::GetPasswordCredentialError => {
-                        Self::InternalServerError("Failed to get password credential".to_string())
+                        Self::InternalServerError("Failed to get password credential".into())
                     }
             CoreError::GetUserCredentialsError => {
-                        Self::InternalServerError("Failed to get user credentials".to_string())
+                        Self::InternalServerError("Failed to get user credentials".into())
                     }
             CoreError::DeleteCredentialError => {
-                        Self::InternalServerError("Failed to delete credential".to_string())
+                        Self::InternalServerError("Failed to delete credential".into())
                     }
             CoreError::TokenGenerationError(msg) => {
-                        Self::InternalServerError(format!("Token generation error: {}", msg))
+                        Self::InternalServerError(format!("Token generation error: {}", msg).into())
                     }
             CoreError::TokenValidationError(msg) => {
-                        Self::Unauthorized(format!("Token validation error: {}", msg))
+                        Self::Unauthorized(format!("Token validation error: {}", msg).into())
                     }
             CoreError::TokenParsingError(msg) => {
-                        Self::BadRequest(format!("Token parsing error: {}", msg))
+                        Self::BadRequest(format!("Token parsing error: {}", msg).into())
                     }
             CoreError::TokenExpirationError(msg) => {
-                        Self::Unauthorized(format!("Token expiration error: {}", msg))
+                        Self::Unauthorized(format!("Token expiration error: {}", msg).into())
                     }
             CoreError::RealmKeyNotFound => {
-                        Self::InternalServerError("Realm key not found".to_string())
+                        Self::InternalServerError("Realm key not found".into())
                     }
-            CoreError::InvalidToken => Self::Unauthorized("Invalid token".to_string()),
-            CoreError::ExpiredToken => Self::Unauthorized("Expired token".to_string()),
-            CoreError::InvalidKey(msg) => Self::BadRequest(format!("Invalid key: {}", msg)),
-            CoreError::SessionNotFound => Self::NotFound("Session not found".to_string()),
-            CoreError::SessionExpired => Self::Unauthorized("Session expired".to_string()),
-            CoreError::InvalidSession => Self::Unauthorized("Invalid session".to_string()),
+            CoreError::InvalidToken => Self::Unauthorized("Invalid token".into()),
+            CoreError::ExpiredToken => Self::Unauthorized("Expired token".into()),
+            CoreError::InvalidKey(msg) => Self::BadRequest(format!("Invalid key: {}", msg).into()),
+            CoreError::SessionNotFound => Self::NotFound("Session not found".into()),
+            CoreError::SessionExpired => Self::Unauthorized("Session expired".into()),
+            CoreError::InvalidSession => Self::Unauthorized("Invalid session".into()),
             CoreError::SessionCreateError => {
-                        Self::InternalServerError("Failed to create session".to_string())
+                        Self::InternalServerError("Failed to create session".into())
                     }
             CoreError::SessionDeleteError => {
-                        Self::InternalServerError("Failed to delete session".to_string())
+                        Self::InternalServerError("Failed to delete session".into())
                     }
             CoreError::InvalidTotpSecretFormat => {
-                        Self::BadRequest("Invalid TOTP secret format".to_string())
+                        Self::BadRequest("Invalid TOTP secret format".into())
                     }
             CoreError::TotpGenerationFailed(msg) => {
-                        Self::InternalServerError(format!("TOTP generation failed: {}", msg))
+                        Self::InternalServerError(format!("TOTP generation failed: {}", msg).into())
                     }
             CoreError::TotpVerificationFailed(msg) => {
-                        Self::Unauthorized(format!("TOTP verification failed: {}", msg))
+                        Self::Unauthorized(format!("TOTP verification failed: {}", msg).into())
                     }
             CoreError::CannotDeleteMasterRealm => {
-                        Self::Forbidden("Cannot delete master realm".to_string())
+                        Self::Forbidden("Cannot delete master realm".into())
                     }
-            CoreError::WebhookNotFound => Self::NotFound("Webhook not found".to_string()),
-            CoreError::WebhookForbidden => Self::Forbidden("Webhook forbidden".to_string()),
+            CoreError::WebhookNotFound => Self::NotFound("Webhook not found".into()),
+            CoreError::WebhookForbidden => Self::Forbidden("Webhook forbidden".into()),
             CoreError::FailedWebhookNotification(msg) => {
-                        Self::InternalServerError(format!("Failed to notify webhook: {}", msg))
+                        Self::InternalServerError(format!("Failed to notify webhook: {}", msg).into())
                     }
             CoreError::WebhookRealmNotFound => {
-                        Self::NotFound("Realm not found for webhook".to_string())
+                        Self::NotFound("Realm not found for webhook".into())
                     }
             CoreError::CreateClientError => {
-                        Self::InternalServerError("Failed to create client".to_string())
+                        Self::InternalServerError("Failed to create client".into())
                     }
-            CoreError::ServiceUnavailable(msg) => Self::ServiceUnavailable(msg),
-            CoreError::RecoveryCodeGenError(msg) => Self::BadRequest(msg),
-            CoreError::RecoveryCodeBurnError(msg) => Self::BadRequest(msg),
+            CoreError::ServiceUnavailable(msg) => Self::ServiceUnavailable(msg.into()),
+            CoreError::RecoveryCodeGenError(msg) => Self::BadRequest(msg.into()),
+            CoreError::RecoveryCodeBurnError(msg) => Self::BadRequest(msg.into()),
             CoreError::AuthorizationCodeStorageFailed => {
-                Self::InternalServerError(String::new())
+                Self::InternalServerError("".into())
             },
             CoreError::AuthSessionExpectedState => {
-                Self::InternalServerError(String::new())
+                Self::InternalServerError("".into())
             },
             CoreError::WebAuthnMissingChallenge => {
-                Self::BadRequest("There is no current webauthn challenge for this session. Make sure you request one from the server before attempting an authentication.".to_string())
+                Self::BadRequest("There is no current webauthn challenge for this session. Make sure you request one from the server before attempting an authentication.".into())
             },
             CoreError::WebAuthnCredentialNotFound => {
-                Self::BadRequest("Missing webauthn credential for the provided id. Have you created a webauthn credential first ?".to_string())
+                Self::BadRequest("Missing webauthn credential for the provided id. Have you created a webauthn credential first ?".into())
             }
             CoreError::WebAuthnChallengeFailed => {
-                Self::Unauthorized("Webauthn challenged failed. A new one must be requested to retry.".to_string())
+                Self::Unauthorized("Webauthn challenged failed. A new one must be requested to retry.".into())
             }
             CoreError::MagicLinkNotEnabled => {
-                Self::BadRequest("Magic link authentication is not enabled for this realm".to_string())
+                Self::BadRequest("Magic link authentication is not enabled for this realm".into())
             }
             CoreError::InvalidMagicLink => {
-                Self::Unauthorized("Invalid magic link token".to_string())
+                Self::Unauthorized("Invalid magic link token".into())
             }
             CoreError::MagicLinkExpired => {
-                Self::Unauthorized("Magic link has expired".to_string())
+                Self::Unauthorized("Magic link has expired".into())
             }
             CoreError::MagicLinkAlreadyUsed => {
-                Self::BadRequest("Magic link has already been used".to_string())
+                Self::BadRequest("Magic link has already been used".into())
             }
             CoreError::ProviderNotFound => {
-                Self::NotFound("Provider not found".to_string())
+                Self::NotFound("Provider not found".into())
             }
             CoreError::ProviderNameAlreadyExists => {
-                Self::BadRequest("Provider name already exists".to_string())
+                Self::BadRequest("Provider name already exists".into())
             }
             CoreError::InvalidProviderConfiguration(msg) => {
-                Self::BadRequest(format!("Invalid provider configuration: {}", msg))
+                Self::BadRequest(format!("Invalid provider configuration: {}", msg).into())
             }
             CoreError::ProviderDisabled => {
-                Self::Forbidden("Provider is disabled".to_string())
+                Self::Forbidden("Provider is disabled".into())
             }
             CoreError::InvalidProviderUrl => {
-                Self::BadRequest("Invalid provider URL".to_string())
+                Self::BadRequest("Invalid provider URL".into())
             },
-            CoreError::External(msg) => Self::ServiceUnavailable(format!("External service error: {}", msg)),
-            CoreError::Database(msg) => Self::InternalServerError(format!("Database error: {}", msg)),
-            CoreError::Configuration(msg) => Self::InternalServerError(format!("Configuration error: {}", msg)),
-            CoreError::FederationAuthenticationFailed(msg) => Self::Unauthorized(format!("Federation authentication error: {}", msg)),
+            CoreError::External(msg) => Self::ServiceUnavailable(format!("External service error: {}", msg).into()),
+            CoreError::Database(msg) => Self::InternalServerError(format!("Database error: {}", msg).into()),
+            CoreError::Configuration(msg) => Self::InternalServerError(format!("Configuration error: {}", msg).into()),
+            CoreError::FederationAuthenticationFailed(msg) => Self::Unauthorized(format!("Federation authentication error: {}", msg).into()),
 
             // Broker (SSO) errors
             CoreError::BrokerSessionNotFound => {
-                Self::BadRequest("Invalid or expired SSO session".to_string())
+                Self::BadRequest("Invalid or expired SSO session".into())
             }
             CoreError::BrokerSessionExpired => {
-                Self::BadRequest("SSO session expired, please try again".to_string())
+                Self::BadRequest("SSO session expired, please try again".into())
             }
             CoreError::InvalidBrokerState => {
-                Self::BadRequest("Invalid state parameter".to_string())
+                Self::BadRequest("Invalid state parameter".into())
             }
             CoreError::IdpTokenExchangeFailed(msg) => {
-                Self::ServiceUnavailable(format!("Identity provider error: {}", msg))
+                Self::ServiceUnavailable(format!("Identity provider error: {}", msg).into())
             }
             CoreError::IdpUserInfoFailed(msg) => {
-                Self::ServiceUnavailable(format!("Failed to retrieve user info: {}", msg))
+                Self::ServiceUnavailable(format!("Failed to retrieve user info: {}", msg).into())
             }
             CoreError::IdpAuthenticationFailed(msg) => {
-                Self::Unauthorized(format!("Identity provider authentication failed: {}", msg))
+                Self::Unauthorized(format!("Identity provider authentication failed: {}", msg).into())
             }
             CoreError::UserLinkingFailed(msg) => {
-                Self::InternalServerError(format!("User linking failed: {}", msg))
+                Self::InternalServerError(format!("User linking failed: {}", msg).into())
             }
             CoreError::LinkOnlyUserNotFound => {
-                Self::Forbidden("No existing account found for linking".to_string())
+                Self::Forbidden("No existing account found for linking".into())
             }
             CoreError::LinkNotFound => {
-                Self::NotFound("Identity provider link not found".to_string())
+                Self::NotFound("Identity provider link not found".into())
             }
             CoreError::InvalidIdToken => {
-                Self::BadRequest("Invalid ID token from identity provider".to_string())
+                Self::BadRequest("Invalid ID token from identity provider".into())
             }
             CoreError::MissingAuthorizationCode => {
-                Self::BadRequest("Missing authorization code from identity provider".to_string())
+                Self::BadRequest("Missing authorization code from identity provider".into())
             }
             CoreError::UserNotFound => {
-                Self::NotFound("User not found".to_string())
+                Self::NotFound("User not found".into())
             }
             CoreError::ClientNotFound => {
-                Self::NotFound("Client not found".to_string())
+                Self::NotFound("Client not found".into())
             }
             CoreError::HintsNotFound => {
-                Self::NotFound("Account hints not found".to_string())
+                Self::NotFound("Account hints not found".into())
             }
             CoreError::InvalidScope(description) => Self::OAuthError {
-                error: "invalid_scope".to_string(),
-                error_description: description,
+                error: "invalid_scope".into(),
+                error_description: description.into(),
             },
-            CoreError::UserDisabled => Self::Forbidden("User account is disabled".to_string()),
-            CoreError::ClientUnderMaintenance(reason) => Self::ServiceUnavailable(reason),
+            CoreError::UserDisabled => Self::Forbidden("User account is disabled".into()),
+            CoreError::ClientUnderMaintenance(reason) => Self::ServiceUnavailable(reason.into()),
             CoreError::EmailTemplateNotFound => {
-                Self::NotFound("Email template not found".to_string())
+                Self::NotFound("Email template not found".into())
             }
             CoreError::NoActiveEmailTemplate(email_type) => {
-                Self::NotFound(format!("No active email template for type: {email_type}"))
+                Self::NotFound(format!("No active email template for type: {email_type}").into())
             }
             CoreError::InvalidEmailTemplateStructure(msg) => {
-                Self::BadRequest(format!("Invalid email template structure: {msg}"))
+                Self::BadRequest(format!("Invalid email template structure: {msg}").into())
             }
             CoreError::EmailTemplateRenderError(msg) => {
-                Self::InternalServerError(format!("Email template render error: {msg}"))
+                Self::InternalServerError(format!("Email template render error: {msg}").into())
             }
         }
     }

--- a/api/src/application/http/health/handlers/health_live.rs
+++ b/api/src/application/http/health/handlers/health_live.rs
@@ -20,7 +20,7 @@ pub async fn health_live(
         .service
         .health()
         .await
-        .map_err(|e| ApiError::ServiceUnavailable(e.to_string()))?;
+        .map_err(|e| ApiError::ServiceUnavailable(e.to_string().into()))?;
 
     Ok(Response::OK(HealthLiveResponse {
         message: "Service is live".to_string(),

--- a/api/src/application/http/health/handlers/health_ready.rs
+++ b/api/src/application/http/health/handlers/health_ready.rs
@@ -13,7 +13,7 @@ pub async fn health_ready(
         .service
         .readness()
         .await
-        .map_err(|e| ApiError::ServiceUnavailable(e.to_string()))?;
+        .map_err(|e| ApiError::ServiceUnavailable(e.to_string().into()))?;
 
     let status = readness.status.clone();
     let overall_status = match status.as_str() {

--- a/api/src/application/http/maintenance/handlers/add_client_whitelist_entry.rs
+++ b/api/src/application/http/maintenance/handlers/add_client_whitelist_entry.rs
@@ -57,7 +57,7 @@ pub async fn add_client_whitelist_entry(
             .map_err(ApiError::from)?,
         _ => {
             return Err(ApiError::BadRequest(
-                "Exactly one of user_id or role_id must be provided".to_string(),
+                "Exactly one of user_id or role_id must be provided".into(),
             ));
         }
     };

--- a/api/src/application/http/maintenance/handlers/add_realm_whitelist_entry.rs
+++ b/api/src/application/http/maintenance/handlers/add_realm_whitelist_entry.rs
@@ -55,7 +55,7 @@ pub async fn add_realm_whitelist_entry(
             .map_err(ApiError::from)?,
         _ => {
             return Err(ApiError::BadRequest(
-                "Exactly one of user_id or role_id must be provided".to_string(),
+                "Exactly one of user_id or role_id must be provided".into(),
             ));
         }
     };

--- a/api/src/application/http/server/api_entities/api_error.rs
+++ b/api/src/application/http/server/api_entities/api_error.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use axum::{
     Json,
     extract::{Form, FromRequest, Request, rejection::FormRejection},
@@ -19,31 +21,34 @@ pub struct ApiErrorData {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct ValidationError {
-    pub message: String,
-    pub field: String,
+    pub message: Cow<'static, str>,
+    pub field: Cow<'static, str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToSchema)]
 pub enum ApiError {
-    InternalServerError(String),
+    InternalServerError(Cow<'static, str>),
     UnProcessableEntity(Vec<ValidationError>),
-    NotFound(String),
-    Unauthorized(String),
-    Forbidden(String),
-    BadRequest(String),
-    ServiceUnavailable(String),
+    NotFound(Cow<'static, str>),
+    Unauthorized(Cow<'static, str>),
+    Forbidden(Cow<'static, str>),
+    BadRequest(Cow<'static, str>),
+    ServiceUnavailable(Cow<'static, str>),
     /// RFC 6749 §5.2 OAuth2 error response
     OAuthError {
-        error: String,
-        error_description: String,
+        error: Cow<'static, str>,
+        error_description: Cow<'static, str>,
     },
 }
 
 impl ApiError {
-    pub fn validation_error(message: &str, field: &str) -> Self {
+    pub fn validation_error(
+        message: impl Into<Cow<'static, str>>,
+        field: impl Into<Cow<'static, str>>,
+    ) -> Self {
         Self::UnProcessableEntity(vec![ValidationError {
-            message: message.to_string(),
-            field: field.to_string(),
+            message: message.into(),
+            field: field.into(),
         }])
     }
 
@@ -66,7 +71,7 @@ where
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let Json(value) = Json::<T>::from_request(req, state)
             .await
-            .map_err(|err| ApiError::BadRequest(format!("Unexpected payload: {err}")))?;
+            .map_err(|err| ApiError::BadRequest(format!("Unexpected payload: {err}").into()))?;
 
         value.validate()?;
 
@@ -79,11 +84,11 @@ impl From<anyhow::Error> for ApiError {
         match e {
             e if e.to_string().contains("validation error") => {
                 Self::UnProcessableEntity(vec![ValidationError {
-                    message: e.to_string(),
-                    field: "unknown".to_string(),
+                    message: e.to_string().into(),
+                    field: "unknown".into(),
                 }])
             }
-            _ => Self::InternalServerError(e.to_string()),
+            _ => Self::InternalServerError(e.to_string().into()),
         }
     }
 }
@@ -97,13 +102,12 @@ impl From<validator::ValidationErrors> for ApiError {
             for error in error_msgs {
                 let message = error
                     .message
-                    .as_ref()
-                    .map(|cow| cow.to_string())
-                    .unwrap_or_else(|| format!("Validation failed on {field}"));
+                    .clone()
+                    .unwrap_or_else(|| Cow::Owned(format!("Validation failed on {field}")));
 
                 validation_errors.push(ValidationError {
                     message,
-                    field: field.to_string(),
+                    field: field.clone(),
                 });
             }
         }
@@ -115,29 +119,27 @@ impl From<validator::ValidationErrors> for ApiError {
 impl From<AuthenticationError> for ApiError {
     fn from(error: AuthenticationError) -> Self {
         match error {
-            AuthenticationError::NotFound => Self::NotFound("Token not found".to_string()),
-            AuthenticationError::Invalid => Self::Unauthorized("Invalid client".to_string()),
+            AuthenticationError::NotFound => Self::NotFound("Token not found".into()),
+            AuthenticationError::Invalid => Self::Unauthorized("Invalid client".into()),
             AuthenticationError::InternalServerError => {
-                Self::InternalServerError("Internal server error".to_string())
+                Self::InternalServerError("Internal server error".into())
             }
-            AuthenticationError::InvalidClient => Self::NotFound("Client not found".to_string()),
-            AuthenticationError::InvalidPassword => {
-                Self::Unauthorized("Invalid password".to_string())
-            }
-            AuthenticationError::InvalidRealm => Self::Unauthorized("Realm not found".to_string()),
-            AuthenticationError::InvalidState => Self::Unauthorized("Invalid state".to_string()),
-            AuthenticationError::InvalidUser => Self::Unauthorized("User not found".to_string()),
+            AuthenticationError::InvalidClient => Self::NotFound("Client not found".into()),
+            AuthenticationError::InvalidPassword => Self::Unauthorized("Invalid password".into()),
+            AuthenticationError::InvalidRealm => Self::Unauthorized("Realm not found".into()),
+            AuthenticationError::InvalidState => Self::Unauthorized("Invalid state".into()),
+            AuthenticationError::InvalidUser => Self::Unauthorized("User not found".into()),
             AuthenticationError::ServiceAccountNotFound => {
-                Self::NotFound("Service account not found".to_string())
+                Self::NotFound("Service account not found".into())
             }
             AuthenticationError::InvalidRefreshToken => {
-                Self::Unauthorized("Invalid refresh token".to_string())
+                Self::Unauthorized("Invalid refresh token".into())
             }
             AuthenticationError::InvalidClientSecret => {
-                Self::Unauthorized("Invalid client secret".to_string())
+                Self::Unauthorized("Invalid client secret".into())
             }
             AuthenticationError::InvalidRequest => {
-                Self::Unauthorized("Invalid authorization request".to_string())
+                Self::Unauthorized("Invalid authorization request".into())
             }
         }
     }
@@ -146,17 +148,15 @@ impl From<AuthenticationError> for ApiError {
 impl From<JwtError> for ApiError {
     fn from(error: JwtError) -> Self {
         match error {
-            JwtError::InvalidToken => Self::Unauthorized("Invalid token".to_string()),
-            JwtError::ValidationError(e) => Self::InternalServerError(e),
-            JwtError::ExpirationError(e) => Self::InternalServerError(e),
-            JwtError::GenerationError(e) => Self::InternalServerError(e),
-            JwtError::HashingError(e) => Self::InternalServerError(e),
-            JwtError::ExpiredToken => Self::InternalServerError("Token expired".to_string()),
-            JwtError::InvalidKey(e) => Self::InternalServerError(e),
-            JwtError::ParsingError(e) => Self::InternalServerError(e),
-            JwtError::RealmKeyNotFound => {
-                Self::InternalServerError("Realm key not found".to_string())
-            }
+            JwtError::InvalidToken => Self::Unauthorized("Invalid token".into()),
+            JwtError::ValidationError(e) => Self::InternalServerError(e.into()),
+            JwtError::ExpirationError(e) => Self::InternalServerError(e.into()),
+            JwtError::GenerationError(e) => Self::InternalServerError(e.into()),
+            JwtError::HashingError(e) => Self::InternalServerError(e.into()),
+            JwtError::ExpiredToken => Self::InternalServerError("Token expired".into()),
+            JwtError::InvalidKey(e) => Self::InternalServerError(e.into()),
+            JwtError::ParsingError(e) => Self::InternalServerError(e.into()),
+            JwtError::RealmKeyNotFound => Self::InternalServerError("Realm key not found".into()),
         }
     }
 }
@@ -164,12 +164,12 @@ impl From<JwtError> for ApiError {
 impl From<WebhookError> for ApiError {
     fn from(error: WebhookError) -> Self {
         match error {
-            WebhookError::Forbidden => Self::Unauthorized("Invalid webhook".to_string()),
-            WebhookError::NotFound => Self::NotFound("Webhook not found".to_string()),
+            WebhookError::Forbidden => Self::Unauthorized("Invalid webhook".into()),
+            WebhookError::NotFound => Self::NotFound("Webhook not found".into()),
             WebhookError::InternalServerError => {
-                Self::InternalServerError("Internal server error".to_string())
+                Self::InternalServerError("Internal server error".into())
             }
-            WebhookError::RealmNotFound => Self::InternalServerError("Realm not found".to_string()),
+            WebhookError::RealmNotFound => Self::InternalServerError("Realm not found".into()),
         }
     }
 }
@@ -215,7 +215,7 @@ impl IntoResponse for ApiError {
                 Json(ApiErrorResponse {
                     code: "E_NOT_FOUND".to_string(),
                     status: 404,
-                    message,
+                    message: message.into(),
                 }),
             )
                 .into_response(),
@@ -224,7 +224,7 @@ impl IntoResponse for ApiError {
                 Json(ApiErrorResponse {
                     code: "E_UNAUTHORIZED".to_string(),
                     status: 401,
-                    message,
+                    message: message.into(),
                 }),
             )
                 .into_response(),
@@ -233,7 +233,7 @@ impl IntoResponse for ApiError {
                 Json(ApiErrorResponse {
                     code: "E_FORBIDDEN".to_string(),
                     status: 403,
-                    message,
+                    message: message.into(),
                 }),
             )
                 .into_response(),
@@ -242,7 +242,7 @@ impl IntoResponse for ApiError {
                 Json(ApiErrorResponse {
                     code: "E_BAD_REQUEST".to_string(),
                     status: 400,
-                    message,
+                    message: message.into(),
                 }),
             )
                 .into_response(),
@@ -251,7 +251,7 @@ impl IntoResponse for ApiError {
                 Json(ApiErrorResponse {
                     code: "E_SERVICE_UNAVAILABLE".to_string(),
                     status: 503,
-                    message,
+                    message: message.into(),
                 }),
             )
                 .into_response(),
@@ -261,8 +261,8 @@ impl IntoResponse for ApiError {
             } => (
                 StatusCode::BAD_REQUEST,
                 Json(OAuth2ErrorResponse {
-                    error,
-                    error_description,
+                    error: error.into(),
+                    error_description: error_description.into(),
                 }),
             )
                 .into_response(),

--- a/api/src/application/http/trident/handlers/burn_recovery_code.rs
+++ b/api/src/application/http/trident/handlers/burn_recovery_code.rs
@@ -56,7 +56,7 @@ pub async fn burn_recovery_code(
 ) -> Result<Response<BurnRecoveryCodeResponse>, ApiError> {
     let session_code = cookie
         .get("FERRISKEY_SESSION")
-        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".to_string()))? // Ou un type d'erreur 401/403
+        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".into()))? // Ou un type d'erreur 401/403
         .value()
         .to_string();
 

--- a/api/src/application/http/trident/handlers/challenge_otp.rs
+++ b/api/src/application/http/trident/handlers/challenge_otp.rs
@@ -50,7 +50,7 @@ pub async fn challenge_otp(
 ) -> Result<Response<ChallengeOtpResponse>, ApiError> {
     let session_code = cookie
         .get("FERRISKEY_SESSION")
-        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".to_string()))? // Ou un type d'erreur 401/403
+        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".into()))? // Ou un type d'erreur 401/403
         .value()
         .to_string();
 
@@ -64,7 +64,7 @@ pub async fn challenge_otp(
             },
         )
         .await
-        .map_err(|e| ApiError::InternalServerError(e.to_string()))?;
+        .map_err(|e| ApiError::InternalServerError(e.to_string().into()))?;
 
     let response = ChallengeOtpResponse {
         url: result.login_url,

--- a/api/src/application/http/trident/handlers/passkey_authenticate.rs
+++ b/api/src/application/http/trident/handlers/passkey_authenticate.rs
@@ -78,7 +78,7 @@ pub async fn passkey_authenticate(
 ) -> Result<Response<PasskeyAuthenticateResponse>, ApiError> {
     let session_code = cookie
         .get("FERRISKEY_SESSION")
-        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".to_string()))?
+        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".into()))?
         .value()
         .to_string();
 

--- a/api/src/application/http/trident/handlers/passkey_request_options.rs
+++ b/api/src/application/http/trident/handlers/passkey_request_options.rs
@@ -71,7 +71,7 @@ pub async fn passkey_request_options(
 ) -> Result<Response<PasskeyRequestOptionsResponse>, ApiError> {
     let session_code = cookie
         .get("FERRISKEY_SESSION")
-        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".to_string()))?
+        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".into()))?
         .value()
         .to_string();
 

--- a/api/src/application/http/trident/handlers/reset_password.rs
+++ b/api/src/application/http/trident/handlers/reset_password.rs
@@ -130,7 +130,7 @@ pub async fn reset_password_with_token(
     }
 
     let cookie_value = HeaderValue::from_str(&identity_cookie.to_string())
-        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".to_string()))?;
+        .map_err(|_| ApiError::InternalServerError("Invalid cookie header".into()))?;
 
     Ok((
         StatusCode::OK,

--- a/api/src/application/http/trident/handlers/setup_otp.rs
+++ b/api/src/application/http/trident/handlers/setup_otp.rs
@@ -51,7 +51,7 @@ pub async fn setup_otp(
         .service
         .setup_otp(identity, SetupOtpInput { issuer })
         .await
-        .map_err(|e| ApiError::InternalServerError(e.to_string()))?;
+        .map_err(|e| ApiError::InternalServerError(e.to_string().into()))?;
 
     let response = SetupOtpResponse {
         issuer: format!("{base_url}/realms/{realm_name}"),

--- a/api/src/application/http/trident/handlers/verify_otp.rs
+++ b/api/src/application/http/trident/handlers/verify_otp.rs
@@ -53,7 +53,7 @@ pub async fn verify_otp(
             },
         )
         .await
-        .map_err(|e| ApiError::InternalServerError(e.to_string()))?;
+        .map_err(|e| ApiError::InternalServerError(e.to_string().into()))?;
 
     Ok(Response::OK(VerifyOtpResponse {
         message: result.message,

--- a/api/src/application/http/trident/handlers/webauthn_public_key_authenticate.rs
+++ b/api/src/application/http/trident/handlers/webauthn_public_key_authenticate.rs
@@ -78,7 +78,7 @@ pub async fn webauthn_public_key_authenticate(
 ) -> Result<Response<AuthenticationAttemptResponse>, ApiError> {
     let session_code = cookie
         .get("FERRISKEY_SESSION")
-        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".to_string()))? // Ou un type d'erreur 401/403
+        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".into()))? // Ou un type d'erreur 401/403
         .value()
         .to_string();
 

--- a/api/src/application/http/trident/handlers/webauthn_public_key_create.rs
+++ b/api/src/application/http/trident/handlers/webauthn_public_key_create.rs
@@ -75,7 +75,7 @@ pub async fn webauthn_public_key_create(
 ) -> Result<Response<ValidatePublicKeyResponse>, ApiError> {
     let session_code = cookie
         .get("FERRISKEY_SESSION")
-        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".to_string()))? // Ou un type d'erreur 401/403
+        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".into()))? // Ou un type d'erreur 401/403
         .value()
         .to_string();
 

--- a/api/src/application/http/trident/handlers/webauthn_public_key_create_options.rs
+++ b/api/src/application/http/trident/handlers/webauthn_public_key_create_options.rs
@@ -64,7 +64,7 @@ pub async fn webauthn_public_key_create_options(
 ) -> Result<Response<CreatePublicKeyResponse>, ApiError> {
     let session_code = cookie
         .get("FERRISKEY_SESSION")
-        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".to_string()))? // Ou un type d'erreur 401/403
+        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".into()))? // Ou un type d'erreur 401/403
         .value()
         .to_string();
 

--- a/api/src/application/http/trident/handlers/webauthn_public_key_request_options.rs
+++ b/api/src/application/http/trident/handlers/webauthn_public_key_request_options.rs
@@ -66,7 +66,7 @@ pub async fn webauthn_public_key_request_options(
 ) -> Result<Response<RequestOptionsResponse>, ApiError> {
     let session_code = cookie
         .get("FERRISKEY_SESSION")
-        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".to_string()))? // Ou un type d'erreur 401/403
+        .ok_or_else(|| ApiError::Unauthorized("Missing session cookie".into()))? // Ou un type d'erreur 401/403
         .value()
         .to_string();
 

--- a/api/src/application/http/user/errors.rs
+++ b/api/src/application/http/user/errors.rs
@@ -5,31 +5,31 @@ impl From<CredentialError> for ApiError {
     fn from(value: CredentialError) -> Self {
         match value {
             CredentialError::CreateCredentialError => {
-                ApiError::InternalServerError("Failed to create credential".to_string())
+                ApiError::InternalServerError("Failed to create credential".into())
             }
             CredentialError::GetUserCredentialsError => {
-                ApiError::InternalServerError("Failed to get credential".to_string())
+                ApiError::InternalServerError("Failed to get credential".into())
             }
             CredentialError::DeleteCredentialError => {
-                ApiError::InternalServerError("Failed to delete credential".to_string())
+                ApiError::InternalServerError("Failed to delete credential".into())
             }
             CredentialError::VerifyPasswordError(error) => {
-                ApiError::InternalServerError(format!("Failed to verify password: {error}"))
+                ApiError::InternalServerError(format!("Failed to verify password: {error}").into())
             }
             CredentialError::DeletePasswordCredentialError => {
-                ApiError::InternalServerError("Failed to delete password credential".to_string())
+                ApiError::InternalServerError("Failed to delete password credential".into())
             }
             CredentialError::GetPasswordCredentialError => {
-                ApiError::InternalServerError("Failed to get password credential".to_string())
+                ApiError::InternalServerError("Failed to get password credential".into())
             }
             CredentialError::HashPasswordError(error) => {
-                ApiError::InternalServerError(format!("Failed to hash password: {error}"))
+                ApiError::InternalServerError(format!("Failed to hash password: {error}").into())
             }
             CredentialError::UpdateCredentialError => {
-                ApiError::InternalServerError("Internal server error".to_string())
+                ApiError::InternalServerError("Internal server error".into())
             }
             CredentialError::UnexpectedCredentialData => {
-                ApiError::InternalServerError("Internal server error".to_string())
+                ApiError::InternalServerError("Internal server error".into())
             }
         }
     }

--- a/api/src/application/http/user/handlers/get_credentials.rs
+++ b/api/src/application/http/user/handlers/get_credentials.rs
@@ -56,7 +56,7 @@ pub async fn get_user_credentials(
             },
         )
         .await
-        .map_err(|e| ApiError::InternalServerError(e.to_string()))?;
+        .map_err(|e| ApiError::InternalServerError(e.to_string().into()))?;
 
     Ok(Response::OK(GetUserCredentialsResponse {
         data: credentials,

--- a/api/src/application/http/user/handlers/reset_password.rs
+++ b/api/src/application/http/user/handlers/reset_password.rs
@@ -68,7 +68,7 @@ pub async fn reset_password(
             },
         )
         .await
-        .map_err(|_| ApiError::InternalServerError("Internal server error".to_string()))?;
+        .map_err(|_| ApiError::InternalServerError("Internal server error".into()))?;
 
     Ok(Response::OK(ResetPasswordResponse {
         message: "Password reset successfully".to_string(),


### PR DESCRIPTION
Updates `ApiError` variants and related structures to use `Cow<'static, str>` instead of `String`.

- Replaced `.to_string()` with `.into()`.
- Updated `ValidationError` to use `Cow`.

Closes #942


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized construction of API error messages across handlers for consistency and minor performance improvements.
  * Error payloads switched to a more efficient string representation to reduce allocations.

* **Breaking Changes**
  * Validation error API and some error payload types changed to a more flexible string type — integrators may need to adjust usages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->