### PR TITLE
Another idea to have more secure final images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.95.0-bookworm AS chef
+FROM rust:1.95.0-trixie AS chef
 
 WORKDIR /usr/local/src/ferriskey
 
@@ -19,32 +19,10 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release
 
-# ── Shared runtime base ───────────────────────────────────────────────────────
-FROM debian:bookworm-slim AS runtime
-
-RUN \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates=20230311+deb12u1 \
-    libssl3=3.0.17-1~deb12u2 && \
-    rm -rf /var/lib/apt/lists/* && \
-    addgroup \
-    --system \
-    --gid 1000 \
-    ferriskey && \
-    adduser \
-    --system \
-    --no-create-home \
-    --disabled-login \
-    --uid 1000 \
-    --gid 1000 \
-    ferriskey
-
-USER ferriskey
-
 # ── API image ─────────────────────────────────────────────────────────────────
-FROM runtime AS api
+FROM gcr.io/distroless/base-debian13:latest AS api
 
+COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
 COPY --from=builder /usr/local/src/ferriskey/target/release/ferriskey-api /usr/local/bin/
 COPY --from=builder /usr/local/src/ferriskey/core/migrations /usr/local/src/ferriskey/migrations
 COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/
@@ -54,8 +32,9 @@ EXPOSE 80
 ENTRYPOINT ["ferriskey-api"]
 
 # ── Operator image ────────────────────────────────────────────────────────────
-FROM runtime AS operator
+FROM gcr.io/distroless/base-debian13:latest AS operator
 
+COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
 COPY --from=builder /usr/local/src/ferriskey/target/release/ferriskey-operator /usr/local/bin/
 
 EXPOSE 80
@@ -99,14 +78,14 @@ COPY front/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=0755 front/docker-entrypoint.sh /docker-entrypoint.d/docker-entrypoint.sh
 
 # ── Standalone image (API + Frontend, single container) ───────────────────────
-FROM debian:bookworm-slim AS standalone
+FROM debian:trixie-slim AS standalone
 
 # hadolint ignore=DL3008
 RUN \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    ca-certificates=20230311+deb12u1 \
-    libssl3=3.0.17-1~deb12u2 \
+    ca-certificates=20250419 \
+    libssl3=3.5.6-1~deb13u1 \
     nginx \
     supervisor && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
Here another way to have final images without any shell inside.

The need to copy `libgcc_s.so.1` came from both binaries:
```bash
root@dc1a3b3757c1:/usr/local/src/ferriskey# ldd /usr/local/src/ferriskey/target/release/ferriskey-operator
        linux-vdso.so.1 (0x00007fa7a2ebf000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fa7a2319000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fa7a2229000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fa7a2035000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fa7a2ec1000)
root@dc1a3b3757c1:/usr/local/src/ferriskey# ldd /usr/local/src/ferriskey/target/release/ferriskey-api
        linux-vdso.so.1 (0x00007f3ddb1c6000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007f3dd80f3000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f3dd7ab9000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f3dd7a8c000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f3dd799c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f3dd77a6000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f3ddb1c8000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f3dd7786000)
        libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x00007f3dd76bc000)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base images across build and runtime stages for improved consistency and smaller images.
  * Upgraded the Rust build toolchain to `1.95.0` and switched relevant Debian bases to `trixie`.
  * Migrated runtime stages to distroless images and ensured required system libraries are included.
  * Refreshed the standalone image’s Debian base and updated pinned `ca-certificates` and `libssl3` packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->