### PR TITLE
fix(auth): handle remaining required actions after OTP challenge

### DIFF
--- a/api/src/application/http/trident/handlers/challenge_otp.rs
+++ b/api/src/application/http/trident/handlers/challenge_otp.rs
@@ -9,6 +9,7 @@ use axum::{Extension, extract::State};
 use axum_cookie::CookieManager;
 use ferriskey_core::domain::authentication::value_objects::Identity;
 use ferriskey_core::domain::trident::ports::{ChallengeOtpInput, TridentService};
+use ferriskey_core::domain::user::entities::RequiredAction;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
@@ -20,9 +21,12 @@ pub struct ChallengeOtpRequest {
     pub code: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ChallengeOtpResponse {
-    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub required_actions: Vec<RequiredAction>,
 }
 
 #[utoipa::path(
@@ -68,6 +72,7 @@ pub async fn challenge_otp(
 
     let response = ChallengeOtpResponse {
         url: result.login_url,
+        required_actions: result.required_actions,
     };
 
     Ok(Response::OK(response))

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -1248,14 +1248,6 @@ where
     ) -> Result<AuthenticateOutput, CoreError> {
         let flow_id = auth_session.compass_flow_id.map(FlowId);
 
-        if !auth_result.required_actions.is_empty() {
-            return Ok(AuthenticateOutput::requires_actions(
-                auth_result.user_id,
-                auth_result.required_actions,
-                auth_result.token.ok_or(CoreError::InternalServerError)?,
-            ));
-        }
-
         let has_otp_credentials = auth_result.credentials.iter().any(|cred| cred == "otp");
         let needs_configure_otp = auth_result
             .required_actions
@@ -1276,6 +1268,14 @@ where
             return Ok(AuthenticateOutput::requires_otp_challenge(
                 auth_result.user_id,
                 token,
+            ));
+        }
+
+        if !auth_result.required_actions.is_empty() {
+            return Ok(AuthenticateOutput::requires_actions(
+                auth_result.user_id,
+                auth_result.required_actions,
+                auth_result.token.ok_or(CoreError::InternalServerError)?,
             ));
         }
 

--- a/core/src/domain/trident/ports.rs
+++ b/core/src/domain/trident/ports.rs
@@ -7,6 +7,7 @@ use crate::domain::{
     common::entities::app_errors::CoreError,
     crypto::HashResult,
     trident::entities::{MfaRecoveryCode, TotpSecret},
+    user::entities::RequiredAction,
 };
 
 pub use webauthn_rs::prelude::{
@@ -89,7 +90,9 @@ pub struct ChallengeOtpInput {
 }
 
 pub struct ChallengeOtpOutput {
-    pub login_url: String,
+    pub login_url: Option<String>,
+    pub required_actions: Vec<RequiredAction>,
+    pub temporary_token: Option<String>,
 }
 
 pub struct SetupOtpInput {

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -964,6 +964,20 @@ where
             ));
         }
 
+        let required_actions = self
+            .user_required_action_repository
+            .get_required_actions(user.id)
+            .await
+            .map_err(|_| CoreError::InternalServerError)?;
+
+        if !required_actions.is_empty() {
+            return Ok(ChallengeOtpOutput {
+                login_url: None,
+                required_actions,
+                temporary_token: None,
+            });
+        }
+
         let authorization_code = generate_random_string();
 
         self.auth_session_repository
@@ -980,7 +994,11 @@ where
             auth_session.redirect_uri, authorization_code, current_state
         );
 
-        Ok(ChallengeOtpOutput { login_url })
+        Ok(ChallengeOtpOutput {
+            login_url: Some(login_url),
+            required_actions: Vec::new(),
+            temporary_token: None,
+        })
     }
 
     async fn setup_otp(

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -56,7 +56,7 @@ export namespace Schemas {
   export type BurnRecoveryCodeRequest = { recovery_code: string; recovery_code_format: string }
   export type BurnRecoveryCodeResponse = { login_url: string }
   export type ChallengeOtpRequest = Partial<{ code: string }>
-  export type ChallengeOtpResponse = { url: string }
+  export type ChallengeOtpResponse = Partial<{ url: string; required_actions: Array<string> }>
   export type ClientType = 'confidential' | 'public' | 'system'
   export type MaintenanceSessionStrategy = 'terminate' | 'expire'
   export type Client = {

--- a/front/src/api/api.interface.ts
+++ b/front/src/api/api.interface.ts
@@ -53,7 +53,8 @@ export interface ChallengeOtpRequest {
 }
 
 export interface ChallengeOtpResponse {
-  url: string
+  url?: string
+  required_actions?: string[]
 }
 
 export interface ClientsResponse {

--- a/front/src/pages/authentication/feature/page-otp-challenge-feature.tsx
+++ b/front/src/pages/authentication/feature/page-otp-challenge-feature.tsx
@@ -49,8 +49,22 @@ export default function PageOtpChallengeFeature() {
   useEffect(() => {
     if (!challengeOtpData) return
 
-    window.location.href = challengeOtpData.url
-  }, [challengeOtpData])
+    if (
+      challengeOtpData.required_actions &&
+      challengeOtpData.required_actions.length > 0 &&
+      token
+    ) {
+      const firstRequiredAction = challengeOtpData.required_actions[0]
+      navigate(
+        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}&client_data=${token}`
+      )
+      return
+    }
+
+    if (challengeOtpData.url) {
+      window.location.href = challengeOtpData.url
+    }
+  }, [challengeOtpData, navigate, realm_name, token])
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for required actions in OTP challenge flow—users may now be directed to complete additional authentication steps (e.g., security verification, profile updates) before gaining access.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/977)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->