### PR TITLE
feat: expose portal layouts http endpoints

### DIFF
--- a/api/src/application/http.rs
+++ b/api/src/application/http.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod health;
 pub mod maintenance;
 pub mod organization;
+pub mod portal_layouts;
 pub mod portal_theme;
 pub mod realm;
 pub mod role;

--- a/api/src/application/http/portal_layouts/handlers/create_layout.rs
+++ b/api/src/application/http/portal_layouts/handlers/create_layout.rs
@@ -1,0 +1,71 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::{
+        entities::PortalLayout,
+        ports::{CreateLayoutInput, PortalLayoutsService},
+    },
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::application::http::{
+    portal_layouts::validators::CreatePortalLayoutValidator,
+    server::{
+        api_entities::{
+            api_error::{ApiError, ApiErrorResponse, ValidateJson},
+            response::Response,
+        },
+        app_state::AppState,
+    },
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CreatePortalLayoutResponse {
+    pub data: PortalLayout,
+}
+
+#[utoipa::path(
+    post,
+    path = "",
+    tag = "portal-layouts",
+    summary = "Create a portal layout",
+    description = "Creates a new portal layout. The first layout in a realm is automatically marked as default.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+    ),
+    request_body = CreatePortalLayoutValidator,
+    responses(
+        (status = 201, description = "Layout created successfully", body = CreatePortalLayoutResponse),
+        (status = 400, description = "Invalid request data", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn create_layout(
+    Path(realm_name): Path<String>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+    ValidateJson(payload): ValidateJson<CreatePortalLayoutValidator>,
+) -> Result<Response<CreatePortalLayoutResponse>, ApiError> {
+    let layout = state
+        .service
+        .create_layout(
+            identity,
+            CreateLayoutInput {
+                realm_name,
+                name: payload.name,
+                tree: payload.tree,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::Created(CreatePortalLayoutResponse {
+        data: layout,
+    }))
+}

--- a/api/src/application/http/portal_layouts/handlers/delete_layout.rs
+++ b/api/src/application/http/portal_layouts/handlers/delete_layout.rs
@@ -1,0 +1,64 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::ports::{GetLayoutInput, PortalLayoutsService},
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::application::http::server::{
+    api_entities::{
+        api_error::{ApiError, ApiErrorResponse},
+        response::Response,
+    },
+    app_state::AppState,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DeletePortalLayoutResponse {
+    message: String,
+}
+
+#[utoipa::path(
+    delete,
+    path = "/{layout_id}",
+    tag = "portal-layouts",
+    summary = "Delete a portal layout",
+    description = "Deletes a portal layout.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+        ("layout_id" = Uuid, Path, description = "Portal layout ID"),
+    ),
+    responses(
+        (status = 200, description = "Layout deleted successfully", body = DeletePortalLayoutResponse),
+        (status = 404, description = "Layout not found", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn delete_layout(
+    Path((realm_name, layout_id)): Path<(String, Uuid)>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+) -> Result<Response<DeletePortalLayoutResponse>, ApiError> {
+    state
+        .service
+        .delete_layout(
+            identity,
+            GetLayoutInput {
+                realm_name,
+                layout_id,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::OK(DeletePortalLayoutResponse {
+        message: "Portal layout deleted successfully".to_string(),
+    }))
+}

--- a/api/src/application/http/portal_layouts/handlers/get_layout.rs
+++ b/api/src/application/http/portal_layouts/handlers/get_layout.rs
@@ -1,0 +1,65 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::{
+        entities::PortalLayout,
+        ports::{GetLayoutInput, PortalLayoutsService},
+    },
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::application::http::server::{
+    api_entities::{
+        api_error::{ApiError, ApiErrorResponse},
+        response::Response,
+    },
+    app_state::AppState,
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct GetPortalLayoutResponse {
+    pub data: PortalLayout,
+}
+
+#[utoipa::path(
+    get,
+    path = "/{layout_id}",
+    tag = "portal-layouts",
+    summary = "Get a portal layout",
+    description = "Retrieves a single portal layout by id.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+        ("layout_id" = Uuid, Path, description = "Portal layout ID"),
+    ),
+    responses(
+        (status = 200, description = "Layout retrieved successfully", body = GetPortalLayoutResponse),
+        (status = 404, description = "Layout not found", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn get_layout(
+    Path((realm_name, layout_id)): Path<(String, Uuid)>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+) -> Result<Response<GetPortalLayoutResponse>, ApiError> {
+    let layout = state
+        .service
+        .get_layout(
+            identity,
+            GetLayoutInput {
+                realm_name,
+                layout_id,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::OK(GetPortalLayoutResponse { data: layout }))
+}

--- a/api/src/application/http/portal_layouts/handlers/get_public_default_layout.rs
+++ b/api/src/application/http/portal_layouts/handlers/get_public_default_layout.rs
@@ -1,0 +1,50 @@
+use axum::extract::{Path, State};
+use ferriskey_core::domain::portal_layouts::{
+    entities::PortalLayout,
+    ports::{ListLayoutsInput, PortalLayoutsService},
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::application::http::server::{
+    api_entities::{
+        api_error::{ApiError, ApiErrorResponse},
+        response::Response,
+    },
+    app_state::AppState,
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct GetPublicDefaultPortalLayoutResponse {
+    pub data: Option<PortalLayout>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/default",
+    tag = "portal-layouts",
+    summary = "Get the public default portal layout",
+    description = "Returns the realm's default portal layout for the unauthenticated portal pages. No auth required.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+    ),
+    responses(
+        (status = 200, description = "Default layout retrieved (may be null)", body = GetPublicDefaultPortalLayoutResponse),
+        (status = 401, description = "Unknown realm", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn get_public_default_layout(
+    Path(realm_name): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Response<GetPublicDefaultPortalLayoutResponse>, ApiError> {
+    let layout = state
+        .service
+        .get_public_default_layout(ListLayoutsInput { realm_name })
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::OK(GetPublicDefaultPortalLayoutResponse {
+        data: layout,
+    }))
+}

--- a/api/src/application/http/portal_layouts/handlers/list_layouts.rs
+++ b/api/src/application/http/portal_layouts/handlers/list_layouts.rs
@@ -1,0 +1,56 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::{
+        entities::PortalLayout,
+        ports::{ListLayoutsInput, PortalLayoutsService},
+    },
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::application::http::server::{
+    api_entities::{
+        api_error::{ApiError, ApiErrorResponse},
+        response::Response,
+    },
+    app_state::AppState,
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ListPortalLayoutsResponse {
+    pub data: Vec<PortalLayout>,
+}
+
+#[utoipa::path(
+    get,
+    path = "",
+    tag = "portal-layouts",
+    summary = "List portal layouts",
+    description = "Returns every portal layout configured for the realm.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+    ),
+    responses(
+        (status = 200, description = "Layouts retrieved successfully", body = ListPortalLayoutsResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn list_layouts(
+    Path(realm_name): Path<String>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+) -> Result<Response<ListPortalLayoutsResponse>, ApiError> {
+    let layouts = state
+        .service
+        .list_layouts(identity, ListLayoutsInput { realm_name })
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::OK(ListPortalLayoutsResponse { data: layouts }))
+}

--- a/api/src/application/http/portal_layouts/handlers/mod.rs
+++ b/api/src/application/http/portal_layouts/handlers/mod.rs
@@ -1,0 +1,7 @@
+pub mod create_layout;
+pub mod delete_layout;
+pub mod get_layout;
+pub mod get_public_default_layout;
+pub mod list_layouts;
+pub mod set_default_layout;
+pub mod update_layout;

--- a/api/src/application/http/portal_layouts/handlers/set_default_layout.rs
+++ b/api/src/application/http/portal_layouts/handlers/set_default_layout.rs
@@ -1,0 +1,67 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::{
+        entities::PortalLayout,
+        ports::{GetLayoutInput, PortalLayoutsService},
+    },
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::application::http::server::{
+    api_entities::{
+        api_error::{ApiError, ApiErrorResponse},
+        response::Response,
+    },
+    app_state::AppState,
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct SetDefaultPortalLayoutResponse {
+    pub data: PortalLayout,
+}
+
+#[utoipa::path(
+    put,
+    path = "/{layout_id}/default",
+    tag = "portal-layouts",
+    summary = "Mark a portal layout as default",
+    description = "Marks the given layout as the default for the realm. Any other default is unset in the same transaction.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+        ("layout_id" = Uuid, Path, description = "Portal layout ID"),
+    ),
+    responses(
+        (status = 200, description = "Layout marked as default", body = SetDefaultPortalLayoutResponse),
+        (status = 404, description = "Layout not found", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn set_default_layout(
+    Path((realm_name, layout_id)): Path<(String, Uuid)>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+) -> Result<Response<SetDefaultPortalLayoutResponse>, ApiError> {
+    let layout = state
+        .service
+        .set_default_layout(
+            identity,
+            GetLayoutInput {
+                realm_name,
+                layout_id,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::Updated(SetDefaultPortalLayoutResponse {
+        data: layout,
+    }))
+}

--- a/api/src/application/http/portal_layouts/handlers/update_layout.rs
+++ b/api/src/application/http/portal_layouts/handlers/update_layout.rs
@@ -1,0 +1,75 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::{
+        entities::PortalLayout,
+        ports::{PortalLayoutsService, UpdateLayoutInput},
+    },
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::application::http::{
+    portal_layouts::validators::UpdatePortalLayoutValidator,
+    server::{
+        api_entities::{
+            api_error::{ApiError, ApiErrorResponse, ValidateJson},
+            response::Response,
+        },
+        app_state::AppState,
+    },
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UpdatePortalLayoutResponse {
+    pub data: PortalLayout,
+}
+
+#[utoipa::path(
+    put,
+    path = "/{layout_id}",
+    tag = "portal-layouts",
+    summary = "Update a portal layout",
+    description = "Updates the name and tree of an existing portal layout.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+        ("layout_id" = Uuid, Path, description = "Portal layout ID"),
+    ),
+    request_body = UpdatePortalLayoutValidator,
+    responses(
+        (status = 200, description = "Layout updated successfully", body = UpdatePortalLayoutResponse),
+        (status = 400, description = "Invalid request data", body = ApiErrorResponse),
+        (status = 404, description = "Layout not found", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn update_layout(
+    Path((realm_name, layout_id)): Path<(String, Uuid)>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+    ValidateJson(payload): ValidateJson<UpdatePortalLayoutValidator>,
+) -> Result<Response<UpdatePortalLayoutResponse>, ApiError> {
+    let layout = state
+        .service
+        .update_layout(
+            identity,
+            UpdateLayoutInput {
+                realm_name,
+                layout_id,
+                name: payload.name,
+                tree: payload.tree,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::Updated(UpdatePortalLayoutResponse {
+        data: layout,
+    }))
+}

--- a/api/src/application/http/portal_layouts/mod.rs
+++ b/api/src/application/http/portal_layouts/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod router;
+pub mod validators;

--- a/api/src/application/http/portal_layouts/router.rs
+++ b/api/src/application/http/portal_layouts/router.rs
@@ -1,0 +1,63 @@
+use super::handlers::create_layout::{__path_create_layout, create_layout};
+use super::handlers::delete_layout::{__path_delete_layout, delete_layout};
+use super::handlers::get_layout::{__path_get_layout, get_layout};
+use super::handlers::get_public_default_layout::{
+    __path_get_public_default_layout, get_public_default_layout,
+};
+use super::handlers::list_layouts::{__path_list_layouts, list_layouts};
+use super::handlers::set_default_layout::{__path_set_default_layout, set_default_layout};
+use super::handlers::update_layout::{__path_update_layout, update_layout};
+use crate::application::{auth::auth, http::server::app_state::AppState};
+use axum::{Router, middleware, routing::get};
+use utoipa::OpenApi;
+
+#[derive(OpenApi)]
+#[openapi(paths(
+    list_layouts,
+    create_layout,
+    get_layout,
+    update_layout,
+    delete_layout,
+    set_default_layout,
+))]
+pub struct PortalLayoutsApiDoc;
+
+#[derive(OpenApi)]
+#[openapi(paths(get_public_default_layout))]
+pub struct PortalLayoutsPublicApiDoc;
+
+pub fn portal_layouts_routes(state: AppState) -> Router<AppState> {
+    let admin_routes = Router::new()
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/portal-layouts",
+                state.args.server.root_path
+            ),
+            get(list_layouts).post(create_layout),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/portal-layouts/{{layout_id}}",
+                state.args.server.root_path
+            ),
+            get(get_layout).put(update_layout).delete(delete_layout),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/portal-layouts/{{layout_id}}/default",
+                state.args.server.root_path
+            ),
+            axum::routing::put(set_default_layout),
+        )
+        .layer(middleware::from_fn_with_state(state.clone(), auth));
+
+    let public_routes = Router::new().route(
+        &format!(
+            "{}/realms/{{realm_name}}/portal-layouts/public/default",
+            state.args.server.root_path
+        ),
+        get(get_public_default_layout),
+    );
+
+    admin_routes.merge(public_routes)
+}

--- a/api/src/application/http/portal_layouts/validators.rs
+++ b/api/src/application/http/portal_layouts/validators.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::Validate;
+
+#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+pub struct CreatePortalLayoutValidator {
+    #[validate(length(
+        min = 1,
+        max = 255,
+        message = "name must be between 1 and 255 characters"
+    ))]
+    pub name: String,
+
+    pub tree: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+pub struct UpdatePortalLayoutValidator {
+    #[validate(length(
+        min = 1,
+        max = 255,
+        message = "name must be between 1 and 255 characters"
+    ))]
+    pub name: String,
+
+    pub tree: serde_json::Value,
+}

--- a/api/src/application/http/server/http_server.rs
+++ b/api/src/application/http/server/http_server.rs
@@ -9,6 +9,7 @@ use crate::application::http::compass::router::compass_routes;
 use crate::application::http::email_template::router::email_template_routes;
 use crate::application::http::maintenance::router::maintenance_routes;
 use crate::application::http::organization::router::organization_routes;
+use crate::application::http::portal_layouts::router::portal_layouts_routes;
 use crate::application::http::portal_theme::router::portal_theme_routes;
 use crate::application::http::realm::router::realm_routes;
 use crate::application::http::role::router::role_routes;
@@ -130,6 +131,7 @@ pub fn router(state: AppState) -> Result<Router, anyhow::Error> {
         .merge(maintenance_routes(state.clone()))
         .merge(email_template_routes(state.clone()))
         .merge(portal_theme_routes(state.clone()))
+        .merge(portal_layouts_routes(state.clone()))
         .merge(trident_routes(state.clone()))
         .merge(seawatch_router(state.clone()))
         .merge(compass_routes(state.clone()))

--- a/api/src/application/http/server/openapi.rs
+++ b/api/src/application/http/server/openapi.rs
@@ -8,6 +8,7 @@ use crate::application::http::{
     email_template::router::{EmailTemplateApiDoc, EmailTemplateVariablesApiDoc},
     maintenance::router::MaintenanceApiDoc,
     organization::router::OrganizationApiDoc,
+    portal_layouts::router::{PortalLayoutsApiDoc, PortalLayoutsPublicApiDoc},
     portal_theme::router::PortalThemeApiDoc,
     realm::router::RealmApiDoc,
     role::router::RoleApiDoc,
@@ -39,6 +40,8 @@ use utoipa::OpenApi;
         (path = "/realms/{realm_name}", api = CompassApiDoc),
         (path = "/realms/{realm_name}/email-templates", api = EmailTemplateApiDoc),
         (path = "/realms/{realm_name}/portal/theme", api = PortalThemeApiDoc),
+        (path = "/realms/{realm_name}/portal-layouts", api = PortalLayoutsApiDoc),
+        (path = "/realms/{realm_name}/portal-layouts/public", api = PortalLayoutsPublicApiDoc),
         (path = "/email-templates/variables", api = EmailTemplateVariablesApiDoc),
         (path = "/realms/{realm_name}/organizations", api = OrganizationApiDoc),
         (path = "/realms/{realm_name}/clients", api = MaintenanceApiDoc)

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -119,6 +119,7 @@ pub mod mail;
 pub mod maintenance;
 pub mod migrate;
 pub mod organization;
+pub mod portal_layouts;
 pub mod portal_theme;
 pub mod realm;
 pub mod role;

--- a/core/src/application/portal_layouts/mod.rs
+++ b/core/src/application/portal_layouts/mod.rs
@@ -1,0 +1,85 @@
+use crate::{
+    ApplicationService,
+    domain::{
+        authentication::value_objects::Identity,
+        common::entities::app_errors::CoreError,
+        portal_layouts::{
+            entities::PortalLayout,
+            ports::{
+                CreateLayoutInput, GetLayoutInput, ListLayoutsInput, PortalLayoutsService,
+                UpdateLayoutInput,
+            },
+        },
+    },
+};
+
+impl PortalLayoutsService for ApplicationService {
+    async fn list_layouts(
+        &self,
+        identity: Identity,
+        input: ListLayoutsInput,
+    ) -> Result<Vec<PortalLayout>, CoreError> {
+        self.portal_layouts_service
+            .list_layouts(identity, input)
+            .await
+    }
+
+    async fn get_layout(
+        &self,
+        identity: Identity,
+        input: GetLayoutInput,
+    ) -> Result<PortalLayout, CoreError> {
+        self.portal_layouts_service
+            .get_layout(identity, input)
+            .await
+    }
+
+    async fn create_layout(
+        &self,
+        identity: Identity,
+        input: CreateLayoutInput,
+    ) -> Result<PortalLayout, CoreError> {
+        self.portal_layouts_service
+            .create_layout(identity, input)
+            .await
+    }
+
+    async fn update_layout(
+        &self,
+        identity: Identity,
+        input: UpdateLayoutInput,
+    ) -> Result<PortalLayout, CoreError> {
+        self.portal_layouts_service
+            .update_layout(identity, input)
+            .await
+    }
+
+    async fn set_default_layout(
+        &self,
+        identity: Identity,
+        input: GetLayoutInput,
+    ) -> Result<PortalLayout, CoreError> {
+        self.portal_layouts_service
+            .set_default_layout(identity, input)
+            .await
+    }
+
+    async fn delete_layout(
+        &self,
+        identity: Identity,
+        input: GetLayoutInput,
+    ) -> Result<(), CoreError> {
+        self.portal_layouts_service
+            .delete_layout(identity, input)
+            .await
+    }
+
+    async fn get_public_default_layout(
+        &self,
+        input: ListLayoutsInput,
+    ) -> Result<Option<PortalLayout>, CoreError> {
+        self.portal_layouts_service
+            .get_public_default_layout(input)
+            .await
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added portal layout management API with full CRUD operations: create, retrieve, update, and delete layouts
  * Ability to set and manage default layouts per realm
  * Public endpoint for accessing default portal layouts without authentication
  * Comprehensive OpenAPI documentation for all portal layout endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/1003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->