### PR TITLE
fix: fix realm redirect to master and update-password 401 error

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios'
 import { useEffect, useMemo, useState } from 'react'
-import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router'
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { fetcher } from './api'
 import { createApiClient } from './api/api.client'
 import { TanstackQueryApiClient } from './api/api.tanstack'
@@ -142,10 +142,13 @@ function isUnresolvedApiUrl(value: unknown) {
   return trimmed.length === 0 || trimmed.includes('${')
 }
 
+function realmFromPath(pathname: string): string {
+  const match = pathname.match(/^\/realms\/([^/]+)/)
+  return match?.[1] ?? 'master'
+}
+
 function App() {
-  const { realm_name } = useParams()
   const [apiUrlSetup, setApiUrlSetup] = useState<boolean>(false)
-  const defaultRealm = realm_name ?? 'master'
 
   useEffect(() => {
     const init = async () => {
@@ -197,16 +200,18 @@ function App() {
     )
   }
 
-  return <AppRoutes defaultRealm={defaultRealm} />
+  return <AppRoutes />
 }
 
-function AppRoutes({ defaultRealm }: { defaultRealm: string }) {
+function AppRoutes() {
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const { isAuthenticated, isLoading } = useAuth()
   const { setConfig } = useConfig()
   const { theme } = useTheme()
   const { data: responseConfig } = useGetConfig()
+
+  const currentRealm = useMemo(() => realmFromPath(pathname), [pathname])
 
   useEffect(() => {
     if (responseConfig) {
@@ -230,12 +235,12 @@ function AppRoutes({ defaultRealm }: { defaultRealm: string }) {
       return
     if (!isAuthenticated && !authenticateRoute) {
       if (!pathname.includes('authentication/login')) {
-        navigate(`/realms/${defaultRealm}/authentication/login`, { replace: true })
+        navigate(`/realms/${currentRealm}/authentication/login`, { replace: true })
       }
     } else if (isAuthenticated && authenticateRoute && !pathname.includes('/callback') && !pathname.includes('/required-action')) {
-      navigate(`/realms/${defaultRealm}/overview`, { replace: true })
+      navigate(`/realms/${currentRealm}/overview`, { replace: true })
     }
-  }, [isAuthenticated, isLoading, authenticateRoute, pathname, defaultRealm, navigate])
+  }, [isAuthenticated, isLoading, authenticateRoute, pathname, currentRealm, navigate])
 
   return (
     <>
@@ -271,8 +276,8 @@ function AppRoutes({ defaultRealm }: { defaultRealm: string }) {
               <Navigate
                 to={
                   isAuthenticated
-                    ? `/realms/${defaultRealm}/overview`
-                    : `/realms/${defaultRealm}/authentication/login`
+                    ? `/realms/${currentRealm}/overview`
+                    : `/realms/${currentRealm}/authentication/login`
                 }
                 replace
               />
@@ -290,8 +295,8 @@ function AppRoutes({ defaultRealm }: { defaultRealm: string }) {
               <Navigate
                 to={
                   isAuthenticated
-                    ? `/realms/${defaultRealm}/overview`
-                    : `/realms/${defaultRealm}/authentication/login`
+                    ? `/realms/${currentRealm}/overview`
+                    : `/realms/${currentRealm}/authentication/login`
                 }
                 replace
               />

--- a/front/src/api/passkey.api.ts
+++ b/front/src/api/passkey.api.ts
@@ -1,44 +1,17 @@
 import { useMutation } from '@tanstack/react-query'
 import { BaseQuery } from '.'
-
-export interface PasskeyRequestOptionsRequest {
-  username?: string
-}
-
-export interface PasskeyPublicKeyOptions {
-  challenge: string
-  timeout?: number
-  rpId?: string
-  allowCredentials?: Array<{
-    type: string
-    id: string
-    transports?: string[]
-  }>
-  userVerification?: string
-  extensions?: Record<string, unknown>
-}
-
-export interface PasskeyRequestOptionsResponse {
-  publicKey: PasskeyPublicKeyOptions
-  mediation?: string
-}
-
-export interface PasskeyAuthenticateResponse {
-  login_url: string
-  status: string
-}
+import type { Schemas } from './api.client'
 
 export const usePasskeyRequestOptionsMutation = () => {
   return useMutation({
     mutationFn: async ({
       realm,
       data,
-    }: BaseQuery & { data: PasskeyRequestOptionsRequest }): Promise<PasskeyRequestOptionsResponse> => {
-      const response = await window.axios.post<PasskeyRequestOptionsResponse>(
-        `/realms/${realm}/login-actions/passkey-request-options`,
-        data
-      )
-      return response.data
+    }: BaseQuery & { data: Schemas.PasskeyRequestOptionsRequest }) => {
+      return window.tanstackApi.client.post('/realms/{realm_name}/login-actions/passkey-request-options', {
+        path: { realm_name: realm ?? 'master' },
+        body: data,
+      } as never) as Promise<Schemas.PasskeyPublicKeyCredentialRequestOptionsJSON>
     },
   })
 }
@@ -48,12 +21,11 @@ export const usePasskeyAuthenticateMutation = () => {
     mutationFn: async ({
       realm,
       data,
-    }: BaseQuery & { data: Record<string, unknown> }): Promise<PasskeyAuthenticateResponse> => {
-      const response = await window.axios.post<PasskeyAuthenticateResponse>(
-        `/realms/${realm}/login-actions/passkey-authenticate`,
-        data
-      )
-      return response.data
+    }: BaseQuery & { data: Schemas.PasskeyPublicKeyCredential }) => {
+      return window.tanstackApi.client.post('/realms/{realm_name}/login-actions/passkey-authenticate', {
+        path: { realm_name: realm ?? 'master' },
+        body: data,
+      } as never) as Promise<Schemas.PasskeyAuthenticateResponse>
     },
   })
 }

--- a/front/src/api/redirect_uris.api.ts
+++ b/front/src/api/redirect_uris.api.ts
@@ -1,6 +1,5 @@
-import { authStore } from '@/store/auth.store'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { RedirectUri } from './core.interface'
+import type { Schemas } from './api.client'
 
 export interface CreateRedirectUriMutate {
   realmName: string
@@ -14,22 +13,13 @@ export const useCreateRedirectUri = () => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async ({ realmName, clientId, payload }: CreateRedirectUriMutate) => {
-      const accessToken = authStore.getState().accessToken
-
-      const response = await window.axios.post<RedirectUri>(
-        `/realms/${realmName}/clients/${clientId}/redirects`,
-        {
+      return window.tanstackApi.client.post('/realms/{realm_name}/clients/{client_id}/redirects', {
+        path: { realm_name: realmName, client_id: clientId },
+        body: {
           value: payload.value,
           enabled: true,
         },
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        }
-      )
-
-      return response.data
+      }) as Promise<Schemas.RedirectUri>
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -49,18 +39,9 @@ export const useDeleteRedirectUri = () => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async ({ realmName, clientId, redirectUriId }: DeleteRedirectUriMutate) => {
-      const accessToken = authStore.getState().accessToken
-
-      const response = await window.axios.delete(
-        `/realms/${realmName}/clients/${clientId}/redirects/${redirectUriId}`,
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        }
-      )
-
-      return response.data
+      return window.tanstackApi.client.delete('/realms/{realm_name}/clients/{client_id}/redirects/{uri_id}', {
+        path: { realm_name: realmName, client_id: clientId, uri_id: redirectUriId },
+      })
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/front/src/api/trident.api.ts
+++ b/front/src/api/trident.api.ts
@@ -1,57 +1,43 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { BaseQuery } from '.'
-import {
-  ChallengeOtpRequest,
-  ChallengeOtpResponse,
-  OtpVerifyRequest,
-  SetupOtpResponse,
-  VerifyOtpResponse,
-} from './api.interface'
+import type { Schemas } from './api.client'
 
 export const useSetupOtp = ({ realm, token }: BaseQuery & { token?: string | null }) => {
   return useQuery({
     queryKey: ['setup-otp'],
-    queryFn: async (): Promise<SetupOtpResponse> => {
-      const response = await window.axios.get<SetupOtpResponse>(
-        `/realms/${realm}/login-actions/setup-otp`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      )
-
-      return response.data
+    queryFn: async (): Promise<Schemas.SetupOtpResponse> => {
+      return window.tanstackApi.client.get('/realms/{realm_name}/login-actions/setup-otp', {
+        path: { realm_name: realm ?? 'master' },
+        header: {
+          Authorization: `Bearer ${token}`,
+        },
+      } as never)
     },
     enabled: !!token,
   })
 }
 
 export interface VerifyOtpRequest {
-  data: OtpVerifyRequest
+  data: Schemas.OtpVerifyRequest
   token: string
 }
 
 export const useVerifyOtp = () => {
   return useMutation({
     mutationFn: async ({ realm, data, token }: BaseQuery & VerifyOtpRequest) => {
-      const response = await window.axios.post<VerifyOtpResponse>(
-        `/realms/${realm}/login-actions/verify-otp`,
-        data,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      )
-
-      return response.data
+      return window.tanstackApi.client.post('/realms/{realm_name}/login-actions/verify-otp', {
+        path: { realm_name: realm ?? 'master' },
+        body: data,
+        header: {
+          Authorization: `Bearer ${token}`,
+        },
+      } as never) as Promise<Schemas.VerifyOtpResponse>
     },
   })
 }
 
 export interface MutationChallengeOtpRequest {
-  data: ChallengeOtpRequest
+  data: Schemas.ChallengeOtpRequest
   token: string
 }
 
@@ -61,18 +47,14 @@ export const useChallengeOtp = () => {
       realm,
       data,
       token,
-    }: BaseQuery & MutationChallengeOtpRequest): Promise<ChallengeOtpResponse> => {
-      const response = await window.axios.post<ChallengeOtpResponse>(
-        `/realms/${realm}/login-actions/challenge-otp`,
-        data,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      )
-
-      return response.data
+    }: BaseQuery & MutationChallengeOtpRequest): Promise<Schemas.ChallengeOtpResponse> => {
+      return window.tanstackApi.client.post('/realms/{realm_name}/login-actions/challenge-otp', {
+        path: { realm_name: realm ?? 'master' },
+        body: data,
+        header: {
+          Authorization: `Bearer ${token}`,
+        },
+      } as never) as Promise<Schemas.ChallengeOtpResponse>
     },
   })
 }
@@ -92,24 +74,20 @@ export const useVerifyMagicLink = () => {
 }
 
 export interface UpdatePasswordRequest {
-  data: { value: string }
+  data: Schemas.UpdatePasswordRequest
   token: string
 }
 
 export const useUpdatePassword = () => {
   return useMutation({
     mutationFn: async ({ realm, data, token }: BaseQuery & UpdatePasswordRequest) => {
-      const response = await window.axios.post(
-        `/realms/${realm}/login-actions/update-password`,
-        data,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      )
-
-      return response.data
+      return window.tanstackApi.client.post('/realms/{realm_name}/login-actions/update-password', {
+        path: { realm_name: realm ?? 'master' },
+        body: data,
+        header: {
+          Authorization: `Bearer ${token}`,
+        },
+      } as never) as Promise<Schemas.UpdatePasswordResponse>
     },
   })
 }

--- a/front/src/api/trident.api.ts
+++ b/front/src/api/trident.api.ts
@@ -91,9 +91,25 @@ export const useVerifyMagicLink = () => {
   })
 }
 
+export interface UpdatePasswordRequest {
+  data: { value: string }
+  token: string
+}
+
 export const useUpdatePassword = () => {
   return useMutation({
-    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/login-actions/update-password')
-      .mutationOptions,
+    mutationFn: async ({ realm, data, token }: BaseQuery & UpdatePasswordRequest) => {
+      const response = await window.axios.post(
+        `/realms/${realm}/login-actions/update-password`,
+        data,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+
+      return response.data
+    },
   })
 }

--- a/front/src/pages/authentication/feature/execution/configure-passkey-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/configure-passkey-feature.tsx
@@ -57,7 +57,7 @@ export default function ConfigurePasskeyFeature() {
       )
 
       // Step 2: Create credential with browser
-      const credential = await startRegistration((optionsRes as { publicKey: unknown }).publicKey)
+      const credential = await startRegistration((optionsRes as { publicKey: Record<string, unknown> }).publicKey)
 
       // Step 3: Send credential to server
       await window.tanstackApi.client.post(

--- a/front/src/pages/authentication/feature/execution/configure-passkey-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/configure-passkey-feature.tsx
@@ -48,20 +48,25 @@ export default function ConfigurePasskeyFeature() {
     setIsLoading(true)
     try {
       // Step 1: Get creation options
-      const optionsRes = await window.axios.post(
-        `/realms/${realm_name}/login-actions/webauthn-public-key-create-options`,
-        {},
-        { headers: { Authorization: `Bearer ${token}` } }
+      const optionsRes = await window.tanstackApi.client.post(
+        '/realms/{realm_name}/login-actions/webauthn-public-key-create-options',
+        {
+          path: { realm_name: realm_name ?? 'master' },
+          header: { Authorization: `Bearer ${token}` },
+        } as never,
       )
 
       // Step 2: Create credential with browser
-      const credential = await startRegistration(optionsRes.data.publicKey)
+      const credential = await startRegistration((optionsRes as { publicKey: unknown }).publicKey)
 
       // Step 3: Send credential to server
-      await window.axios.post(
-        `/realms/${realm_name}/login-actions/webauthn-public-key-create`,
-        credential,
-        { headers: { Authorization: `Bearer ${token}` } }
+      await window.tanstackApi.client.post(
+        '/realms/{realm_name}/login-actions/webauthn-public-key-create',
+        {
+          path: { realm_name: realm_name ?? 'master' },
+          body: credential,
+          header: { Authorization: `Bearer ${token}` },
+        } as never,
       )
 
       setIsSuccess(true)

--- a/front/src/pages/authentication/feature/execution/update-password-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/update-password-feature.tsx
@@ -19,6 +19,12 @@ export default function UpdatePasswordFeature() {
   const navigate = useNavigate()
   const token = searchParams.get('client_data')
 
+  useEffect(() => {
+    if (!token) {
+      navigate(`/realms/${realm_name}/authentication/login`, { replace: true })
+    }
+  }, [token, navigate, realm_name])
+
   const form = useForm<UpdatePasswordSchema>({
     resolver: zodResolver(updatePasswordSchema),
     defaultValues: {

--- a/front/src/pages/authentication/feature/execution/update-password-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/update-password-feature.tsx
@@ -28,13 +28,13 @@ export default function UpdatePasswordFeature() {
   })
 
   const handleClick = form.handleSubmit((payload) => {
+    if (!token) return
     updatePassword({
-      path: {
-        realm_name: realm_name ?? 'master',
-      },
-      body: {
+      realm: realm_name ?? 'master',
+      data: {
         value: payload.password,
       },
+      token,
     })
   })
 

--- a/front/src/pages/authentication/feature/page-login-feature.tsx
+++ b/front/src/pages/authentication/feature/page-login-feature.tsx
@@ -11,7 +11,7 @@ import { AuthenticationStatus } from '@/api/api.interface.ts'
 import { useGetLoginSettings } from '@/api/realm.api'
 import { usePasskeyRequestOptionsMutation, usePasskeyAuthenticateMutation } from '@/api/passkey.api'
 import { useSendMagicLink } from '@/api/trident.api'
-import { isWebAuthnAvailable, isConditionalMediationAvailable, startAuthentication, startConditionalAuthentication } from '@/lib/webauthn'
+import { isWebAuthnAvailable, isConditionalMediationAvailable, startAuthentication, startConditionalAuthentication, type PublicKeyCredentialRequestOptionsJSON } from '@/lib/webauthn'
 import { magicLinkSchema, MagicLinkSchema } from '@/pages/authentication/schemas/magic-link.schema'
 
 const authenticateSchema = z.object({
@@ -128,7 +128,7 @@ export default function PageLoginFeature() {
         if (aborted) return
 
         const assertion = await startConditionalAuthentication(
-          response.publicKey,
+          response.publicKey as PublicKeyCredentialRequestOptionsJSON,
           abortController.signal
         )
 
@@ -268,7 +268,7 @@ export default function PageLoginFeature() {
       {
         onSuccess: async (response) => {
           try {
-            const assertion = await startAuthentication(response.publicKey)
+            const assertion = await startAuthentication(response.publicKey as PublicKeyCredentialRequestOptionsJSON)
             authenticatePasskey(
               { realm: realm_name, data: assertion },
               {


### PR DESCRIPTION
- Extract realm from URL pathname instead of useParams() (which is always undefined at root level), preventing non-master realm users from being redirected to master
- Switch useUpdatePassword to manual axios call with explicit Authorization header bearing the Temporary JWT token, fixing 401 on required action password update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Routing now derives the active realm from the URL path, simplifying top-level initialization and route handling.

* **New Features**
  * Unified API client for authentication flows with standardized request/response typing.
  * Passkey and OTP flows moved to the unified client for consistent behavior.
  * Added an explicit update-password request shape for safer server interactions.

* **Bug Fixes**
  * Prevented password-reset submissions without a valid token; authentication redirects now use the active realm.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/981)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->