### PR TITLE
refactor(email registration): split registration URL context

### DIFF
--- a/api/src/application/http/authentication/handlers/registration.rs
+++ b/api/src/application/http/authentication/handlers/registration.rs
@@ -4,7 +4,7 @@ use ferriskey_core::domain::{
     authentication::{
         entities::JwtToken,
         ports::AuthService,
-        value_objects::{RegisterUserInput, RegisterUserOutput},
+        value_objects::{RegisterUserInput, RegisterUserOutput, RegisterUserUrlContext},
     },
     realm::ports::RealmService,
 };
@@ -14,16 +14,14 @@ use uuid::Uuid;
 use validator::Validate;
 
 use super::auth::root_scoped_base_url;
-use crate::application::{
-    http::server::{
-        api_entities::{
-            api_error::{ApiError, ApiErrorResponse, ValidateJson},
-            response::Response,
-        },
-        app_state::AppState,
+use crate::application::http::server::{
+    api_entities::{
+        api_error::{ApiError, ApiErrorResponse, ValidateJson},
+        response::Response,
     },
-    url::FullUrl,
+    app_state::AppState,
 };
+use crate::application::url::FullUrl;
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct RegistrationRequest {
@@ -57,6 +55,21 @@ pub enum RegistrationResponse {
     PendingVerification(PendingVerificationResponse),
 }
 
+fn registration_verification_base_url(webapp_url: &str) -> String {
+    webapp_url.trim_end_matches('/').to_string()
+}
+
+fn registration_url_context(
+    webapp_url: &str,
+    request_base_url: &str,
+    root_path: &str,
+) -> RegisterUserUrlContext {
+    RegisterUserUrlContext {
+        issuer_base_url: root_scoped_base_url(request_base_url, root_path),
+        verification_base_url: registration_verification_base_url(webapp_url),
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/protocol/openid-connect/registrations",
@@ -78,7 +91,7 @@ pub enum RegistrationResponse {
 pub async fn registration_handler(
     Path(realm_name): Path<String>,
     State(state): State<AppState>,
-    FullUrl(_, url): FullUrl,
+    FullUrl(_, base_url): FullUrl,
     cookie: CookieManager,
     ValidateJson(req): ValidateJson<RegistrationRequest>,
 ) -> Result<Response<RegistrationResponse>, ApiError> {
@@ -92,11 +105,15 @@ pub async fn registration_handler(
         .get("FERRISKEY_SESSION")
         .and_then(|c| Uuid::parse_str(c.value()).ok());
 
-    let base_url = root_scoped_base_url(&url, &state.args.server.root_path);
+    let url_context = registration_url_context(
+        &state.args.webapp_url,
+        &base_url,
+        &state.args.server.root_path,
+    );
     let output = state
         .service
         .register_user(
-            base_url.clone(),
+            url_context,
             RegisterUserInput {
                 email: req.email,
                 first_name: req.first_name,
@@ -127,8 +144,9 @@ pub async fn registration_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json;
+
+    use super::*;
 
     #[test]
     fn test_registration_request_deserialization() {
@@ -237,6 +255,31 @@ mod tests {
                     "refresh_expires_in": 600,
                 }
             })
+        );
+    }
+
+    #[test]
+    fn registration_verification_base_url_uses_webapp_url() {
+        let base_url = registration_verification_base_url("http://localhost:3000/");
+
+        assert_eq!(base_url, "http://localhost:3000");
+    }
+
+    #[test]
+    fn registration_url_context_separates_issuer_and_verification_bases() {
+        let context = registration_url_context(
+            "https://account.longcipher.com/",
+            "https://ferriskey-api.longcipher.com",
+            "/auth",
+        );
+
+        assert_eq!(
+            context.issuer_base_url,
+            "https://ferriskey-api.longcipher.com/auth"
+        );
+        assert_eq!(
+            context.verification_base_url,
+            "https://account.longcipher.com"
         );
     }
 }

--- a/core/src/application/auth/mod.rs
+++ b/core/src/application/auth/mod.rs
@@ -11,7 +11,7 @@ use crate::{
             value_objects::{
                 EndSessionInput, EndSessionOutput, GenerateTokensForUserInput, GetUserInfoInput,
                 Identity, IntrospectTokenInput, RegisterUserInput, RegisterUserOutput,
-                RevokeTokenInput, UserInfoResponse,
+                RegisterUserUrlContext, RevokeTokenInput, UserInfoResponse,
             },
         },
         common::entities::app_errors::CoreError,
@@ -57,10 +57,10 @@ impl AuthService for ApplicationService {
 
     async fn register_user(
         &self,
-        url: String,
+        url_context: RegisterUserUrlContext,
         input: RegisterUserInput,
     ) -> Result<RegisterUserOutput, CoreError> {
-        self.auth_service.register_user(url, input).await
+        self.auth_service.register_user(url_context, input).await
     }
 
     async fn get_userinfo(

--- a/core/src/domain/authentication/ports.rs
+++ b/core/src/domain/authentication/ports.rs
@@ -15,7 +15,7 @@ use crate::domain::{
         },
         value_objects::{
             AuthenticationResult, CreateAuthSessionRequest, GrantTypeParams, RegisterUserInput,
-            RegisterUserOutput,
+            RegisterUserOutput, RegisterUserUrlContext,
         },
     },
     common::entities::app_errors::CoreError,
@@ -138,7 +138,7 @@ pub trait AuthService: Send + Sync {
     ) -> impl Future<Output = Result<AuthenticateOutput, CoreError>> + Send;
     fn register_user(
         &self,
-        url: String,
+        url_context: RegisterUserUrlContext,
         input: RegisterUserInput,
     ) -> impl Future<Output = Result<RegisterUserOutput, CoreError>> + Send;
     fn get_userinfo(

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -37,8 +37,8 @@ use crate::domain::{
         value_objects::{
             AuthenticationResult, EndSessionInput, EndSessionOutput, GenerateTokenInput,
             GenerateTokensForUserInput, GetUserInfoInput, GrantTypeParams, Identity,
-            IntrospectTokenInput, RegisterUserInput, RegisterUserOutput, RevokeTokenInput,
-            UserInfoResponse,
+            IntrospectTokenInput, RegisterUserInput, RegisterUserOutput, RegisterUserUrlContext,
+            RevokeTokenInput, UserInfoResponse,
         },
     },
     client::ports::{ClientRepository, PostLogoutRedirectUriRepository, RedirectUriRepository},
@@ -1248,6 +1248,14 @@ where
     ) -> Result<AuthenticateOutput, CoreError> {
         let flow_id = auth_session.compass_flow_id.map(FlowId);
 
+        if !auth_result.required_actions.is_empty() {
+            return Ok(AuthenticateOutput::requires_actions(
+                auth_result.user_id,
+                auth_result.required_actions,
+                auth_result.token.ok_or(CoreError::InternalServerError)?,
+            ));
+        }
+
         let has_otp_credentials = auth_result.credentials.iter().any(|cred| cred == "otp");
         let needs_configure_otp = auth_result
             .required_actions
@@ -1268,14 +1276,6 @@ where
             return Ok(AuthenticateOutput::requires_otp_challenge(
                 auth_result.user_id,
                 token,
-            ));
-        }
-
-        if !auth_result.required_actions.is_empty() {
-            return Ok(AuthenticateOutput::requires_actions(
-                auth_result.user_id,
-                auth_result.required_actions,
-                auth_result.token.ok_or(CoreError::InternalServerError)?,
             ));
         }
 
@@ -2118,9 +2118,14 @@ where
 
     async fn register_user(
         &self,
-        url: String,
+        url_context: RegisterUserUrlContext,
         input: RegisterUserInput,
     ) -> Result<RegisterUserOutput, CoreError> {
+        let RegisterUserUrlContext {
+            issuer_base_url,
+            verification_base_url,
+        } = url_context;
+
         let realm = self
             .realm_repository
             .get_by_name(&input.realm_name)
@@ -2174,7 +2179,7 @@ where
 
             if let Err(err) = self
                 .email_verification_service
-                .send_verification_email(user.id, input.realm_name, url)
+                .send_verification_email(user.id, input.realm_name, verification_base_url)
                 .await
             {
                 // Avoid leaving behind an unverified user that can no longer re-register.
@@ -2218,7 +2223,7 @@ where
             .generate_tokens_for_user(GenerateTokensForUserInput {
                 user_id: user.id,
                 realm_id: realm.id.into(),
-                base_url: url,
+                base_url: issuer_base_url,
                 client_id: None,
             })
             .await?;

--- a/core/src/domain/authentication/value_objects.rs
+++ b/core/src/domain/authentication/value_objects.rs
@@ -69,6 +69,12 @@ pub struct RegisterUserInput {
     pub session_code: Option<Uuid>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisterUserUrlContext {
+    pub issuer_base_url: String,
+    pub verification_base_url: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(tag = "status", content = "data", rename_all = "snake_case")]
 pub enum RegisterUserOutput {


### PR DESCRIPTION
## Summary
- Split registration URL handling into issuer and email verification base URLs.
- Keep JWT issuer generation based on the API request/root path while building verification links from the configured webapp URL.
- Preserve the existing registration outcomes for authenticated, redirect, and pending verification flows.

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p ferriskey-api registration
- cargo test -p ferriskey-core authentication


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated verification and authentication URL handling to improve reliability of email verification links and token issuance during registration.
* **Bug Fixes**
  * Fixed authentication flow so required-action flows no longer fall through into OTP challenges, preventing incorrect OTP prompts for users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/987)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->