### PR TITLE
Fix webapp container name

### DIFF
--- a/charts/ferriskey/templates/webapp/deployment.yaml
+++ b/charts/ferriskey/templates/webapp/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: api
+        - name: webapp
           {{- with .Values.webapp.args }}
           args:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
A very big pull request :)
webapp container name is called api in the deployment.yaml file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/1036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->