### PR TITLE
Use the official nginx-unprivileged image to simplify deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,13 +84,11 @@ COPY front/ .
 RUN VITE_API_URL="" pnpm run build
 
 # ── Frontend runtime ──────────────────────────────────────────────────────────
-FROM nginx:1.28.0-alpine3.21-slim AS webapp
+FROM nginxinc/nginx-unprivileged:1.31.1-alpine3.23-slim AS webapp
 
 COPY --from=webapp-build /usr/local/src/ferriskey/dist /usr/local/src/ferriskey
 COPY front/nginx.conf /etc/nginx/conf.d/default.conf
-COPY front/docker-entrypoint.sh /docker-entrypoint.d/docker-entrypoint.sh
-
-RUN chmod +x /docker-entrypoint.d/docker-entrypoint.sh
+COPY --chmod=0755 front/docker-entrypoint.sh /docker-entrypoint.d/docker-entrypoint.sh
 
 # ── Standalone image (API + Frontend, single container) ───────────────────────
 FROM debian:bookworm-slim AS standalone
@@ -113,8 +111,7 @@ COPY --from=webapp-build /usr/local/src/ferriskey/dist /usr/share/nginx/html
 
 COPY front/nginx-standalone.conf /etc/nginx/conf.d/default.conf
 COPY docker/supervisord.conf /etc/supervisor/conf.d/ferriskey.conf
-COPY docker/standalone-entrypoint.sh /standalone-entrypoint.sh
-RUN chmod +x /standalone-entrypoint.sh
+COPY --chmod=0755 docker/standalone-entrypoint.sh /standalone-entrypoint.sh
 
 EXPOSE 80
 

--- a/charts/ferriskey/templates/webapp/deployment.yaml
+++ b/charts/ferriskey/templates/webapp/deployment.yaml
@@ -97,10 +97,6 @@ spec:
           {{- end }}
           volumeMounts:
             - name: empty-dir
-              mountPath: /run
-              readOnly: false
-              subPath: run
-            - name: empty-dir
               mountPath: /tmp
               readOnly: false
               subPath: tmp
@@ -108,10 +104,6 @@ spec:
               mountPath: /usr/share/nginx/html
               readOnly: false
               subPath: usr/share/nginx/html
-            - name: empty-dir
-              mountPath: /var/cache/nginx
-              readOnly: false
-              subPath: var/cache/nginx
             {{- with $volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container and deployment configurations for improved infrastructure compatibility and streamlined build processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ferriskey/ferriskey/pull/1037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->