### PR TITLE
feat: add external provider component in portal builder

### DIFF
--- a/core/src/domain/portal_theme/validation.rs
+++ b/core/src/domain/portal_theme/validation.rs
@@ -9,7 +9,12 @@ use crate::domain::portal_theme::entities::PortalPageType;
 pub const REQUIRED_BLOCKS: &[(PortalPageType, &[&str])] = &[
     (
         PortalPageType::Login,
-        &["email_input", "password_input", "submit_button"],
+        &[
+            "email_input",
+            "password_input",
+            "submit_button",
+            "identity_providers",
+        ],
     ),
     (
         PortalPageType::Register,
@@ -121,7 +126,8 @@ mod tests {
             { "type": "container", "children": [
                 { "type": "email_input" },
                 { "type": "password_input" },
-                { "type": "submit_button" }
+                { "type": "submit_button" },
+                { "type": "identity_providers" }
             ]}
         ]);
         assert!(validate_tree(PortalPageType::Login, &tree).is_ok());
@@ -162,7 +168,8 @@ mod tests {
             vec![
                 "email_input".to_string(),
                 "password_input".to_string(),
-                "submit_button".to_string()
+                "submit_button".to_string(),
+                "identity_providers".to_string()
             ]
         );
     }

--- a/front/src/lib/builder-portal/components.tsx
+++ b/front/src/lib/builder-portal/components.tsx
@@ -2,6 +2,7 @@ import {
   AtSign,
   Box,
   CheckSquare,
+  Globe,
   Heading as HeadingIcon,
   Image as ImageIcon,
   KeyRound,
@@ -30,6 +31,7 @@ const ALL_CHILDREN = [
   'password_input',
   'totp_input',
   'submit_button',
+  'identity_providers',
   'page-content',
 ]
 
@@ -227,6 +229,18 @@ export const portalComponents: ComponentDefinition[] = [
     },
     defaultStyles: {},
   },
+  {
+    type: 'identity_providers',
+    label: 'Identity providers',
+    icon: <Globe size={14} />,
+    defaultProps: {
+      // Separator label displayed above the list ("Or continue with").
+      separatorLabel: 'Or continue with',
+      // Localizable button label prefix; the provider's display name is appended.
+      buttonLabel: 'Continue with',
+    },
+    defaultStyles: {},
+  },
 ]
 
 /** Block types that are specialized for a portal page (not generic layout). */
@@ -235,6 +249,7 @@ export const REQUIRED_BLOCK_TYPES = new Set([
   'password_input',
   'totp_input',
   'submit_button',
+  'identity_providers',
 ])
 
 /** Block types that only make sense in a layout tree, never in a page tree. */

--- a/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
+++ b/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
@@ -661,6 +661,28 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
         </div>
       )
 
+    case 'identity_providers':
+      return (
+        <div className='flex flex-col'>
+          {identity}
+          <div className='border-b border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground'>
+            Identity providers — the list is populated at runtime from the realm's configured providers. Only the labels are editable.
+          </div>
+          <ConfigSection title='Labels'>
+            <TextField
+              label='Separator label'
+              value={node.props.separatorLabel as string}
+              onChange={(v) => updateProp('separatorLabel', v)}
+            />
+            <TextField
+              label='Button label prefix'
+              value={node.props.buttonLabel as string}
+              onChange={(v) => updateProp('buttonLabel', v)}
+            />
+          </ConfigSection>
+        </div>
+      )
+
     case 'page-content':
       return (
         <div className='flex flex-col'>

--- a/front/src/lib/builder-portal/renderer.tsx
+++ b/front/src/lib/builder-portal/renderer.tsx
@@ -1,4 +1,8 @@
 import type { CSSProperties, ReactNode } from 'react'
+import type { Schemas } from '@/api/api.client'
+import ProviderIcon, {
+  isProviderIconKey,
+} from '@/pages/identity-providers/components/provider-icon'
 import type { BuilderNode } from '../builder-core'
 
 type RenderOptions = {
@@ -9,6 +13,11 @@ type RenderOptions = {
    * preview), so inputs accept user input instead of being disabled.
    */
   runtime?: boolean
+  /**
+   * Real identity providers fed by the realm's login settings — replaces the
+   * placeholder list rendered for `identity_providers` blocks in the canvas.
+   */
+  identityProviders?: Schemas.IdentityProviderPresentation[]
 }
 
 export function treeToReactNode(tree: BuilderNode[], options: RenderOptions = {}): ReactNode {
@@ -189,8 +198,205 @@ function renderNode(node: BuilderNode, options: RenderOptions): ReactNode {
         </div>
       )
 
+    case 'identity_providers':
+      return (
+        <IdentityProvidersBlock
+          key={node.id}
+          node={node}
+          providers={options.identityProviders}
+          runtime={options.runtime}
+        />
+      )
+
     default:
       return null
+  }
+}
+
+const PLACEHOLDER_PROVIDERS: Pick<
+  Schemas.IdentityProviderPresentation,
+  'id' | 'display_name' | 'icon' | 'kind' | 'login_url'
+>[] = [
+  { id: 'preview-google', display_name: 'Google', icon: 'google', kind: 'google', login_url: '#' },
+  { id: 'preview-github', display_name: 'GitHub', icon: 'github', kind: 'github', login_url: '#' },
+]
+
+const isAbsoluteUrl = (value: string) => /^https?:\/\//i.test(value)
+
+function buildProviderLoginUrl(loginUrl: string): string {
+  const base = window.apiUrl.endsWith('/') ? window.apiUrl : `${window.apiUrl}/`
+  const path = loginUrl.replace(/^\//, '')
+  const url = new URL(isAbsoluteUrl(loginUrl) ? loginUrl : path, base)
+  const currentParams = new URLSearchParams(window.location.search)
+  currentParams.forEach((value, key) => {
+    if (!url.searchParams.has(key)) {
+      url.searchParams.set(key, value)
+    }
+  })
+  return url.toString()
+}
+
+export function IdentityProvidersBlock({
+  node,
+  providers,
+  runtime,
+}: {
+  node: BuilderNode
+  providers?: Schemas.IdentityProviderPresentation[]
+  runtime?: boolean
+}) {
+  const separatorLabel = (node.props.separatorLabel as string) || 'Or continue with'
+  const buttonLabelPrefix = (node.props.buttonLabel as string) || 'Continue with'
+
+  // In the canvas (or when the realm has no providers yet) we render two
+  // sample buttons so the admin still sees what the block will look like.
+  const list = runtime
+    ? (providers ?? [])
+    : (providers && providers.length > 0 ? providers : PLACEHOLDER_PROVIDERS)
+
+  if (runtime && list.length === 0) {
+    // At runtime, an empty list collapses the whole block so the surrounding
+    // layout doesn't show an orphan "Or continue with" separator.
+    return null
+  }
+
+  return (
+    <div
+      data-fk-id={node.id}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        ...orderStyle(node),
+      }}
+    >
+      <div style={providerSeparatorStyle()}>
+        <span style={providerSeparatorLineStyle()} />
+        <span style={providerSeparatorLabelStyle()}>{separatorLabel}</span>
+        <span style={providerSeparatorLineStyle()} />
+      </div>
+      <div style={{ display: 'grid', gap: 12 }}>
+        {list.map((provider) => {
+          const iconKey = provider.icon?.toLowerCase()
+          const knownIcon = iconKey && isProviderIconKey(iconKey) ? iconKey : null
+          const customIconSrc = iconKey && !knownIcon ? provider.icon : null
+          const href =
+            runtime && provider.login_url && provider.login_url !== '#'
+              ? buildProviderLoginUrl(provider.login_url)
+              : '#'
+          return (
+            <a
+              key={provider.id}
+              href={href}
+              style={providerButtonStyle()}
+              onClick={runtime ? undefined : (e) => e.preventDefault()}
+            >
+              <span style={providerIconSlotStyle()}>
+                {knownIcon ? (
+                  <ProviderIcon icon={knownIcon} size='sm' className='h-4 w-4' />
+                ) : customIconSrc ? (
+                  <img
+                    src={customIconSrc}
+                    alt={provider.display_name ?? ''}
+                    style={{ width: 16, height: 16 }}
+                  />
+                ) : (
+                  <span style={providerIconFallbackStyle()}>
+                    {provider.display_name?.[0]?.toUpperCase() ?? '?'}
+                  </span>
+                )}
+              </span>
+              <span style={providerLabelStyle()}>
+                {buttonLabelPrefix} {provider.display_name}
+              </span>
+              <span style={providerArrowStyle()}>→</span>
+            </a>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function providerSeparatorStyle(): CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    fontSize: 13,
+    color: 'var(--fk-color-body-text, #6b7280)',
+  }
+}
+
+function providerSeparatorLineStyle(): CSSProperties {
+  return {
+    flex: 1,
+    height: 1,
+    backgroundColor: 'var(--fk-color-body-text, #e5e7eb)',
+    opacity: 0.3,
+  }
+}
+
+function providerSeparatorLabelStyle(): CSSProperties {
+  return {
+    padding: '0 8px',
+    fontSize: 13,
+    color: 'var(--fk-color-body-text, #6b7280)',
+  }
+}
+
+function providerButtonStyle(): CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    width: '100%',
+    padding: '10px 12px',
+    borderRadius: 'var(--fk-radius-button, 6px)',
+    border: 'var(--fk-border-button, 1px) solid var(--fk-color-body-text, #e5e7eb)',
+    backgroundColor: 'var(--fk-color-secondary-button, #ffffff)',
+    color: 'var(--fk-color-secondary-button-label, #111827)',
+    fontSize: 'var(--fk-font-base-size, 14px)',
+    fontWeight: 500,
+    textDecoration: 'none',
+    cursor: 'pointer',
+  }
+}
+
+function providerIconSlotStyle(): CSSProperties {
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 24,
+    height: 24,
+    flexShrink: 0,
+  }
+}
+
+function providerIconFallbackStyle(): CSSProperties {
+  return {
+    fontSize: 11,
+    fontWeight: 600,
+    color: 'var(--fk-color-body-text, #6b7280)',
+    textTransform: 'uppercase',
+  }
+}
+
+function providerLabelStyle(): CSSProperties {
+  return {
+    flex: 1,
+    textAlign: 'left',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  }
+}
+
+function providerArrowStyle(): CSSProperties {
+  return {
+    fontSize: 12,
+    color: 'var(--fk-color-body-text, #9ca3af)',
   }
 }
 

--- a/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
+++ b/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
@@ -7,6 +7,7 @@ import {
   containerStyle,
   divStyle,
   headingStyle,
+  IdentityProvidersBlock,
   imageJustify,
   imageStyle,
   inputFieldStyle,
@@ -125,6 +126,8 @@ export function renderVisualBlock(
     case 'password_input':
     case 'totp_input':
       return <InputBlock node={node} isSelected={isSelected} />
+    case 'identity_providers':
+      return <IdentityProvidersPreview node={node} isSelected={isSelected} />
     case 'page-content':
       return <PageContentSlot node={node} isSelected={isSelected} />
     default:
@@ -348,6 +351,23 @@ function InputBlock({ node, isSelected }: { node: BuilderNode; isSelected: boole
         style={mergeStyles({ ...inputFieldStyle(), pointerEvents: 'none' }, isSelected)}
       />
       {helperText ? <span style={inputHelperStyle()}>{helperText}</span> : null}
+    </div>
+  )
+}
+
+function IdentityProvidersPreview({
+  node,
+  isSelected,
+}: {
+  node: BuilderNode
+  isSelected: boolean
+}) {
+  return (
+    <div style={chromeStyle(isSelected)}>
+      {/* Canvas preview reuses the runtime renderer with `runtime=false` so
+          the placeholder providers (Google / GitHub) are drawn — keeps the
+          builder visually identical to what realm end-users will see. */}
+      <IdentityProvidersBlock node={node} runtime={false} />
     </div>
   )
 }

--- a/front/src/pages/authentication/components/portal-layout-wrapper.tsx
+++ b/front/src/pages/authentication/components/portal-layout-wrapper.tsx
@@ -6,6 +6,7 @@ import {
   useGetPortalPageRequirements,
 } from '@/api/portal-theme.api'
 import { useGetPublicPortalLayout } from '@/api/portal-layouts.api'
+import { useGetLoginSettings } from '@/api/realm.api'
 import type { RouterParams } from '@/routes/router'
 import type { BuilderNode } from '@/lib/builder-core'
 import { generateBreakpointCss, treeToReactNode } from '@/lib/builder-portal'
@@ -66,6 +67,11 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
   })
   const { data: requirementsData, isLoading: isRequirementsLoading } =
     useGetPortalPageRequirements({ realm })
+  // Pulled separately from the auth feature so portal pages that don't render
+  // the React `<PageLogin />` fallback still have the realm's configured
+  // identity providers available to the `identity_providers` block.
+  const { data: loginSettings } = useGetLoginSettings({ realm })
+  const identityProviders = loginSettings?.identity_providers ?? []
 
   const cssVars = useMemo(
     () => themeToCssVars(mergeWithDefaults(activeData?.design_tokens)) as CSSProperties,
@@ -130,7 +136,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
 
   const pageContent: ReactNode = (
     <form onSubmit={handleSubmit}>
-      {treeToReactNode(pageTree, { runtime: true })}
+      {treeToReactNode(pageTree, { runtime: true, identityProviders })}
     </form>
   )
 
@@ -146,7 +152,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
   return (
     <div style={cssVars}>
       {responsiveStyle}
-      {treeToReactNode(layoutTree, { runtime: true, pageContent })}
+      {treeToReactNode(layoutTree, { runtime: true, pageContent, identityProviders })}
     </div>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added identity providers block to portal builder for displaying available login options configured in realm settings.
  * Configure customizable separator and button labels for identity provider blocks directly in the builder.
  * Identity providers render with icons at runtime; builder preview displays placeholder providers.
  * Supports standard provider icons, custom icon images, and fallback initials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/1017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->