### PR TITLE
fix(auth-session): reset authenticated flag when reissuing authorization code in brokered SSO flow

### DIFF
--- a/core/src/infrastructure/repositories/auth_session_repository.rs
+++ b/core/src/infrastructure/repositories/auth_session_repository.rs
@@ -135,6 +135,10 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
                 Expr::value(code),
             )
             .col_expr(
+                crate::entity::auth_sessions::Column::Authenticated,
+                Expr::value(false),
+            )
+            .col_expr(
                 crate::entity::auth_sessions::Column::UserId,
                 Expr::value(user_id),
             )
@@ -393,7 +397,8 @@ mod tests {
             .await
             .expect("create test schema");
 
-        let schema_url = format!("{}?options=-c search_path={}", base_url, schema);
+        let separator = if base_url.contains('?') { '&' } else { '?' };
+        let schema_url = format!("{base_url}{separator}options=-c search_path={schema}");
         let schema_pool = sqlx::PgPool::connect(&schema_url)
             .await
             .expect("connect schema pool");
@@ -518,5 +523,33 @@ mod tests {
             "update_code must reset authenticated to false on reuse (RFC 6749 §10.5)"
         );
         assert_eq!(after_second.code, Some("code-round-2".into()));
+    }
+
+    /// `update_code_and_user_id` must also reset `authenticated` to `false`.
+    ///
+    /// This path is taken when Ferriskey simultaneously stamps a fresh code and
+    /// binds a user to the session (e.g. direct-grant flows).  The same RFC 6749
+    /// §4.1.2 invariant applies: the code has not been exchanged yet.
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-core -- --ignored"]
+    async fn update_code_and_user_id_resets_authenticated_to_false() {
+        let (repo, realm_id, client_id) = setup().await;
+
+        let session = make_session(realm_id, client_id, true);
+        let created = repo.create(&session).await.expect("create session");
+        assert!(created.authenticated, "pre-condition");
+
+        let user_id = Uuid::new_v4();
+        let updated = repo
+            .update_code_and_user_id(created.id, "fresh-code-with-user".into(), user_id)
+            .await
+            .expect("update_code_and_user_id");
+
+        assert!(
+            !updated.authenticated,
+            "update_code_and_user_id must reset authenticated to false (RFC 6749 §4.1.2)"
+        );
+        assert_eq!(updated.code, Some("fresh-code-with-user".into()));
+        assert_eq!(updated.user_id, Some(user_id));
     }
 }

--- a/core/src/infrastructure/repositories/auth_session_repository.rs
+++ b/core/src/infrastructure/repositories/auth_session_repository.rs
@@ -249,6 +249,35 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
         Ok(session)
     }
 
+    /// Stamps a fresh authorization code onto an existing auth session and resets
+    /// the `authenticated` flag to `false`.
+    ///
+    /// # RFC 6749 semantics
+    ///
+    /// The OAuth 2.0 Authorization Code flow (RFC 6749 §4.1) separates two
+    /// distinct moments:
+    ///
+    /// * **§4.1.2 – Authorization Response**: the authorization server issues a
+    ///   short-lived, single-use authorization code and redirects the client.
+    ///   At this point the code has *not* yet been exchanged.
+    ///
+    /// * **§4.1.3 – Access Token Request**: the client presents the code to the
+    ///   token endpoint in exchange for tokens.  Only after a successful exchange
+    ///   should the code be considered "used".
+    ///
+    /// RFC 6749 §10.5 further requires that the authorization server ensure codes
+    /// "cannot be used more than once".  Ferriskey implements this invariant with
+    /// the `authenticated` column: `false` means the code is ready to be
+    /// exchanged; `true` means it has already been exchanged (or revoked) and
+    /// must be rejected by the token endpoint.
+    ///
+    /// This function is called during the brokered SSO callback (RFC 8414 / OIDC
+    /// Core §3.1) when Ferriskey reuses an existing `auth_session` that already
+    /// has a user linked.  A fresh code is generated for the downstream client,
+    /// therefore `authenticated` **must** be reset to `false` so that the token
+    /// endpoint will accept the exchange.  Leaving `authenticated = true` here
+    /// causes `authorization_code()` to reject the brand-new code immediately
+    /// with `CoreError::InvalidToken`, breaking the entire brokered login flow.
     async fn update_code(
         &self,
         session_code: Uuid,
@@ -259,9 +288,12 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
                 crate::entity::auth_sessions::Column::Code,
                 Expr::value(code),
             )
+            // Reset to false: this code has not yet been exchanged for tokens.
+            // See RFC 6749 §4.1.2 (code issuance) vs §4.1.3 (code exchange) and
+            // the `authenticated` invariant described in the doc-comment above.
             .col_expr(
                 crate::entity::auth_sessions::Column::Authenticated,
-                Expr::value(true),
+                Expr::value(false),
             )
             .filter(crate::entity::auth_sessions::Column::Id.eq(session_code))
             .exec_with_returning(&self.db)
@@ -318,5 +350,173 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
             })?;
 
         Ok(())
+    }
+}
+
+/// Integration tests for `PostgresAuthSessionRepository`.
+///
+/// These tests require a running PostgreSQL instance and are skipped during
+/// regular `cargo test` runs.  Execute them explicitly with:
+///
+/// ```text
+/// cargo test -p ferriskey-core -- --ignored
+/// ```
+///
+/// Environment variables (defaults shown):
+/// ```text
+/// DATABASE_URL = postgres://ferriskey:ferriskey@localhost:5432/ferriskey
+/// ```
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::Database as SeaOrmDatabase;
+    use sqlx::Executor as _;
+    use uuid::Uuid;
+
+    use crate::domain::authentication::{
+        entities::{AuthSession, AuthSessionParams},
+        ports::AuthSessionRepository as _,
+    };
+    use crate::domain::realm::entities::RealmId;
+
+    async fn setup() -> (PostgresAuthSessionRepository, Uuid, Uuid) {
+        let base_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://ferriskey:ferriskey@localhost:5432/ferriskey".to_string());
+
+        let schema = format!("auth_session_test_{}", Uuid::new_v4().simple());
+
+        let admin_pool = sqlx::PgPool::connect(&base_url)
+            .await
+            .expect("connect admin pool");
+        admin_pool
+            .execute(sqlx::query(&format!(r#"CREATE SCHEMA "{}""#, schema)))
+            .await
+            .expect("create test schema");
+
+        let schema_url = format!("{}?options=-c search_path={}", base_url, schema);
+        let schema_pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+        sqlx::migrate!("migrations")
+            .run(&schema_pool)
+            .await
+            .expect("run migrations");
+
+        let realm_id = Uuid::new_v4();
+        let client_id = Uuid::new_v4();
+
+        sqlx::query(
+            "INSERT INTO realms (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())",
+        )
+        .bind(realm_id)
+        .bind(format!("test-realm-{realm_id}"))
+        .execute(&schema_pool)
+        .await
+        .expect("insert test realm");
+
+        sqlx::query(
+            "INSERT INTO clients (id, realm_id, name, client_id, enabled, protocol, \
+             public_client, service_account_enabled, client_type, created_at, updated_at) \
+             VALUES ($1, $2, 'test-client', 'test-client', TRUE, 'openid-connect', \
+             TRUE, FALSE, 'public', NOW(), NOW())",
+        )
+        .bind(client_id)
+        .bind(realm_id)
+        .execute(&schema_pool)
+        .await
+        .expect("insert test client");
+
+        let db = SeaOrmDatabase::connect(&schema_url)
+            .await
+            .expect("sea-orm connect");
+        (PostgresAuthSessionRepository::new(db), realm_id, client_id)
+    }
+
+    fn make_session(realm_id: Uuid, client_id: Uuid, authenticated: bool) -> AuthSession {
+        AuthSession::new(AuthSessionParams {
+            realm_id: RealmId::new(realm_id),
+            client_id,
+            redirect_uri: "http://localhost/callback".into(),
+            response_type: "code".into(),
+            scope: "openid".into(),
+            state: None,
+            nonce: None,
+            user_id: None,
+            code: None,
+            authenticated,
+            webauthn_challenge: None,
+            webauthn_challenge_issued_at: None,
+            compass_flow_id: None,
+        })
+    }
+
+    /// A freshly-issued authorization code must have `authenticated = false`.
+    ///
+    /// RFC 6749 §4.1.2 defines code issuance (step D of the flow); the code has
+    /// not been exchanged yet so it must not be pre-marked as used.
+    ///
+    /// Regression: `update_code` was previously setting `authenticated = true`,
+    /// causing the token endpoint to reject the brand-new code immediately with
+    /// `CoreError::InvalidToken` — breaking every brokered SSO login where
+    /// Ferriskey reused an existing `auth_session` row.
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-core -- --ignored"]
+    async fn update_code_resets_authenticated_to_false() {
+        let (repo, realm_id, client_id) = setup().await;
+
+        // Start with an already-consumed session (authenticated = true).
+        let session = make_session(realm_id, client_id, true);
+        let created = repo.create(&session).await.expect("create session");
+        assert!(created.authenticated, "pre-condition");
+
+        let updated = repo
+            .update_code(created.id, "fresh-auth-code".into())
+            .await
+            .expect("update_code");
+
+        assert!(
+            !updated.authenticated,
+            "update_code must reset authenticated to false (RFC 6749 §4.1.2)"
+        );
+        assert_eq!(updated.code, Some("fresh-auth-code".into()));
+    }
+
+    /// `update_code` must reset `authenticated` on every call so a session can
+    /// be reused across multiple brokered SSO login cycles.
+    ///
+    /// RFC 6749 §10.5 requires single-use per code, not per session: after a
+    /// successful exchange (`authenticated = true`) a subsequent `update_code`
+    /// must produce a fresh, exchangeable code.
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-core -- --ignored"]
+    async fn update_code_enables_reuse_across_login_cycles() {
+        let (repo, realm_id, client_id) = setup().await;
+
+        let session = make_session(realm_id, client_id, false);
+        let created = repo.create(&session).await.expect("create session");
+
+        // First SSO callback — issues code for first login.
+        let after_first = repo
+            .update_code(created.id, "code-round-1".into())
+            .await
+            .expect("first update_code");
+        assert!(!after_first.authenticated, "ready for first exchange");
+
+        // Token exchange marks the code as used (RFC 6749 §4.1.3).
+        repo.update_authenticated(created.id, true)
+            .await
+            .expect("mark used");
+
+        // Second SSO callback — reuses the session for a new login cycle.
+        let after_second = repo
+            .update_code(created.id, "code-round-2".into())
+            .await
+            .expect("second update_code");
+
+        assert!(
+            !after_second.authenticated,
+            "update_code must reset authenticated to false on reuse (RFC 6749 §10.5)"
+        );
+        assert_eq!(after_second.code, Some("code-round-2".into()));
     }
 }

--- a/core/src/infrastructure/repositories/auth_session_repository.rs
+++ b/core/src/infrastructure/repositories/auth_session_repository.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use sea_orm::{
-    prelude::Expr, ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection,
-    EntityTrait, QueryFilter,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    prelude::Expr,
 };
 use tracing::error;
 use uuid::Uuid;

--- a/core/src/infrastructure/repositories/auth_session_repository.rs
+++ b/core/src/infrastructure/repositories/auth_session_repository.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
-    prelude::Expr,
+    prelude::Expr, ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection,
+    EntityTrait, QueryFilter,
 };
 use tracing::error;
 use uuid::Uuid;
@@ -384,8 +384,9 @@ mod tests {
     use crate::domain::realm::entities::RealmId;
 
     async fn setup() -> (PostgresAuthSessionRepository, Uuid, Uuid) {
-        let base_url = std::env::var("DATABASE_URL")
-            .unwrap_or_else(|_| "postgres://ferriskey:ferriskey@localhost:5432/ferriskey".to_string());
+        let base_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+            "postgres://ferriskey:ferriskey@localhost:5432/ferriskey".to_string()
+        });
 
         let schema = format!("auth_session_test_{}", Uuid::new_v4().simple());
 


### PR DESCRIPTION
## What happened

Every brokered SSO login (identity provider callback) returns HTTP 401 `Invalid token` when the client attempts the authorization code exchange, making the entire brokered login flow non-functional.

The error comes from `authorization_code()` in `authentication/services.rs`:

```rust
if auth_session.authenticated {
    return Err(CoreError::InvalidToken);   // ← always hit
}
```

## Why

`update_code` in `auth_session_repository.rs` was setting `authenticated = true` at the same time as stamping the new authorization code:

```rust
// Before — broken
.col_expr(Column::Authenticated, Expr::value(true))   // ❌
```

The `authenticated` flag is Ferriskey's implementation of the single-use requirement in [RFC 6749 §10.5](https://www.rfc-editor.org/rfc/rfc6749#section-10.5): it is set to `true` only **after** a successful token exchange to prevent code replay.

[RFC 6749 §4.1.2](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2) defines the moment of code **issuance** — the code has not been exchanged yet and must not be pre-marked as used. Setting `authenticated = true` here caused `authorization_code()` to reject the brand-new code immediately, before the client ever got a chance to exchange it.

The bug is triggered specifically in the UPDATE path of `handle_callback` (`broker_services.rs` line 617) when `broker_session.auth_session_id` is `Some` — i.e. when Ferriskey reuses an existing `auth_session` row for the brokered login rather than creating a fresh one.

## Fix

Reset `authenticated` to `false` when issuing a new code, consistent with the CREATE path and with RFC 6749 §4.1.2:

```rust
// After — correct
.col_expr(Column::Authenticated, Expr::value(false))   // ✅
```

## Tests

Two integration tests added to `auth_session_repository.rs` (marked `#[ignore]`, require PostgreSQL):

- `update_code_resets_authenticated_to_false` — regression test: verifies that calling `update_code` on a session with `authenticated = true` produces a session with `authenticated = false`.
- `update_code_enables_reuse_across_login_cycles` — covers the multi-cycle reuse scenario: after a successful exchange marks the session used, a subsequent `update_code` must reset the flag so the session can be reused for a new login.

Run with:
```
cargo test -p ferriskey-core -- --ignored
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fresh authorization codes now reliably reset session authentication state so sessions remain unauthenticated until the token exchange, preventing premature authentication during brokered SSO reuse.

* **Tests**
  * Added integration tests verifying session reuse across multiple login cycles and correct authentication-state transitions when issuing fresh authorization codes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/1000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->