### PR TITLE
fix(front): append /details to client-scope links from a Client

### DIFF
--- a/front/src/pages/client/ui/components/assigned-scopes-table.tsx
+++ b/front/src/pages/client/ui/components/assigned-scopes-table.tsx
@@ -12,7 +12,10 @@ import { ChevronDown } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { useAssignScope, useUnassignScope } from '@/api/client.api'
 import { Link } from 'react-router-dom'
-import { CLIENT_SCOPES_URL } from '@/routes/sub-router/client-scope.router'
+import {
+  CLIENT_SCOPE_DETAILS_URL,
+  CLIENT_SCOPE_URL,
+} from '@/routes/sub-router/client-scope.router'
 import { Schemas } from '@/api/api.client'
 
 interface AssignedScopesTableProps {
@@ -121,7 +124,7 @@ export default function AssignedScopesTable({ realm, clientId, scopes, isLoading
               <TableRow key={scope.id}>
                 <TableCell>
                   <Link
-                    to={`${CLIENT_SCOPES_URL(realm)}/${scope.id}`}
+                    to={`${CLIENT_SCOPE_URL(realm, scope.id)}${CLIENT_SCOPE_DETAILS_URL}`}
                     className='hover:underline'
                   >
                     {scope.name}

--- a/front/src/pages/client/ui/page-client-scopes.tsx
+++ b/front/src/pages/client/ui/page-client-scopes.tsx
@@ -9,7 +9,10 @@ import EffectiveScopesPreview from './components/effective-scopes-preview'
 import { OverviewList } from '@/components/ui/overview-list'
 import { Badge } from '@/components/ui/badge'
 import { Link } from 'react-router-dom'
-import { CLIENT_SCOPES_URL } from '@/routes/sub-router/client-scope.router'
+import {
+  CLIENT_SCOPE_DETAILS_URL,
+  CLIENT_SCOPE_URL,
+} from '@/routes/sub-router/client-scope.router'
 import { Schemas } from '@/api/api.client'
 
 export default function PageClientScopes() {
@@ -47,7 +50,7 @@ export default function PageClientScopes() {
               <div className='flex items-center gap-4 flex-1 min-w-0'>
                 <div className='flex flex-col gap-1 truncate'>
                   <Link
-                    to={`${CLIENT_SCOPES_URL(realm_name)}/${scope.id}`}
+                    to={`${CLIENT_SCOPE_URL(realm_name, scope.id)}${CLIENT_SCOPE_DETAILS_URL}`}
                     className='font-medium hover:underline truncate'
                   >
                     {scope.name}


### PR DESCRIPTION
## Summary

Fixes #962. When viewing a Client and clicking one of its assigned client scopes (e.g. `openid`), the Link's `href` was `/client-scopes/{scope.id}` -- but the route declared at `front/src/pages/client-scope/page-client-scope.tsx:19` matches `:scope_id/details`, so the navigation landed on no route and the page rendered blank.

The standalone Client Scopes overview list already builds the URL correctly (it goes through `CLIENT_SCOPE_URL` + `CLIENT_SCOPE_DETAILS_URL` in `page-client-scopes-overview-feature.tsx:29`), which is why that path doesn't repro the bug.

## Change

Two `<Link>` `to=` props now use the same helper combo the Client Scopes overview navigation uses:

- `front/src/pages/client/ui/page-client-scopes.tsx` — Assigned-scopes section header link
- `front/src/pages/client/ui/components/assigned-scopes-table.tsx` — table-row link inside the same page

Both go from:

```tsx
to={`${CLIENT_SCOPES_URL(realm_name)}/${scope.id}`}
```

to:

```tsx
to={`${CLIENT_SCOPE_URL(realm_name, scope.id)}${CLIENT_SCOPE_DETAILS_URL}`}
```

The `CLIENT_SCOPES_URL` import is still used (or replaced) per file as needed.

## Verification

- `cd front && pnpm run build` — succeeds.
- `pnpm run lint` — clean (no new warnings; the 11 pre-existing warnings are in unrelated files).
- Repro path: open a Client, scroll to "Assigned Scopes", click any scope. Before: blank page (URL ends `/client-scopes/<id>`). After: scope detail page renders (URL ends `/client-scopes/<id>/details`).

## AI assistance disclosure

This PR was written with assistance from Claude (Anthropic). The bug analysis and patch were reviewed before submission.

Closes #962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated client scope navigation link routing to use an improved URL construction pattern for accessing scope details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->