### PR TITLE
fix(front): fix realm redirect to master and update-password 401 error

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios'
 import { useEffect, useMemo, useState } from 'react'
-import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router'
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { fetcher } from './api'
 import { createApiClient } from './api/api.client'
 import { TanstackQueryApiClient } from './api/api.tanstack'
@@ -142,10 +142,13 @@ function isUnresolvedApiUrl(value: unknown) {
   return trimmed.length === 0 || trimmed.includes('${')
 }
 
+function realmFromPath(pathname: string): string {
+  const match = pathname.match(/^\/realms\/([^/]+)/)
+  return match?.[1] ?? 'master'
+}
+
 function App() {
-  const { realm_name } = useParams()
   const [apiUrlSetup, setApiUrlSetup] = useState<boolean>(false)
-  const defaultRealm = realm_name ?? 'master'
 
   useEffect(() => {
     const init = async () => {
@@ -197,16 +200,18 @@ function App() {
     )
   }
 
-  return <AppRoutes defaultRealm={defaultRealm} />
+  return <AppRoutes />
 }
 
-function AppRoutes({ defaultRealm }: { defaultRealm: string }) {
+function AppRoutes() {
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const { isAuthenticated, isLoading } = useAuth()
   const { setConfig } = useConfig()
   const { theme } = useTheme()
   const { data: responseConfig } = useGetConfig()
+
+  const currentRealm = useMemo(() => realmFromPath(pathname), [pathname])
 
   useEffect(() => {
     if (responseConfig) {
@@ -230,12 +235,12 @@ function AppRoutes({ defaultRealm }: { defaultRealm: string }) {
       return
     if (!isAuthenticated && !authenticateRoute) {
       if (!pathname.includes('authentication/login')) {
-        navigate(`/realms/${defaultRealm}/authentication/login`, { replace: true })
+        navigate(`/realms/${currentRealm}/authentication/login`, { replace: true })
       }
     } else if (isAuthenticated && authenticateRoute && !pathname.includes('/callback') && !pathname.includes('/required-action')) {
-      navigate(`/realms/${defaultRealm}/overview`, { replace: true })
+      navigate(`/realms/${currentRealm}/overview`, { replace: true })
     }
-  }, [isAuthenticated, isLoading, authenticateRoute, pathname, defaultRealm, navigate])
+  }, [isAuthenticated, isLoading, authenticateRoute, pathname, currentRealm, navigate])
 
   return (
     <>
@@ -271,8 +276,8 @@ function AppRoutes({ defaultRealm }: { defaultRealm: string }) {
               <Navigate
                 to={
                   isAuthenticated
-                    ? `/realms/${defaultRealm}/overview`
-                    : `/realms/${defaultRealm}/authentication/login`
+                    ? `/realms/${currentRealm}/overview`
+                    : `/realms/${currentRealm}/authentication/login`
                 }
                 replace
               />
@@ -290,8 +295,8 @@ function AppRoutes({ defaultRealm }: { defaultRealm: string }) {
               <Navigate
                 to={
                   isAuthenticated
-                    ? `/realms/${defaultRealm}/overview`
-                    : `/realms/${defaultRealm}/authentication/login`
+                    ? `/realms/${currentRealm}/overview`
+                    : `/realms/${currentRealm}/authentication/login`
                 }
                 replace
               />

--- a/front/src/api/trident.api.ts
+++ b/front/src/api/trident.api.ts
@@ -91,9 +91,25 @@ export const useVerifyMagicLink = () => {
   })
 }
 
+export interface UpdatePasswordRequest {
+  data: { value: string }
+  token: string
+}
+
 export const useUpdatePassword = () => {
   return useMutation({
-    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/login-actions/update-password')
-      .mutationOptions,
+    mutationFn: async ({ realm, data, token }: BaseQuery & UpdatePasswordRequest) => {
+      const response = await window.axios.post(
+        `/realms/${realm}/login-actions/update-password`,
+        data,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+
+      return response.data
+    },
   })
 }

--- a/front/src/pages/authentication/feature/execution/update-password-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/update-password-feature.tsx
@@ -28,13 +28,13 @@ export default function UpdatePasswordFeature() {
   })
 
   const handleClick = form.handleSubmit((payload) => {
+    if (!token) return
     updatePassword({
-      path: {
-        realm_name: realm_name ?? 'master',
-      },
-      body: {
+      realm: realm_name ?? 'master',
+      data: {
         value: payload.password,
       },
+      token,
     })
   })
 


### PR DESCRIPTION
- Extract realm from URL pathname instead of useParams() (which is always undefined at root level), preventing non-master realm users from being redirected to master
- Switch useUpdatePassword to manual axios call with explicit Authorization header bearing the Temporary JWT token, fixing 401 on required action password update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Password update submissions are now prevented when required authentication credentials are missing, improving security and preventing submission errors.

* **Refactor**
  * Improved application realm detection and password update request handling for better reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/980)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->