### PR TITLE
fix(operator): install rustls crypto provider before TLS init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,7 @@ dependencies = [
  "mockall 0.13.1",
  "rand 0.9.2",
  "reqwest 0.12.24",
+ "rustls",
  "schemars 1.1.0",
  "serde",
  "serde_json",
@@ -4389,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -13,6 +13,10 @@ name = "ferriskey-operator"
 [dependencies]
 kube = { version = "2.0.1", features = ["derive", "runtime", "client"] }
 k8s-openapi = { version = "0.26.0", features = ["latest"] }
+# Explicit rustls dependency to select the aws-lc-rs crypto provider at startup.
+# Required because rustls 0.23 compiles both aws-lc-rs and ring backends via
+# kube-client, and panics unless one is installed as the default before TLS runs.
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tokio = { version = "1.45.1", features = ["full"] }
 anyhow = "1.0.98"
 tracing = "0.1.41"

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -2,6 +2,13 @@ use ferriskey_operator::application::OperatorApp;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // rustls 0.23 requires an explicit crypto provider when multiple backends
+    // are compiled in (aws-lc-rs and ring are both present via kube-client).
+    // Install aws-lc-rs as the default before any TLS connection is attempted.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
+
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         .init();

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -7,7 +7,7 @@ async fn main() -> anyhow::Result<()> {
     // Install aws-lc-rs as the default before any TLS connection is attempted.
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
-        .expect("failed to install rustls crypto provider");
+        .map_err(|_| anyhow::anyhow!("failed to install rustls crypto provider"))?;
 
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)


### PR DESCRIPTION
Fixes #989

## What happened

The operator pod crashes immediately on startup with this panic:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate feature
Call CryptoProvider::install_default() before this point to select a provider manually
```

## Why

`rustls` 0.23 changed behaviour: when multiple crypto backends are compiled into the binary, it no longer silently picks one — it panics. Both `aws-lc-rs` and `ring` end up in our binary as transitive dependencies of `kube-client` 2.x, so the ambiguity triggers the panic on every startup before any Kubernetes API call is even attempted.

## Fix

Two minimal changes:

**`operator/Cargo.toml`** — explicit `rustls` dependency with the `aws-lc-rs` feature, so the provider module is reachable from `main.rs`:

```toml
rustls = { version = "0.23", features = ["aws-lc-rs"] }
```

**`operator/src/main.rs`** — install the provider as the very first statement in `main()`, before `tokio` or `kube` touch any TLS:

```rust
rustls::crypto::aws_lc_rs::default_provider()
    .install_default()
    .expect("failed to install rustls crypto provider");
```

`aws-lc-rs` is chosen over `ring` because it is the rustls project's recommended default and is already the primary backend in our dependency tree.

## Testing

Verified locally: operator pod starts, connects to the Kubernetes API, and begins reconciling `FerrisKeyCluster` resources without panicking.

---

> Discovered while testing PR #988 (operator Helm chart). The chart itself is correct — this is a pre-existing issue in the operator binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by ensuring the TLS cryptographic provider is initialized before any connections, preventing runtime crashes and connection failures.
  * Better handling of provider initialization failures to avoid unexpected panics during TLS setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/990)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->