### PR TITLE
Update base images to move to debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.95.0-bookworm AS chef
+FROM rust:1.95.0-trixie AS chef
 
 WORKDIR /usr/local/src/ferriskey
 
@@ -20,13 +20,13 @@ COPY . .
 RUN cargo build --release
 
 # ── Shared runtime base ───────────────────────────────────────────────────────
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 RUN \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    ca-certificates=20230311+deb12u1 \
-    libssl3=3.0.17-1~deb12u2 && \
+    ca-certificates=20250419 \
+    libssl3=3.5.6-1~deb13u1 && \
     rm -rf /var/lib/apt/lists/* && \
     addgroup \
     --system \
@@ -91,14 +91,14 @@ COPY front/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=0755 front/docker-entrypoint.sh /docker-entrypoint.d/docker-entrypoint.sh
 
 # ── Standalone image (API + Frontend, single container) ───────────────────────
-FROM debian:bookworm-slim AS standalone
+FROM debian:trixie-slim AS standalone
 
 # hadolint ignore=DL3008
 RUN \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    ca-certificates=20230311+deb12u1 \
-    libssl3=3.0.17-1~deb12u2 \
+    ca-certificates=20250419 \
+    libssl3=3.5.6-1~deb13u1 \
     nginx \
     supervisor && \
     rm -rf /var/lib/apt/lists/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,14 @@ RUN \
     ca-certificates=20250419 \
     libssl3=3.5.6-1~deb13u1 && \
     rm -rf /var/lib/apt/lists/* && \
-    addgroup \
+    groupadd \
     --system \
     --gid 1000 \
     ferriskey && \
-    adduser \
+    useradd \
     --system \
     --no-create-home \
-    --disabled-login \
+    --shell /usr/sbin/nologin \
     --uid 1000 \
     --gid 1000 \
     ferriskey


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base images to newer stable releases for improved stability and security.
  * Refreshed pinned TLS/certificate and SSL dependencies to current versions.
  * Streamlined system user and group setup commands in the container build for more consistent, maintainable images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->