### PR TITLE
feat(front): autofocus username field on login page

### DIFF
--- a/front/src/components/login-form.tsx
+++ b/front/src/components/login-form.tsx
@@ -58,6 +58,7 @@ export function LoginForm({
                     type='email'
                     placeholder='m@example.com'
                     required
+                    autoFocus
                   />
                 </div>
                 <div className='grid gap-3'>


### PR DESCRIPTION
Closes #960.

Adds `autoFocus` to the email `<Input>` in `front/src/components/login-form.tsx` so the cursor lands in the field as soon as the login page renders. Users can start typing immediately instead of clicking the field first.

The same `autoFocus` pattern is already used by the user/organization attribute inputs (`front/src/pages/{user,organization}/ui/page-*-attributes.tsx`), so this matches existing convention.

Verified locally with `pnpm exec eslint src/components/login-form.tsx` (clean) and `pnpm exec tsc -b` (no errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The login form email field now automatically receives focus when the page loads, streamlining the user login experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->