### PR TITLE
fix(front): bug can't remove entierly the port default value on edit it

### DIFF
--- a/front/src/components/ui/input-text.tsx
+++ b/front/src/components/ui/input-text.tsx
@@ -30,7 +30,8 @@ export function InputText({
 }: InputTextProps) {
   const [focused, setFocused] = useState<boolean>(false)
   const inputRef = useRef<HTMLDivElement>(null)
-  const currentValue = value
+  const currentValue =
+    typeof value === 'number' && Number.isNaN(value) ? '' : value
   const [currentType, setCurrentType] = useState<string>(type)
 
   const hasFocus = focused
@@ -78,8 +79,7 @@ export function InputText({
                 if (!onChange) return
 
                 if (type === 'number') {
-                  const val = e.currentTarget.valueAsNumber
-                  onChange(Number.isNaN(val) ? undefined : val)
+                  onChange(e.currentTarget.valueAsNumber)
                   return
                 }
 

--- a/front/src/components/ui/input-text.tsx
+++ b/front/src/components/ui/input-text.tsx
@@ -9,6 +9,7 @@ export interface InputTextProps {
   type?: 'text' | 'number' | 'password' | 'email'
   className?: string
   onChange?: (value: string | number | undefined) => void
+  onBlur?: () => void
   error?: string
   disabled?: boolean
   autoComplete?: string
@@ -21,6 +22,7 @@ export function InputText({
   label,
   value = '',
   onChange,
+  onBlur,
   type = 'text',
   error,
   className = '',
@@ -86,7 +88,10 @@ export function InputText({
                 onChange(e.currentTarget.value)
               }}
               onFocus={() => setFocused(true)}
-              onBlur={() => setFocused(false)}
+              onBlur={() => {
+                setFocused(false)
+                onBlur?.()
+              }}
             />
 
             {String(currentValue).length > 0 && type === 'password' && (

--- a/front/src/pages/realm/ui/page-realm-settings-smtp.tsx
+++ b/front/src/pages/realm/ui/page-realm-settings-smtp.tsx
@@ -100,7 +100,7 @@ function SmtpConfigForm({
                 <p className='text-sm text-muted-foreground mt-0.5'>SMTP server port (e.g. 587, 465, 25).</p>
               </div>
               <div className='w-1/2'>
-                <InputText label='Port' type='number' {...field} value={String(field.value)} error={form.formState.errors.port?.message} />
+                <InputText label='Port' type='number' {...field} error={form.formState.errors.port?.message} />
               </div>
             </div>
           )}

--- a/front/src/pages/realm/ui/page-realm-settings-smtp.tsx
+++ b/front/src/pages/realm/ui/page-realm-settings-smtp.tsx
@@ -100,7 +100,21 @@ function SmtpConfigForm({
                 <p className='text-sm text-muted-foreground mt-0.5'>SMTP server port (e.g. 587, 465, 25).</p>
               </div>
               <div className='w-1/2'>
-                <InputText label='Port' type='number' {...field} error={form.formState.errors.port?.message} />
+                <InputText
+                  label='Port'
+                  type='number'
+                  {...field}
+                  onBlur={() => {
+                    if (typeof field.value !== 'number' || Number.isNaN(field.value)) {
+                      const fallback = form.formState.defaultValues?.port
+                      if (typeof fallback === 'number') {
+                        field.onChange(fallback)
+                      }
+                    }
+                    field.onBlur()
+                  }}
+                  error={form.formState.errors.port?.message}
+                />
               </div>
             </div>
           )}


### PR DESCRIPTION
Removed `value={String(field.value)}` override. Spread `{...field}` alone passes value correctly. Empty field stays empty, schema `z.number().min(1)` rejects on submit so user gets validation error instead of phantom 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved SMTP Port field handling to rely on form controls and validate/fallback on blur for non-numeric values.
  * Updated input component to accept blur callbacks and forward them.
* **Bug Fixes**
  * Prevented display of raw NaN for numeric inputs by rendering empty value instead of "NaN".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->