### PR TITLE
feat: add cargo-chef and dump the rust version `1.95`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,77 +1,25 @@
-FROM rust:1.91.1-bookworm AS rust-build
+FROM rust:1.95.0-bookworm AS chef
 
 WORKDIR /usr/local/src/ferriskey
 
-RUN cargo install sqlx-cli --no-default-features --features postgres
+RUN cargo install cargo-chef --version 0.1.77 --locked && \
+    cargo install sqlx-cli --version 0.8.6 --no-default-features --features postgres --locked
 
-COPY Cargo.toml Cargo.lock ./
-COPY libs/maskass/Cargo.toml ./libs/maskass/
-COPY libs/ferriskey-domain/Cargo.toml ./libs/ferriskey-domain/
-COPY libs/ferriskey-security/Cargo.toml ./libs/ferriskey-security/
-COPY libs/ferriskey-trident/Cargo.toml ./libs/ferriskey-trident/
-COPY libs/ferriskey-abyss/Cargo.toml ./libs/ferriskey-abyss/
-COPY libs/ferriskey-aegis/Cargo.toml ./libs/ferriskey-aegis/
-COPY libs/ferriskey-mail/Cargo.toml ./libs/ferriskey-mail/
-COPY libs/ferriskey-compass/Cargo.toml ./libs/ferriskey-compass/
-COPY libs/ferriskey-migrate/Cargo.toml ./libs/ferriskey-migrate/
-COPY libs/ferriskey-organization/Cargo.toml ./libs/ferriskey-organization/
+# ── Planner: analyse the workspace and produce recipe.json ────────────────────
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-COPY core/Cargo.toml ./core/
+# ── Builder: cook deps first (cached), then build real source ─────────────────
+FROM chef AS builder
 
-COPY api/Cargo.toml ./api/
-COPY operator/Cargo.toml ./operator/
-COPY client/Cargo.toml ./client/
+COPY --from=planner /usr/local/src/ferriskey/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
-RUN \
-  mkdir -p api/src core/src entity/src operator/src client/src \
-  libs/maskass/src libs/ferriskey-domain/src libs/ferriskey-security/src libs/ferriskey-trident/src libs/ferriskey-abyss/src libs/ferriskey-aegis/src libs/ferriskey-mail/src libs/ferriskey-compass/src libs/ferriskey-migrate/src libs/ferriskey-organization/src && \
-  touch libs/maskass/src/lib.rs && \
-  touch libs/ferriskey-domain/src/lib.rs && \
-  touch libs/ferriskey-security/src/lib.rs && \
-  touch libs/ferriskey-trident/src/lib.rs && \
-  touch libs/ferriskey-abyss/src/lib.rs && \
-  touch libs/ferriskey-aegis/src/lib.rs && \
-  touch libs/ferriskey-mail/src/lib.rs && \
-  touch libs/ferriskey-compass/src/lib.rs && \
-  touch libs/ferriskey-migrate/src/lib.rs && \
-  touch libs/ferriskey-organization/src/lib.rs && \
-  touch core/src/lib.rs && \
-  touch client/src/lib.rs && \
-  echo "fn main() {}" > operator/src/main.rs && \
-  echo "fn main() {}" > api/src/main.rs && \
-  cargo build --release
+COPY . .
+RUN cargo build --release
 
-COPY libs/maskass libs/maskass
-COPY libs/ferriskey-domain libs/ferriskey-domain
-COPY libs/ferriskey-security libs/ferriskey-security
-COPY libs/ferriskey-trident libs/ferriskey-trident
-COPY libs/ferriskey-abyss libs/ferriskey-abyss
-COPY libs/ferriskey-aegis libs/ferriskey-aegis
-COPY libs/ferriskey-mail libs/ferriskey-mail
-COPY libs/ferriskey-compass libs/ferriskey-compass
-COPY libs/ferriskey-migrate libs/ferriskey-migrate
-COPY libs/ferriskey-organization libs/ferriskey-organization
-
-COPY core core
-COPY api api
-COPY operator operator
-COPY client client
-
-RUN \
-  touch libs/maskass/src/lib.rs && \
-  touch libs/ferriskey-domain/src/lib.rs && \
-  touch libs/ferriskey-security/src/lib.rs && \
-  touch libs/ferriskey-trident/src/lib.rs && \
-  touch libs/ferriskey-abyss/src/lib.rs && \
-  touch libs/ferriskey-aegis/src/lib.rs && \
-  touch libs/ferriskey-mail/src/lib.rs && \
-  touch libs/ferriskey-compass/src/lib.rs && \
-  touch libs/ferriskey-migrate/src/lib.rs && \
-  touch libs/ferriskey-organization/src/lib.rs && \
-  touch core/src/lib.rs && \
-  touch operator/src/main.rs && \
-  cargo build --release
-
+# ── Shared runtime base ───────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 RUN \
@@ -94,24 +42,27 @@ RUN \
 
 USER ferriskey
 
+# ── API image ─────────────────────────────────────────────────────────────────
 FROM runtime AS api
 
-COPY --from=rust-build /usr/local/src/ferriskey/target/release/ferriskey-api /usr/local/bin/
-COPY --from=rust-build /usr/local/src/ferriskey/core/migrations /usr/local/src/ferriskey/migrations
-COPY --from=rust-build /usr/local/cargo/bin/sqlx /usr/local/bin/
+COPY --from=builder /usr/local/src/ferriskey/target/release/ferriskey-api /usr/local/bin/
+COPY --from=builder /usr/local/src/ferriskey/core/migrations /usr/local/src/ferriskey/migrations
+COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/
 
 EXPOSE 80
 
 ENTRYPOINT ["ferriskey-api"]
 
+# ── Operator image ────────────────────────────────────────────────────────────
 FROM runtime AS operator
 
-COPY --from=rust-build /usr/local/src/ferriskey/target/release/ferriskey-operator /usr/local/bin/
+COPY --from=builder /usr/local/src/ferriskey/target/release/ferriskey-operator /usr/local/bin/
 
 EXPOSE 80
 
 ENTRYPOINT ["ferriskey-operator"]
 
+# ── Frontend build ────────────────────────────────────────────────────────────
 FROM node:20.14.0-alpine AS webapp-build
 
 WORKDIR /usr/local/src/ferriskey
@@ -132,6 +83,7 @@ COPY front/ .
 
 RUN pnpm run build
 
+# ── Frontend runtime ──────────────────────────────────────────────────────────
 FROM nginx:1.28.0-alpine3.21-slim AS webapp
 
 COPY --from=webapp-build /usr/local/src/ferriskey/dist /usr/local/src/ferriskey

--- a/docs/ferriskey-signoz-dashboard.json
+++ b/docs/ferriskey-signoz-dashboard.json
@@ -1,0 +1,662 @@
+{
+  "description": "FerrisKey operational dashboard for SigNoz. Uses OpenTelemetry traces and logs emitted by the API service name `ferriskey_server`. Import from SigNoz: Dashboards -> New dashboard -> Import JSON.",
+  "dotMigrated": true,
+  "layout": [
+    { "h": 1, "i": "row-traffic", "moved": false, "static": false, "w": 12, "x": 0, "y": 0 },
+    { "h": 5, "i": "request-rate", "moved": false, "static": false, "w": 4, "x": 0, "y": 1 },
+    { "h": 5, "i": "p95-latency", "moved": false, "static": false, "w": 4, "x": 4, "y": 1 },
+    { "h": 5, "i": "log-rate", "moved": false, "static": false, "w": 4, "x": 8, "y": 1 },
+    { "h": 8, "i": "route-throughput", "moved": false, "static": false, "w": 6, "x": 0, "y": 6 },
+    { "h": 8, "i": "route-latency", "moved": false, "static": false, "w": 6, "x": 6, "y": 6 },
+    { "h": 1, "i": "row-failures", "moved": false, "static": false, "w": 12, "x": 0, "y": 14 },
+    { "h": 7, "i": "status-distribution", "moved": false, "static": false, "w": 4, "x": 0, "y": 15 },
+    { "h": 7, "i": "slow-endpoints", "moved": false, "static": false, "w": 4, "x": 4, "y": 15 },
+    { "h": 7, "i": "log-severity", "moved": false, "static": false, "w": 4, "x": 8, "y": 15 },
+    { "h": 8, "i": "span-errors", "moved": false, "static": false, "w": 6, "x": 0, "y": 22 },
+    { "h": 8, "i": "recent-logs", "moved": false, "static": false, "w": 6, "x": 6, "y": 22 }
+  ],
+  "panelMap": {},
+  "tags": [
+    "ferriskey",
+    "otel",
+    "traces",
+    "logs"
+  ],
+  "title": "FerrisKey API - Logs and Traces",
+  "uploadedGrafana": false,
+  "variables": {},
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "row-traffic",
+      "panelTypes": "row",
+      "title": "Traffic, latency and application log volume"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Server spans per second for the FerrisKey API.",
+      "fillSpans": false,
+      "id": "request-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": "" },
+              "aggregateOperator": "count",
+              "dataSource": "traces",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "service-filter", "key": { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }, "op": "=", "value": "ferriskey_server" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "requests/sec",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-request-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag" },
+        { "dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag" },
+        { "dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag" },
+        { "dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "P95 duration for inbound server spans.",
+      "fillSpans": false,
+      "id": "p95-latency",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag" },
+              "aggregateOperator": "p95",
+              "dataSource": "traces",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "service-filter", "key": { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }, "op": "=", "value": "ferriskey_server" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95 latency",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-p95-latency",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag" },
+        { "dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "P95 Latency",
+      "yAxisUnit": "ns"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Application logs per second for FerrisKey.",
+      "fillSpans": false,
+      "id": "log-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": "" },
+              "aggregateOperator": "count",
+              "dataSource": "logs",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "log-service-filter", "key": { "dataType": "string", "id": "service.name--string--resource--false", "isColumn": false, "key": "service.name", "type": "resource" }, "op": "=", "value": "ferriskey_server" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "logs/sec",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-log-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }],
+      "selectedTracesFields": [{ "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Log Rate",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Request rate grouped by FerrisKey's current tracing span fields: method and uri.",
+      "fillSpans": false,
+      "id": "route-throughput",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": "" },
+              "aggregateOperator": "count",
+              "dataSource": "traces",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "service-filter", "key": { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }, "op": "=", "value": "ferriskey_server" },
+                  { "id": "method-exists", "key": { "dataType": "string", "id": "method--string--tag--true", "isColumn": true, "isJSON": false, "key": "method", "type": "tag" }, "op": "exists", "value": "" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "method--string--tag--true", "isColumn": true, "isJSON": false, "key": "method", "type": "tag" },
+                { "dataType": "string", "id": "uri--string--tag--true", "isColumn": true, "isJSON": false, "key": "uri", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{method}} {{uri}}",
+              "limit": null,
+              "orderBy": [{ "columnName": "#SIGNOZ_VALUE", "order": "desc" }],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-route-throughput",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "method--string--tag--true", "isColumn": true, "isJSON": false, "key": "method", "type": "tag" },
+        { "dataType": "string", "id": "uri--string--tag--true", "isColumn": true, "isJSON": false, "key": "uri", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Throughput by Route",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "P95 latency grouped by FerrisKey's current tracing span fields: method and uri.",
+      "fillSpans": false,
+      "id": "route-latency",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag" },
+              "aggregateOperator": "p95",
+              "dataSource": "traces",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "service-filter", "key": { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }, "op": "=", "value": "ferriskey_server" },
+                  { "id": "method-exists", "key": { "dataType": "string", "id": "method--string--tag--true", "isColumn": true, "isJSON": false, "key": "method", "type": "tag" }, "op": "exists", "value": "" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "method--string--tag--true", "isColumn": true, "isJSON": false, "key": "method", "type": "tag" },
+                { "dataType": "string", "id": "uri--string--tag--true", "isColumn": true, "isJSON": false, "key": "uri", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{method}} {{uri}}",
+              "limit": null,
+              "orderBy": [{ "columnName": "#SIGNOZ_VALUE", "order": "desc" }],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-route-latency",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "method--string--tag--true", "isColumn": true, "isJSON": false, "key": "method", "type": "tag" },
+        { "dataType": "string", "id": "uri--string--tag--true", "isColumn": true, "isJSON": false, "key": "uri", "type": "tag" },
+        { "dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP P95 Latency by Route",
+      "yAxisUnit": "ns"
+    },
+    {
+      "description": "",
+      "id": "row-failures",
+      "panelTypes": "row",
+      "title": "Failures, slow paths and logs"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP status code counts from server spans.",
+      "fillSpans": false,
+      "id": "status-distribution",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "table",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": "" },
+              "aggregateOperator": "count",
+              "dataSource": "traces",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "service-filter", "key": { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }, "op": "=", "value": "ferriskey_server" },
+                  { "id": "server-span-filter", "key": { "dataType": "string", "id": "spanKind--string--tag--true", "isColumn": true, "isJSON": false, "key": "spanKind", "type": "tag" }, "op": "=", "value": "Server" },
+                  { "id": "status-exists", "key": { "dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag" }, "op": "exists", "value": "" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag" }],
+              "having": [],
+              "legend": "spans",
+              "limit": null,
+              "orderBy": [{ "columnName": "#SIGNOZ_VALUE", "order": "desc" }],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-status-distribution",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag" },
+        { "dataType": "string", "id": "httpRoute--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpRoute", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Status Distribution",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": { "A": "ns" },
+      "description": "Slowest server span names by average duration.",
+      "fillSpans": false,
+      "id": "slow-endpoints",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "table",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag" },
+              "aggregateOperator": "avg",
+              "dataSource": "traces",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "service-filter", "key": { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }, "op": "=", "value": "ferriskey_server" },
+                  { "id": "server-span-filter", "key": { "dataType": "string", "id": "spanKind--string--tag--true", "isColumn": true, "isJSON": false, "key": "spanKind", "type": "tag" }, "op": "=", "value": "Server" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag" },
+                { "dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag" },
+                { "dataType": "string", "id": "httpRoute--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpRoute", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "avg duration",
+              "limit": 10,
+              "orderBy": [{ "columnName": "#SIGNOZ_VALUE", "order": "desc" }],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-slow-endpoints",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag" },
+        { "dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag" },
+        { "dataType": "string", "id": "httpRoute--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpRoute", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Slowest Endpoints",
+      "yAxisUnit": "ns"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Log counts grouped by severity.",
+      "fillSpans": false,
+      "id": "log-severity",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "table",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": "" },
+              "aggregateOperator": "count",
+              "dataSource": "logs",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "log-service-filter", "key": { "dataType": "string", "id": "service.name--string--resource--false", "isColumn": false, "key": "service.name", "type": "resource" }, "op": "=", "value": "ferriskey_server" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "severity_text--string----true", "isColumn": true, "isJSON": false, "key": "severity_text", "type": "" }],
+              "having": [],
+              "legend": "logs",
+              "limit": null,
+              "orderBy": [{ "columnName": "#SIGNOZ_VALUE", "order": "desc" }],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-log-severity",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }, { "dataType": "string", "name": "severity_text", "type": "" }],
+      "selectedTracesFields": [{ "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Log Severity",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "SigNoz APM error-rate metric grouped by operation.",
+      "fillSpans": false,
+      "id": "span-errors",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "table",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "float64", "id": "signoz_calls_total--float64--Sum--true", "isColumn": true, "isJSON": false, "key": "signoz_calls_total", "type": "Sum" },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "metric-service-filter", "key": { "dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag" }, "op": "=", "value": "ferriskey_server" },
+                  { "id": "metric-error-filter", "key": { "dataType": "string", "id": "status.code--string--tag--false", "isColumn": false, "isJSON": false, "key": "status.code", "type": "tag" }, "op": "=", "value": "STATUS_CODE_ERROR" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "operation--string--tag--false", "isColumn": false, "isJSON": false, "key": "operation", "type": "tag" },
+                { "dataType": "string", "id": "status.code--string--tag--false", "isColumn": false, "isJSON": false, "key": "status.code", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "errors/sec",
+              "limit": 20,
+              "orderBy": [{ "columnName": "#SIGNOZ_VALUE", "order": "desc" }],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-span-errors",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "body", "type": "" }, { "dataType": "string", "name": "timestamp", "type": "" }],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag" },
+        { "dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "APM Error Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Recent application log lines for FerrisKey.",
+      "fillSpans": false,
+      "id": "recent-logs",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "list",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": { "dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": "" },
+              "aggregateOperator": "noop",
+              "dataSource": "logs",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "log-service-filter", "key": { "dataType": "string", "id": "service.name--string--resource--false", "isColumn": false, "key": "service.name", "type": "resource" }, "op": "=", "value": "ferriskey_server" }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": 50,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "query-recent-logs",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [{ "dataType": "string", "name": "timestamp", "type": "" }, { "dataType": "string", "name": "severity_text", "type": "" }, { "dataType": "string", "name": "body", "type": "" }],
+      "selectedTracesFields": [{ "dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag" }],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Recent Logs",
+      "yAxisUnit": "short"
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker build efficiency with dependency caching and pinned build tools; upgraded Rust runtime to 1.95.0.
* **New Features**
  * Added a SigNoz/Grafana dashboard for the FerrisKey API: request rate, p95 latency, log volume, HTTP throughput/p95, status distribution, slow endpoints, log severity, APM error-rate table, and recent logs list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->