### PR TITLE
feat(charts): add Helm chart for the Ferriskey operator

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -36,7 +36,7 @@ jobs:
           tag_version="${tag//ferriskey-/}"
           chart_version="$(yq .version charts/ferriskey/Chart.yaml)"
           if [ "$tag_version" != "$chart_version" ]; then
-            echo "Tag version `$tag_version` does not match chart version `$chart_version`"
+            echo "Tag version '${tag_version}' does not match chart version '${chart_version}'"
             exit 1
           fi
           echo "version=$tag_version" >> "$GITHUB_OUTPUT"
@@ -67,7 +67,7 @@ jobs:
           tag_version="${tag//ferriskey-operator-/}"
           chart_version="$(yq .version charts/ferriskey-operator/Chart.yaml)"
           if [ "$tag_version" != "$chart_version" ]; then
-            echo "Tag version `$tag_version` does not match chart version `$chart_version`"
+            echo "Tag version '${tag_version}' does not match chart version '${chart_version}'"
             exit 1
           fi
           echo "version=$tag_version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - ferriskey-*.*.*
+      - ferriskey-operator-*.*.*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +16,7 @@ permissions:
 
 jobs:
   helm:
+    if: startsWith(github.ref_name, 'ferriskey-') && !startsWith(github.ref_name, 'ferriskey-operator-')
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -43,3 +45,34 @@ jobs:
         run: |
           helm package charts/ferriskey
           helm push ferriskey-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/ferriskey/charts
+
+  helm-operator:
+    if: startsWith(github.ref_name, 'ferriskey-operator-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+
+      - name: set up helm
+        uses: azure/setup-helm@v4
+
+      - name: log-in to ghcr
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ferriskey --password-stdin
+
+      - name: check version
+        id: version
+        run: |
+          tag="${{ github.ref_name }}"
+          tag_version="${tag//ferriskey-operator-/}"
+          chart_version="$(yq .version charts/ferriskey-operator/Chart.yaml)"
+          if [ "$tag_version" != "$chart_version" ]; then
+            echo "Tag version `$tag_version` does not match chart version `$chart_version`"
+            exit 1
+          fi
+          echo "version=$tag_version" >> "$GITHUB_OUTPUT"
+
+      - name: push chart
+        run: |
+          helm package charts/ferriskey-operator
+          helm push ferriskey-operator-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/ferriskey/charts

--- a/charts/ferriskey-operator/.helmignore
+++ b/charts/ferriskey-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ferriskey-operator/Chart.yaml
+++ b/charts/ferriskey-operator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ferriskey-operator
+description: A Helm chart for the Ferriskey Kubernetes Operator
+type: application
+version: 0.1.0
+appVersion: "0.6.0"

--- a/charts/ferriskey-operator/README.md.gotmpl
+++ b/charts/ferriskey-operator/README.md.gotmpl
@@ -1,0 +1,78 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Overview
+
+The Ferriskey Operator manages `FerrisKeyCluster` instances declaratively through a Kubernetes Custom Resource Definition (CRD). This chart deploys the operator itself — the CRD, the operator Deployment, and the required RBAC resources.
+
+To deploy a Ferriskey cluster once the operator is running, create a `FerrisKeyCluster` resource:
+
+```yaml
+apiVersion: ferriskey.rs/v1alpha1
+kind: FerrisKeyCluster
+metadata:
+  name: my-ferriskey
+  namespace: ferriskey
+spec:
+  name: my-ferriskey
+  replicas: 1
+  version: "0.6.0"
+  api:
+    apiUrl: "https://api.iam.example.com"
+    webappUrl: "https://iam.example.com"
+    allowedOrigins:
+      - "https://iam.example.com"
+  database:
+    secretRef:
+      name: ferriskey-db-credentials
+    databaseName: ferriskey
+    sslMode: require
+```
+
+The database secret must contain the fields `host`, `port`, `user`, and `password`.
+
+## Installation
+
+```sh
+helm install ferriskey-operator oci://ghcr.io/ferriskey/charts/ferriskey-operator \
+  --namespace ferriskey-system \
+  --create-namespace
+```
+
+## CRD Management
+
+By default (`crds.install: true`), the CRD is installed as part of this chart and annotated with `helm.sh/resource-policy: keep` (`crds.keep: true`) to prevent accidental deletion on `helm uninstall`.
+
+If you manage CRDs externally (e.g. via GitOps or a separate CRD chart), set:
+
+```yaml
+crds:
+  install: false
+```
+
+## RBAC
+
+By default (`rbac.create: true`), the chart creates a `ClusterRole` and `ClusterRoleBinding` granting the operator the permissions it needs to manage `FerrisKeyCluster` resources across all namespaces.
+
+If you manage RBAC externally, set:
+
+```yaml
+rbac:
+  create: false
+```
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/ferriskey-operator/templates/_helpers.yaml
+++ b/charts/ferriskey-operator/templates/_helpers.yaml
@@ -1,0 +1,64 @@
+{{- define "ferriskey-operator.global.name" -}}
+{{ (.Values.nameOverride | default .Release.Name) | trunc 43 }}
+{{- end -}}
+
+{{- define "ferriskey-operator.global.labels" -}}
+app.kubernetes.io/instance: {{ include "ferriskey-operator.global.name" . }}
+app.kubernetes.io/version: {{ .Chart.Version }}
+app.kubernetes.io/part-of: ferriskey
+{{- end -}}
+
+{{- define "ferriskey-operator.global.podLabels" -}}
+app.kubernetes.io/instance: {{ include "ferriskey-operator.global.name" . }}
+app.kubernetes.io/part-of: ferriskey
+{{- end -}}
+
+{{- define "ferriskey-operator.operator.name" -}}
+{{ include "ferriskey-operator.global.name" . }}-operator
+{{- end -}}
+
+{{- define "ferriskey-operator.operator.labels" -}}
+{{- $labels := merge .Values.common.labels .Values.operator.labels -}}
+{{- include "ferriskey-operator.global.labels" . }}
+app.kubernetes.io/name: ferriskey-operator
+app.kubernetes.io/component: operator
+{{- with $labels }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "ferriskey-operator.operator.podLabels" -}}
+{{- $labels := merge .Values.common.podLabels .Values.operator.podLabels -}}
+{{- include "ferriskey-operator.global.podLabels" . }}
+app.kubernetes.io/name: ferriskey-operator
+app.kubernetes.io/component: operator
+{{- with $labels }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "ferriskey-operator.operator.serviceAccountName" -}}
+{{- if .Values.operator.serviceAccount.create -}}
+{{ .Values.operator.serviceAccount.name | default (include "ferriskey-operator.operator.name" .) }}
+{{- else -}}
+default
+{{- end -}}
+{{- end -}}
+
+{{- define "ferriskey-operator.operator.clusterRoleName" -}}
+{{ include "ferriskey-operator.operator.name" . }}
+{{- end -}}
+
+{{- define "ferriskey-operator.operator.clusterRoleBindingName" -}}
+{{ include "ferriskey-operator.operator.name" . }}
+{{- end -}}
+
+{{- define "ferriskey-operator.util.bool" -}}
+{{- if eq .value nil -}}
+{{- if ne .default nil -}}
+{{ .default }}
+{{- end -}}
+{{- else -}}
+{{ .value }}
+{{- end -}}
+{{- end -}}

--- a/charts/ferriskey-operator/templates/_helpers.yaml
+++ b/charts/ferriskey-operator/templates/_helpers.yaml
@@ -41,7 +41,7 @@ app.kubernetes.io/component: operator
 {{- if .Values.operator.serviceAccount.create -}}
 {{ .Values.operator.serviceAccount.name | default (include "ferriskey-operator.operator.name" .) }}
 {{- else -}}
-default
+{{ .Values.operator.serviceAccount.name | default "default" }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/ferriskey-operator/templates/_helpers.yaml
+++ b/charts/ferriskey-operator/templates/_helpers.yaml
@@ -18,7 +18,7 @@ app.kubernetes.io/part-of: ferriskey
 {{- end -}}
 
 {{- define "ferriskey-operator.operator.labels" -}}
-{{- $labels := merge .Values.common.labels .Values.operator.labels -}}
+{{- $labels := merge (default (dict) .Values.common.labels) (default (dict) .Values.operator.labels) -}}
 {{- include "ferriskey-operator.global.labels" . }}
 app.kubernetes.io/name: ferriskey-operator
 app.kubernetes.io/component: operator
@@ -28,7 +28,7 @@ app.kubernetes.io/component: operator
 {{- end -}}
 
 {{- define "ferriskey-operator.operator.podLabels" -}}
-{{- $labels := merge .Values.common.podLabels .Values.operator.podLabels -}}
+{{- $labels := merge (default (dict) .Values.common.podLabels) (default (dict) .Values.operator.podLabels) -}}
 {{- include "ferriskey-operator.global.podLabels" . }}
 app.kubernetes.io/name: ferriskey-operator
 app.kubernetes.io/component: operator

--- a/charts/ferriskey-operator/templates/crd.yaml
+++ b/charts/ferriskey-operator/templates/crd.yaml
@@ -1,0 +1,167 @@
+{{- if .Values.crds.install }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ferriskeyclusters.ferriskey.rs
+  {{- if .Values.crds.keep }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+  labels:
+    {{- include "ferriskey-operator.global.labels" . | nindent 4 }}
+spec:
+  group: ferriskey.rs
+  names:
+    categories: []
+    kind: FerrisKeyCluster
+    plural: ferriskeyclusters
+    shortNames:
+      - fkcl
+    singular: ferriskeycluster
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: FerrisKey Version
+          jsonPath: .spec.version
+          name: Version
+          type: string
+        - description: Number of Replicas
+          jsonPath: .spec.replicas
+          name: Replicas
+          type: integer
+        - description: Is the cluster ready?
+          jsonPath: .status.ready
+          name: Ready
+          type: boolean
+        - description: Current Phase
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Auto-generated derived type for FerrisKeyClusterSpec via `CustomResource`
+          properties:
+            spec:
+              properties:
+                api:
+                  properties:
+                    allowedOrigins:
+                      description: Allowed origins for CORS
+                      items:
+                        type: string
+                      type: array
+                    apiUrl:
+                      description: URL for the API service
+                      type: string
+                    webappUrl:
+                      description: URL for the web application
+                      type: string
+                  required:
+                    - allowedOrigins
+                    - apiUrl
+                    - webappUrl
+                  type: object
+                database:
+                  properties:
+                    databaseName:
+                      description: 'Optional: Database name override (if not specified in secret)'
+                      nullable: true
+                      type: string
+                    secretRef:
+                      description: Reference to a secret containing database credentials
+                      properties:
+                        name:
+                          description: Name of the secret containing database credentials
+                          type: string
+                        namespace:
+                          description: 'Optional: Namespace of the secret (defaults to same namespace as cluster)'
+                          nullable: true
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    sslMode:
+                      description: 'Optional: SSL mode for database connection'
+                      nullable: true
+                      type: string
+                  required:
+                    - secretRef
+                  type: object
+                name:
+                  type: string
+                replicas:
+                  format: uint32
+                  minimum: 0.0
+                  type: integer
+                version:
+                  type: string
+              required:
+                - api
+                - database
+                - name
+                - replicas
+                - version
+              type: object
+            status:
+              nullable: true
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      conditionType:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      message:
+                        nullable: true
+                        type: string
+                      reason:
+                        nullable: true
+                        type: string
+                      status:
+                        type: string
+                    required:
+                      - conditionType
+                      - lastTransitionTime
+                      - status
+                    type: object
+                  nullable: true
+                  type: array
+                databaseStatus:
+                  nullable: true
+                  properties:
+                    connected:
+                      type: boolean
+                    database:
+                      nullable: true
+                      type: string
+                    host:
+                      nullable: true
+                      type: string
+                    lastCheck:
+                      nullable: true
+                      type: string
+                  required:
+                    - connected
+                  type: object
+                message:
+                  nullable: true
+                  type: string
+                phase:
+                  nullable: true
+                  type: string
+                ready:
+                  type: boolean
+              required:
+                - ready
+              type: object
+          required:
+            - spec
+          title: FerrisKeyCluster
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{- end }}

--- a/charts/ferriskey-operator/templates/operator/cluster-role-binding.yaml
+++ b/charts/ferriskey-operator/templates/operator/cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ferriskey-operator.operator.clusterRoleBindingName" . }}
+  labels:
+    {{- include "ferriskey-operator.operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "ferriskey-operator.operator.clusterRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ferriskey-operator.operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ferriskey-operator/templates/operator/cluster-role.yaml
+++ b/charts/ferriskey-operator/templates/operator/cluster-role.yaml
@@ -26,10 +26,13 @@ rules:
     resources: ["jobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # The operator manages FerrisKeyCluster custom resources, their status, and finalizers
+  # The operator manages FerrisKeyCluster custom resources, their status, and finalizers.
+  # create and delete are intentionally omitted — FerrisKeyCluster instances are
+  # user-managed. The operator only reconciles (watches, reads, patches status,
+  # and manages the finalizer field).
   - apiGroups: ["ferriskey.rs"]
     resources: ["ferriskeyclusters", "ferriskeyclusters/status", "ferriskeyclusters/finalizers"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 
   # The operator may inspect CRDs to verify they are installed
   - apiGroups: ["apiextensions.k8s.io"]

--- a/charts/ferriskey-operator/templates/operator/cluster-role.yaml
+++ b/charts/ferriskey-operator/templates/operator/cluster-role.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ferriskey-operator.operator.clusterRoleName" . }}
+  labels:
+    {{- include "ferriskey-operator.operator.labels" . | nindent 4 }}
+rules:
+  # Core resources — the operator creates and manages Services, Secrets, and watches Events
+  - apiGroups: [""]
+    resources: ["services", "secrets", "events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # The operator reads pods to assess cluster health
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+
+  # The operator creates and manages API and webapp Deployments
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # The operator creates database migration Jobs
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # The operator manages FerrisKeyCluster custom resources, their status, and finalizers
+  - apiGroups: ["ferriskey.rs"]
+    resources: ["ferriskeyclusters", "ferriskeyclusters/status", "ferriskeyclusters/finalizers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # The operator may inspect CRDs to verify they are installed
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/ferriskey-operator/templates/operator/deployment.yaml
+++ b/charts/ferriskey-operator/templates/operator/deployment.yaml
@@ -1,0 +1,151 @@
+{{- $affinity := merge dict .Values.common.affinity .Values.operator.affinity -}}
+{{- $annotations := merge dict .Values.common.annotations .Values.operator.annotations -}}
+{{- $dnsConfig := merge dict .Values.common.dnsConfig .Values.operator.dnsConfig -}}
+{{- $env := concat .Values.common.env .Values.operator.env -}}
+{{- $envFrom := concat .Values.common.envFrom .Values.operator.envFrom -}}
+{{- $hostAliases := concat .Values.common.hostAliases .Values.operator.hostAliases -}}
+{{- $imagePullSecrets := concat .Values.common.imagePullSecrets .Values.operator.imagePullSecrets -}}
+{{- $initContainers := concat .Values.common.initContainers .Values.operator.initContainers -}}
+{{- $podAnnotations := merge dict .Values.common.podAnnotations .Values.operator.podAnnotations -}}
+{{- $revisionHistoryLimit := .Values.operator.revisionHistoryLimit | default .Values.common.revisionHistoryLimit -}}
+{{- $runtimeClassName := .Values.operator.runtimeClassName | default .Values.common.runtimeClassName -}}
+{{- $schedulerName := .Values.operator.schedulerName | default .Values.common.schedulerName -}}
+{{- $tolerations := concat .Values.common.tolerations .Values.operator.tolerations -}}
+{{- $topologySpreadConstraints := concat .Values.common.topologySpreadConstraints .Values.operator.topologySpreadConstraints -}}
+{{- $volumeMounts := concat .Values.common.volumeMounts .Values.operator.volumeMounts -}}
+{{- $volumes := concat .Values.common.volumes .Values.operator.volumes -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ferriskey-operator.operator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "ferriskey-operator.operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.operator.replicas }}
+  {{- if ne $revisionHistoryLimit nil }}
+  revisionHistoryLimit: {{ $revisionHistoryLimit }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ferriskey-operator.operator.podLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with $podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ferriskey-operator.operator.podLabels" . | nindent 8 }}
+    spec:
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: operator
+          {{- with .Values.operator.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.operator.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Values.common.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy | default .Values.common.image.pullPolicy }}
+          {{- with .Values.operator.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.operator.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.operator.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with $dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if ne .Values.operator.hostIPC nil }}
+      hostIPC: {{ .Values.operator.hostIPC }}
+      {{- end }}
+      {{- if ne .Values.operator.hostNetwork nil }}
+      hostNetwork: {{ .Values.operator.hostNetwork }}
+      {{- end }}
+      {{- if ne .Values.operator.hostPID nil }}
+      hostPID: {{ .Values.operator.hostPID }}
+      {{- end }}
+      {{- if ne .Values.operator.hostUsers nil }}
+      hostUsers: {{ .Values.operator.hostUsers }}
+      {{- end }}
+      {{- with $imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.nodeName }}
+      nodeName: {{ .Values.operator.nodeName }}
+      {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.preemptionPolicy }}
+      preemptionPolicy: {{ .Values.operator.preemptionPolicy }}
+      {{- end }}
+      {{- if ne .Values.operator.priority nil }}
+      priority: {{ .Values.operator.priority }}
+      {{- end }}
+      {{- if .Values.operator.priorityClassName }}
+      priorityClassName: {{ .Values.operator.priorityClassName }}
+      {{- end }}
+      {{- if $runtimeClassName }}
+      runtimeClassName: {{ $runtimeClassName }}
+      {{- end }}
+      {{- if $schedulerName }}
+      schedulerName: {{ $schedulerName }}
+      {{- end }}
+      {{- with .Values.operator.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ferriskey-operator.operator.serviceAccountName" . }}
+      {{- with $tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ferriskey-operator/templates/operator/service-account.yaml
+++ b/charts/ferriskey-operator/templates/operator/service-account.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.operator.serviceAccount.create }}
+{{- $annotations := merge dict .Values.common.serviceAccount.annotations .Values.operator.serviceAccount.annotations -}}
+{{- $labels := merge dict .Values.common.serviceAccount.labels .Values.operator.serviceAccount.labels -}}
+{{- $automountServiceAccountToken := include "ferriskey-operator.util.bool" (dict "value" .Values.operator.serviceAccount.automountServiceAccountToken "default" .Values.common.serviceAccount.automountServiceAccountToken) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ferriskey-operator.operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "ferriskey-operator.operator.labels" . | nindent 4 }}
+    {{- with $labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if ne $automountServiceAccountToken "" }}
+automountServiceAccountToken: {{ $automountServiceAccountToken }}
+{{- end }}
+{{- end }}

--- a/charts/ferriskey-operator/templates/validate.yaml
+++ b/charts/ferriskey-operator/templates/validate.yaml
@@ -1,0 +1,4 @@
+{{- /* Validate chart values before rendering resources. */ -}}
+{{- if and .Values.rbac.create (not .Values.operator.serviceAccount.create) -}}
+{{- fail "rbac.create requires operator.serviceAccount.create to be true — the ClusterRoleBinding needs a ServiceAccount to bind to" -}}
+{{- end -}}

--- a/charts/ferriskey-operator/values.yaml
+++ b/charts/ferriskey-operator/values.yaml
@@ -1,0 +1,238 @@
+# -- Override the name of the release.
+nameOverride: ~
+
+crds:
+  # -- Install the FerrisKeyCluster CRD as part of this chart.
+  # Set to `false` if you manage CRDs externally (e.g. via GitOps or a separate CRD chart).
+  install: true
+  # -- Keep the CRD on chart uninstall by annotating it with `helm.sh/resource-policy: keep`.
+  # Strongly recommended in production to avoid accidental data loss.
+  keep: true
+
+rbac:
+  # -- Create the ClusterRole and ClusterRoleBinding required by the operator.
+  # Set to `false` if you manage RBAC externally.
+  create: true
+
+common:
+  # -- Common annotations for all workloads.
+  annotations: {}
+  # -- Common labels for all workloads.
+  labels: {}
+
+  # -- Common annotations for all pods.
+  podAnnotations: {}
+  # -- Common labels for all pods.
+  podLabels: {}
+
+  image:
+    # -- Default pull policy for all images.
+    pullPolicy: IfNotPresent
+    # -- Default tag for all images. Defaults to the chart's appVersion.
+    tag: ~
+
+  # -- Common image pull secrets for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#localobjectreference-v1-core
+  imagePullSecrets: []
+
+  # -- (int) Default revision history limit for all workloads.
+  revisionHistoryLimit: ~
+
+  # -- Common environment variables for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envvar-v1-core
+  env: []
+  # -- Common environment variables from sources for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envfromsource-v1-core
+  envFrom: []
+
+  # -- Common volume mounts for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#volumemount-v1-core
+  volumeMounts: []
+  # -- Common volumes for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#volume-v1-core
+  volumes: []
+
+  # -- Common affinity for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#affinity-v1-core
+  affinity: {}
+  # -- Common tolerations for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#toleration-v1-core
+  tolerations: []
+  # -- Common topology spread constraints for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#topologyspreadconstraint-v1-core
+  topologySpreadConstraints: []
+
+  # -- Common DNS config for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#poddnsconfig-v1-core
+  dnsConfig: {}
+  # -- Common host aliases for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#hostalias-v1-core
+  hostAliases: []
+
+  # -- Common init containers for all pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#container-v1-core
+  initContainers: []
+
+  # -- Default runtime class name for all pods.
+  runtimeClassName: ~
+  # -- Default scheduler name for all pods.
+  schedulerName: ~
+
+  serviceAccount:
+    # -- Common annotations on all service accounts.
+    annotations: {}
+    # -- Common labels on all service accounts.
+    labels: {}
+    # -- (bool) Automount service account token by default for all service accounts.
+    automountServiceAccountToken: ~
+
+operator:
+  # -- Annotations on the operator workload.
+  annotations: {}
+  # -- Labels on the operator workload.
+  labels: {}
+
+  # -- Annotations on the operator pods.
+  podAnnotations: {}
+  # -- Labels on the operator pods.
+  podLabels: {}
+
+  image:
+    # -- Repository for the operator image.
+    repository: ghcr.io/ferriskey/ferriskey-operator
+    # -- Tag for the operator image. Defaults to the chart's appVersion.
+    tag: ~
+    # -- Pull policy for the operator image.
+    pullPolicy: ~
+
+  # -- Image pull secrets for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#localobjectreference-v1-core
+  imagePullSecrets: []
+
+  # -- Number of replicas for the operator.
+  # Operators should run as a single replica. Scale via leader election, not replicas.
+  replicas: 1
+
+  # -- (int) Revision history limit for the operator workload.
+  revisionHistoryLimit: ~
+
+  # -- Arguments for the operator container.
+  args: []
+  # -- Command for the operator container.
+  command: []
+
+  # -- Environment variables for the operator container.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envvar-v1-core
+  env: []
+  # -- Environment variables from sources for the operator container.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envfromsource-v1-core
+  envFrom: []
+
+  # -- Volume mounts for the operator container.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#volumemount-v1-core
+  volumeMounts: []
+  # -- Volumes for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#volume-v1-core
+  volumes: []
+
+  # -- Resources for the operator container.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#resourcerequirements-v1-core
+  resources:
+    requests:
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+  # -- Security context for the operator container.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#securitycontext-v1-core
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+
+  # -- Liveness probe for the operator container.
+  # Uses a process-level check since the operator does not expose an HTTP health endpoint.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#probe-v1-core
+  livenessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - kill -0 1
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  # -- Affinity for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#affinity-v1-core
+  affinity: {}
+  # -- Node name for the operator pods.
+  nodeName: ~
+  # -- Node selector for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#nodeselector-v1-core
+  nodeSelector: {}
+  # -- Tolerations for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#toleration-v1-core
+  tolerations: []
+  # -- Topology spread constraints for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#topologyspreadconstraint-v1-core
+  topologySpreadConstraints: []
+
+  # -- Security context for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podsecuritycontext-v1-core
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- (bool) Use host's IPC namespace for the operator pods.
+  hostIPC: ~
+  # -- (bool) Use host's network namespace for the operator pods.
+  hostNetwork: ~
+  # -- (bool) Use host's PID namespace for the operator pods.
+  hostPID: ~
+  # -- (bool) Use host's user namespace for the operator pods.
+  hostUsers: ~
+
+  # -- DNS config for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#poddnsconfig-v1-core
+  dnsConfig: {}
+  # -- Host aliases for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#hostalias-v1-core
+  hostAliases: []
+
+  # -- Init containers for the operator pods.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#container-v1-core
+  initContainers: []
+
+  # -- Preemption policy for the operator pods.
+  preemptionPolicy: ~
+  # -- (int) Priority for the operator pods.
+  priority: ~
+  # -- Priority class name for the operator pods.
+  priorityClassName: ~
+
+  # -- Runtime class name for the operator pods.
+  runtimeClassName: ~
+  # -- Scheduler name for the operator pods.
+  schedulerName: ~
+
+  serviceAccount:
+    # -- Create a service account for the operator.
+    create: true
+    # -- Name of the service account. Defaults to the operator workload name.
+    name: ~
+    # -- Annotations on the operator service account.
+    annotations: {}
+    # -- Labels on the operator service account.
+    labels: {}
+    # -- Automount the service account token.
+    # Must be true — the operator needs the token to call the Kubernetes API.
+    automountServiceAccountToken: true

--- a/sh/helm-docs.sh
+++ b/sh/helm-docs.sh
@@ -4,3 +4,4 @@ set -e
 
 bash -c "docker run --rm -v $(pwd):/helm-docs -u $(id -u) jnorwood/helm-docs:latest"
 git diff --exit-code --quiet -- charts/ferriskey/README.md
+git diff --exit-code --quiet -- charts/ferriskey-operator/README.md


### PR DESCRIPTION
Closes #511

## What this does

Adds `charts/ferriskey-operator/` — a production-grade Helm chart to deploy the Ferriskey Kubernetes Operator (CRDs + operator service), following the exact same conventions as the existing `charts/ferriskey` chart.

## Chart structure

```
charts/ferriskey-operator/
├── .helmignore
├── Chart.yaml                  (version: 0.1.0, appVersion: 0.6.0)
├── README.md.gotmpl            (helm-docs compatible)
├── values.yaml                 (fully documented)
└── templates/
    ├── _helpers.yaml           (named templates, same pattern as main chart)
    ├── validate.yaml           (fail-fast guard)
    ├── crd.yaml                (FerrisKeyCluster CRD, toggleable)
    └── operator/
        ├── deployment.yaml
        ├── service-account.yaml
        ├── cluster-role.yaml
        └── cluster-role-binding.yaml
```

## Key design decisions

**No bjw-s app-template dependency.** The common library only supports namespaced `Role`/`RoleBinding` — not `ClusterRole`/`ClusterRoleBinding`, which the operator requires. A hand-crafted chart following the project's own conventions is cleaner and has no external dependency.

**CRD in `templates/` with toggles** (`crds.install`, `crds.keep`) rather than Helm's native `crds/` directory, so users who manage CRDs via GitOps can opt out, and upgrades can update the CRD schema.

**RBAC** (`rbac.create`) creates a `ClusterRole` with least-privilege rules derived from what the operator actually does in `k8s.rs`: manages Deployments, Services, Secrets, Jobs, and FerrisKeyCluster resources across namespaces.

**Liveness probe** uses `exec: kill -0 1` — the operator has no HTTP health endpoint, so this is the correct Kubernetes-native approach for a binary process without adding scope to this ticket.

**Hardened security defaults** matching the main chart: `readOnlyRootFilesystem`, drop ALL capabilities, non-root UID 1000, `seccompProfile: RuntimeDefault`.

## CI

Updated `.github/workflows/helm.yaml` to publish the operator chart on `ferriskey-operator-*.*.*` tags to `oci://ghcr.io/ferriskey/charts`, independent of the main chart versioning.

## Quick install

```sh
helm install ferriskey-operator oci://ghcr.io/ferriskey/charts/ferriskey-operator \
  --namespace ferriskey-system \
  --create-namespace
```

---

> **Note for reviewer:** During local testing, the operator pod crashed on startup with a rustls crypto provider panic (both `aws-lc-rs` and `ring` are compiled in via `kube-client` 2.x, and rustls 0.23 requires an explicit default to be set). This is **not in scope for this ticket** — the chart itself is correct and the image deploys fine. I've opened a separate issue and PR for that Rust-level fix.

@NathaelB — ready for your review 🦀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart to deploy the Ferriskey Operator (includes CRD, Deployment, ServiceAccount, RBAC, and templated README).
  * Chart adds configurable CRD installation/retention, RBAC/service-account toggles, and comprehensive default values for the operator (image, replicas, probes, resources, scheduling).
  * Validation guard prevents RBAC/service-account mismatches.
  * Release workflow now packages and publishes the operator chart automatically on matching release tags.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/988)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->