### PR TITLE
feat: add basic auth support

### DIFF
--- a/api/src/application/http/authentication.rs
+++ b/api/src/application/http/authentication.rs
@@ -1,3 +1,4 @@
+pub mod basic_auth;
 pub mod handlers;
 pub mod router;
 pub mod validators;

--- a/api/src/application/http/authentication/basic_auth.rs
+++ b/api/src/application/http/authentication/basic_auth.rs
@@ -1,0 +1,53 @@
+use axum::http::HeaderMap;
+use base64::{Engine, engine::general_purpose};
+
+pub fn try_parse_basic_client_credentials(headers: &HeaderMap) -> Option<(String, String)> {
+    let value = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    let prefix = "Basic ";
+    if value.len() < prefix.len() || !value[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        return None;
+    }
+    let value = &value[prefix.len()..];
+
+    let decoded = general_purpose::STANDARD.decode(value).ok()?;
+    let decoded = String::from_utf8(decoded).ok()?;
+
+    let (client_id, client_secret) = decoded.split_once(':')?;
+    Some((client_id.to_string(), client_secret.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::try_parse_basic_client_credentials;
+    use axum::http::{HeaderMap, HeaderValue, header::AUTHORIZATION};
+
+    fn basic(value: &str) -> HeaderValue {
+        HeaderValue::from_str(value).unwrap()
+    }
+
+    #[test]
+    fn parses_basic_credentials() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, basic("Basic Y2xpZW50OnNlY3JldA==")); // client:secret
+
+        let creds = try_parse_basic_client_credentials(&headers);
+        assert_eq!(creds, Some(("client".to_string(), "secret".to_string())));
+    }
+
+    #[test]
+    fn rejects_non_basic_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, basic("Bearer token"));
+        assert_eq!(try_parse_basic_client_credentials(&headers), None);
+    }
+
+    #[test]
+    fn rejects_malformed_base64() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, basic("Basic ???"));
+        assert_eq!(try_parse_basic_client_credentials(&headers), None);
+    }
+}

--- a/api/src/application/http/authentication/handlers/introspect.rs
+++ b/api/src/application/http/authentication/handlers/introspect.rs
@@ -3,12 +3,12 @@ use axum::{
     extract::{Path, State},
     http::HeaderMap,
 };
-use base64::{Engine, engine::general_purpose};
 use ferriskey_core::domain::authentication::{
     entities::TokenIntrospectionResponse, ports::AuthService, value_objects::IntrospectTokenInput,
 };
 use validator::Validate;
 
+use crate::application::http::authentication::basic_auth::try_parse_basic_client_credentials;
 use crate::application::http::server::{
     api_entities::{api_error::ApiError, response::Response},
     app_state::AppState,
@@ -17,24 +17,6 @@ use crate::application::http::{
     authentication::validators::IntrospectRequestValidator,
     server::api_entities::api_error::ApiErrorResponse,
 };
-
-fn try_parse_basic_client_credentials(headers: &HeaderMap) -> Option<(String, String)> {
-    let value = headers
-        .get(axum::http::header::AUTHORIZATION)?
-        .to_str()
-        .ok()?;
-    let prefix = "Basic ";
-    if value.len() < prefix.len() || !value[..prefix.len()].eq_ignore_ascii_case(prefix) {
-        return None;
-    }
-    let value = &value[prefix.len()..];
-
-    let decoded = general_purpose::STANDARD.decode(value).ok()?;
-    let decoded = String::from_utf8(decoded).ok()?;
-
-    let (client_id, client_secret) = decoded.split_once(':')?;
-    Some((client_id.to_string(), client_secret.to_string()))
-}
 
 #[utoipa::path(
     post,
@@ -87,37 +69,4 @@ pub async fn introspect_token(
         .await?;
 
     Ok(Response::OK(response))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::try_parse_basic_client_credentials;
-    use axum::http::{HeaderMap, HeaderValue, header::AUTHORIZATION};
-
-    fn basic(value: &str) -> HeaderValue {
-        HeaderValue::from_str(value).unwrap()
-    }
-
-    #[test]
-    fn parses_basic_credentials() {
-        let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, basic("Basic Y2xpZW50OnNlY3JldA==")); // client:secret
-
-        let creds = try_parse_basic_client_credentials(&headers);
-        assert_eq!(creds, Some(("client".to_string(), "secret".to_string())));
-    }
-
-    #[test]
-    fn rejects_non_basic_header() {
-        let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, basic("Bearer token"));
-        assert_eq!(try_parse_basic_client_credentials(&headers), None);
-    }
-
-    #[test]
-    fn rejects_malformed_base64() {
-        let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, basic("Basic ???"));
-        assert_eq!(try_parse_basic_client_credentials(&headers), None);
-    }
 }

--- a/api/src/application/http/authentication/handlers/openid_configuration.rs
+++ b/api/src/application/http/authentication/handlers/openid_configuration.rs
@@ -19,6 +19,7 @@ pub struct GetOpenIdConfigurationResponse {
     pub userinfo_endpoint: String,
     pub jwks_uri: String,
     pub grant_types_supported: Vec<String>,
+    pub token_endpoint_auth_methods_supported: Vec<String>,
 }
 
 #[utoipa::path(
@@ -74,6 +75,10 @@ pub async fn get_openid_configuration(
             "refresh_token".to_string(),
             "client_credentials".to_string(),
             "password".to_string(),
+        ],
+        token_endpoint_auth_methods_supported: vec![
+            "client_secret_basic".to_string(),
+            "client_secret_post".to_string(),
         ],
     }))
 }

--- a/api/src/application/http/authentication/handlers/token.rs
+++ b/api/src/application/http/authentication/handlers/token.rs
@@ -1,4 +1,5 @@
 use super::auth::root_scoped_base_url;
+use crate::application::http::authentication::basic_auth::try_parse_basic_client_credentials;
 use crate::application::http::server::api_entities::api_error::ApiError;
 use crate::application::http::server::app_state::AppState;
 use crate::application::http::{
@@ -9,7 +10,7 @@ use crate::application::url::FullUrl;
 use axum::{
     Form,
     extract::{Path, State},
-    http::{HeaderValue, StatusCode, header::SET_COOKIE},
+    http::{HeaderMap, HeaderValue, StatusCode, header::SET_COOKIE},
     response::IntoResponse,
 };
 use axum_extra::extract::cookie::{Cookie, SameSite};
@@ -37,12 +38,10 @@ const IDENTITY_COOKIE: &str = "FERRISKEY_IDENTITY";
     )
 )]
 #[instrument(
-    skip(state, payload),
+    skip(state, payload, headers),
     fields(
         realm_name = %realm_name,
-        client_id = %payload.client_id,
         grant_type = ?payload.grant_type,
-        has_client_secret = payload.client_secret.is_some(),
         has_username = payload.username.is_some(),
         has_password = payload.password.is_some(),
         has_code = payload.code.is_some(),
@@ -53,11 +52,19 @@ pub async fn exchange_token(
     Path(realm_name): Path<String>,
     State(state): State<AppState>,
     FullUrl(_, base_url): FullUrl,
+    headers: HeaderMap,
     Form(payload): Form<TokenRequestValidator>,
 ) -> Result<impl IntoResponse, ApiError> {
+    let (client_id, client_secret) = match try_parse_basic_client_credentials(&headers) {
+        Some((id, sec)) => (id, Some(sec)),
+        None => (
+            payload.client_id.clone().unwrap_or_default(),
+            payload.client_secret.clone(),
+        ),
+    };
+
     let grant_type = payload.grant_type.clone();
-    let client_id = payload.client_id.clone();
-    let has_client_secret = payload.client_secret.is_some();
+    let has_client_secret = client_secret.is_some();
     let has_username = payload.username.is_some();
     let has_password = payload.password.is_some();
     let has_code = payload.code.is_some();
@@ -69,8 +76,8 @@ pub async fn exchange_token(
         .service
         .exchange_token(ExchangeTokenInput {
             realm_name,
-            client_id: payload.client_id,
-            client_secret: payload.client_secret,
+            client_id: client_id.clone(),
+            client_secret,
             code: payload.code,
             username: payload.username,
             password: payload.password,

--- a/api/src/application/http/authentication/validators.rs
+++ b/api/src/application/http/authentication/validators.rs
@@ -8,10 +8,11 @@ pub struct TokenRequestValidator {
     #[serde(default)]
     pub grant_type: GrantType,
 
-    #[validate(length(min = 1, message = "client_id is required"))]
+    // Used by `client_secret_post`
     #[serde(default)]
-    pub client_id: String,
+    pub client_id: Option<String>,
 
+    // Used by `client_secret_post`
     #[serde(default)]
     pub client_secret: Option<String>,
 

--- a/api/tests/token_basic_auth_test.rs
+++ b/api/tests/token_basic_auth_test.rs
@@ -1,0 +1,261 @@
+/// Integration tests for token endpoint Basic Auth (RFC 6749 §2.3.1 `client_secret_basic`)
+/// and the `token_endpoint_auth_methods_supported` field in the OIDC discovery document.
+///
+/// Run with:
+///   cargo test -p ferriskey-api -- --ignored
+#[cfg(test)]
+mod tests {
+    use std::{env, sync::Arc};
+
+    use axum::http::HeaderValue;
+    use axum_test::TestServer;
+    use base64::{Engine, engine::general_purpose};
+    use ferriskey_api::{
+        application::http::server::{app_state::AppState, http_server::router},
+        args::Args,
+    };
+    use ferriskey_core::{
+        application::create_service,
+        domain::common::{
+            DatabaseConfig, FerriskeyConfig, entities::StartupConfig, ports::CoreService,
+        },
+    };
+    use serde_json::{Value, json};
+    use sqlx::Executor;
+    use uuid::Uuid;
+
+    fn env_or(key: &str, default: &str) -> String {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+
+    fn env_u16_or(key: &str, default: u16) -> u16 {
+        env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    struct TestContext {
+        server: TestServer,
+        realm_name: String,
+    }
+
+    async fn setup() -> TestContext {
+        let db_host = env_or("DATABASE_HOST", "localhost");
+        let db_port = env_u16_or("DATABASE_PORT", 5432);
+        let db_name = env_or("DATABASE_NAME", "ferriskey");
+        let db_user = env_or("DATABASE_USER", "ferriskey");
+        let db_password = env_or("DATABASE_PASSWORD", "ferriskey");
+
+        let schema = format!("token_auth_test_{}", Uuid::new_v4().simple());
+
+        let admin_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+
+        let admin_pool = sqlx::PgPool::connect(&admin_url)
+            .await
+            .expect("connect admin pool");
+
+        admin_pool
+            .execute(sqlx::query(&format!(
+                "CREATE SCHEMA IF NOT EXISTS \"{}\"",
+                schema
+            )))
+            .await
+            .expect("create schema");
+
+        let schema_url = format!(
+            "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
+            db_user,
+            db_password,
+            db_host,
+            db_port,
+            db_name,
+            urlencoding::encode(&schema)
+        );
+
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+
+        sqlx::migrate!("../core/migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let service = create_service(FerriskeyConfig {
+            database: DatabaseConfig {
+                host: db_host,
+                port: db_port,
+                username: db_user,
+                password: db_password,
+                name: db_name,
+                schema: schema.clone(),
+            },
+        })
+        .await
+        .expect("create service");
+
+        let realm_name = format!("realm-{}", Uuid::new_v4().simple());
+
+        service
+            .initialize_application(StartupConfig {
+                master_realm_name: realm_name.clone(),
+                admin_username: "admin".to_string(),
+                admin_password: "admin".to_string(),
+                admin_email: "admin@test.local".to_string(),
+                default_client_id: "admin-cli".to_string(),
+            })
+            .await
+            .expect("initialize application");
+
+        let args = Arc::new(Args::default());
+        let state = AppState::new(args, service);
+        let app = router(state).expect("build router");
+        let server = TestServer::new(app).expect("create test server");
+
+        TestContext { server, realm_name }
+    }
+
+    async fn get_admin_token(ctx: &TestContext) -> String {
+        let response = ctx
+            .server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/token",
+                ctx.realm_name
+            ))
+            .form(&[
+                ("grant_type", "password"),
+                ("client_id", "admin-cli"),
+                ("username", "admin"),
+                ("password", "admin"),
+            ])
+            .await;
+
+        assert_eq!(response.status_code(), 200, "token request failed");
+        let body: Value = response.json();
+        body["access_token"]
+            .as_str()
+            .expect("access_token in response")
+            .to_string()
+    }
+
+    fn auth_header(token: &str) -> HeaderValue {
+        format!("Bearer {}", token).parse().unwrap()
+    }
+
+    async fn create_confidential_client(ctx: &TestContext, token: &str) -> (String, String) {
+        let client_id = format!("conf-client-{}", Uuid::new_v4().simple());
+
+        let response = ctx
+            .server
+            .post(&format!("/realms/{}/clients", ctx.realm_name))
+            .add_header("Authorization", auth_header(token))
+            .json(&json!({
+                "client_id": client_id,
+                "name": "Confidential Test Client",
+                "client_type": "confidential",
+                "protocol": "openid-connect",
+                "public_client": false,
+                "service_account_enabled": true,
+                "direct_access_grants_enabled": false,
+                "enabled": true,
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), 201, "client creation failed");
+        let body: Value = response.json();
+        let secret = body["secret"]
+            .as_str()
+            .expect("confidential client has a secret")
+            .to_string();
+        (client_id, secret)
+    }
+
+    fn basic_auth_value(client_id: &str, client_secret: &str) -> HeaderValue {
+        let encoded = general_purpose::STANDARD.encode(format!("{client_id}:{client_secret}"));
+        format!("Basic {encoded}").parse().unwrap()
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn token_endpoint_accepts_client_secret_basic() {
+        let ctx = setup().await;
+        let admin_token = get_admin_token(&ctx).await;
+        let (client_id, secret) = create_confidential_client(&ctx, &admin_token).await;
+
+        let response = ctx
+            .server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/token",
+                ctx.realm_name
+            ))
+            .add_header("Authorization", basic_auth_value(&client_id, &secret))
+            .form(&[("grant_type", "client_credentials")])
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            200,
+            "client_secret_basic should succeed, got body: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        assert!(body["access_token"].is_string());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn token_endpoint_still_accepts_client_secret_post() {
+        let ctx = setup().await;
+        let admin_token = get_admin_token(&ctx).await;
+        let (client_id, secret) = create_confidential_client(&ctx, &admin_token).await;
+
+        let response = ctx
+            .server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/token",
+                ctx.realm_name
+            ))
+            .form(&[
+                ("grant_type", "client_credentials"),
+                ("client_id", client_id.as_str()),
+                ("client_secret", secret.as_str()),
+            ])
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            200,
+            "client_secret_post should still work, got body: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        assert!(body["access_token"].is_string());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn discovery_advertises_token_endpoint_auth_methods() {
+        let ctx = setup().await;
+
+        let response = ctx
+            .server
+            .get(&format!(
+                "/realms/{}/.well-known/openid-configuration",
+                ctx.realm_name
+            ))
+            .await;
+
+        assert_eq!(response.status_code(), 200);
+        let body: Value = response.json();
+        let methods = body["token_endpoint_auth_methods_supported"]
+            .as_array()
+            .expect("token_endpoint_auth_methods_supported is an array");
+        let methods: Vec<&str> = methods.iter().filter_map(|v| v.as_str()).collect();
+        assert!(methods.contains(&"client_secret_basic"));
+        assert!(methods.contains(&"client_secret_post"));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP Basic Authentication support for the token endpoint, allowing client credentials to be provided via Authorization headers as an alternative to form fields.

* **Updates**
  * OpenID configuration endpoint now advertises supported token endpoint authentication methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/1012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->