### PR TITLE
feat(observability): add configurable OTLP transport protocol (gRPC or HTTP)

### DIFF
--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -1,0 +1,152 @@
+name: docker-registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        required: true
+        default: main
+        description: "Branch, tag, or SHA to build from"
+      push:
+        type: boolean
+        default: false
+        description: "Push the built image to GHCR"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner.name }}
+    strategy:
+      matrix:
+        runner:
+          - name: blacksmith-2vcpu-ubuntu-2404
+            platform: linux/amd64
+          - name: blacksmith-2vcpu-ubuntu-2404-arm
+            platform: linux/arm64
+        target:
+          - api
+          - operator
+          - webapp
+          - standalone
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: set up buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: cache layers
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/.buildx-cache
+          key: buildx-${{ runner.arch }}-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            buildx-${{ runner.arch }}-${{ matrix.target }}-
+
+      - name: get image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/Estrelio/ferriskey-${{ matrix.target }}
+
+      - name: log-in to ghcr
+        if: inputs.push
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build and push
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          platforms: ${{ matrix.runner.platform }}
+          tags: ghcr.io/Estrelio/ferriskey-${{ matrix.target }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
+
+      - name: prepare digest
+        if: inputs.push
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: upload digest
+        if: inputs.push
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ runner.arch }}-${{ matrix.target }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: move cache
+        run: |
+          rm -rf ${{ runner.temp }}/.buildx-cache
+          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
+
+  push-manifest:
+    if: inputs.push
+    needs:
+      - build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    strategy:
+      matrix:
+        target:
+          - api
+          - operator
+          - webapp
+          - standalone
+    steps:
+      - name: set up buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*-${{ matrix.target }}
+          merge-multiple: true
+
+      - name: log-in to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: sanitize ref for docker tag
+        id: ref
+        run: echo "tag=$(echo '${{ inputs.branch }}' | sed 's/[^a-zA-Z0-9._-]/-/g')" >> "$GITHUB_OUTPUT"
+
+      - name: get image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/Estrelio/ferriskey-${{ matrix.target }}
+          tags: |
+            type=raw,value=${{ steps.ref.outputs.tag }}
+            type=sha
+
+      - name: push manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(printf 'ghcr.io/Estrelio/ferriskey-${{ matrix.target }}@sha256:%s ' *)

--- a/.github/workflows/docker-registry.yml
+++ b/.github/workflows/docker-registry.yml
@@ -57,7 +57,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/Estrelio/ferriskey-${{ matrix.target }}
+          images: ghcr.io/estrelio/ferriskey-${{ matrix.target }}
 
       - name: log-in to ghcr
         if: inputs.push
@@ -74,7 +74,7 @@ jobs:
           context: .
           target: ${{ matrix.target }}
           platforms: ${{ matrix.runner.platform }}
-          tags: ghcr.io/Estrelio/ferriskey-${{ matrix.target }}
+          tags: ghcr.io/estrelio/ferriskey-${{ matrix.target }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
           cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
@@ -141,7 +141,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/Estrelio/ferriskey-${{ matrix.target }}
+          images: ghcr.io/estrelio/ferriskey-${{ matrix.target }}
           tags: |
             type=raw,value=${{ steps.ref.outputs.tag }}
             type=sha
@@ -149,4 +149,4 @@ jobs:
       - name: push manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(printf 'ghcr.io/Estrelio/ferriskey-${{ matrix.target }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(printf 'ghcr.io/estrelio/ferriskey-${{ matrix.target }}@sha256:%s ' *)

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -38,7 +38,7 @@ utoipa-redoc = { version = "6.0.0", features = ["axum"] }
 utoipa-rapidoc = { version = "6.0.0", features = ["axum"] }
 webauthn-rs = "0.5.2"
 tracing-opentelemetry = "0.32.0"
-opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic"] }
+opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "http-proto"] }
 opentelemetry_sdk = "0.31.0"
 opentelemetry = "0.31.0"
 urlencoding = "2.1.3"

--- a/api/src/args.rs
+++ b/api/src/args.rs
@@ -320,6 +320,13 @@ pub struct ServerTlsArgs {
     pub key: PathBuf,
 }
 
+#[derive(clap::ValueEnum, Debug, Clone, Default)]
+pub enum OtlpProtocol {
+    #[default]
+    Grpc,
+    Http,
+}
+
 #[derive(clap::Args, Debug, Clone)]
 pub struct ObservabilityArgs {
     #[arg(
@@ -349,6 +356,15 @@ pub struct ObservabilityArgs {
         required = false
     )]
     pub metrics_endpoint: Option<String>,
+    #[arg(
+        long = "otlp-protocol",
+        env = "OTLP_PROTOCOL",
+        name = "OTLP_PROTOCOL",
+        long_help = "Transport protocol for the OTLP exporter. Use 'grpc' for Tempo/Jaeger, 'http' for PostHog and other HTTP-only collectors.",
+        default_value = "grpc",
+        required = false
+    )]
+    pub otlp_protocol: OtlpProtocol,
 }
 
 impl Default for ObservabilityArgs {
@@ -357,6 +373,7 @@ impl Default for ObservabilityArgs {
             active_observability: false,
             otlp_endpoint: Some("http://localhost:4317".to_string()),
             metrics_endpoint: Some("http://localhost:4317".to_string()),
+            otlp_protocol: OtlpProtocol::Grpc,
         }
     }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -21,7 +21,7 @@ use opentelemetry_sdk::logs::SdkLoggerProvider;
 
 use crate::application::http::server::http_server::{router, state};
 use crate::application::http::server::openapi::ApiDoc;
-use crate::args::{Args, Command, LogArgs, ObservabilityArgs};
+use crate::args::{Args, Command, LogArgs, ObservabilityArgs, OtlpProtocol};
 use ferriskey_core::domain::common::entities::StartupConfig;
 use ferriskey_core::domain::common::ports::CoreService;
 use opentelemetry::trace::TracerProvider as _;
@@ -76,10 +76,16 @@ fn init_tracing_and_logging(
             .build();
 
         // Create the OTLP exporter
-        let span_exporter = SpanExporter::builder()
-            .with_tonic()
-            .with_endpoint(otlp_endpoint)
-            .build()?;
+        let span_exporter = match &observability_args.otlp_protocol {
+            OtlpProtocol::Grpc => SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint(otlp_endpoint)
+                .build()?,
+            OtlpProtocol::Http => SpanExporter::builder()
+                .with_http()
+                .with_endpoint(otlp_endpoint)
+                .build()?,
+        };
 
         // Build the tracer provider with the exporter
         let tracer_provider = SdkTracerProvider::builder()
@@ -97,11 +103,17 @@ fn init_tracing_and_logging(
 
         // Prometheus natively supports accepting metrics via the OTLP protocol
         // Create the metric exporter
-        let metric_exporter = MetricExporter::builder()
-            .with_tonic()
-            .with_protocol(Protocol::Grpc)
-            .with_endpoint(metrics_endpoint)
-            .build()?;
+        let metric_exporter = match &observability_args.otlp_protocol {
+            OtlpProtocol::Grpc => MetricExporter::builder()
+                .with_tonic()
+                .with_protocol(Protocol::Grpc)
+                .with_endpoint(metrics_endpoint)
+                .build()?,
+            OtlpProtocol::Http => MetricExporter::builder()
+                .with_http()
+                .with_endpoint(metrics_endpoint)
+                .build()?,
+        };
 
         let meter_provider = SdkMeterProvider::builder()
             .with_periodic_exporter(metric_exporter)
@@ -110,10 +122,16 @@ fn init_tracing_and_logging(
         // Metrics layer for tracing
         let metrics_layer = MetricsLayer::new(meter_provider);
 
-        let log_exporter = LogExporter::builder()
-            .with_tonic()
-            .with_endpoint(otlp_endpoint)
-            .build()?;
+        let log_exporter = match &observability_args.otlp_protocol {
+            OtlpProtocol::Grpc => LogExporter::builder()
+                .with_tonic()
+                .with_endpoint(otlp_endpoint)
+                .build()?,
+            OtlpProtocol::Http => LogExporter::builder()
+                .with_http()
+                .with_endpoint(otlp_endpoint)
+                .build()?,
+        };
 
         let logger_provider = SdkLoggerProvider::builder()
             .with_resource(resource)

--- a/charts/ferriskey/templates/_helpers.yaml
+++ b/charts/ferriskey/templates/_helpers.yaml
@@ -187,5 +187,8 @@ default
 - name: OTLP_ENDPOINT
   value: {{ .Values.opentelemetry.otlpEndpoint | quote }}
 
+- name: OTLP_PROTOCOL
+  value: {{ .Values.opentelemetry.protocol | default "grpc" | quote }}
+
 {{- end }}
 {{- end }}

--- a/charts/ferriskey/values.yaml
+++ b/charts/ferriskey/values.yaml
@@ -864,6 +864,10 @@ opentelemetry:
   # -- OTLP endpoint for OpenTelemetry exporter.
   otlpEndpoint: http://tempo:4317
 
+  # -- Transport protocol for the OTLP exporter. Supported values: grpc, http.
+  # Use http for collectors like PostHog that do not support gRPC.
+  protocol: grpc
+
 gatewayAPI:
   httpRoute:
     # -- Enable the HTTPRoute.

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -265,6 +265,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             realm_maintenance_whitelist.clone(),
             user_attribute.clone(),
             email_verification_service.clone(),
+            webhook.clone(),
             Arc::new(MapperEngine::new()),
             flow_recorder.clone(),
         ),

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -433,6 +433,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             organization_attribute.clone(),
             organization_member.clone(),
             policy.clone(),
+            webhook.clone(),
         ),
         flow_recorder,
         db: postgres.get_db(),

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -366,6 +366,7 @@ pub struct ApplicationService {
         OrganizationRepo,
         OrganizationAttributeRepo,
         OrganizationMemberRepo,
+        WebhookRepo,
     >,
     #[allow(dead_code)]
     pub(crate) flow_recorder: FlowRecorder,

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -209,6 +209,7 @@ type ApplicationAuthService = AuthServiceImpl<
     RealmMaintenanceWhitelistRepo,
     UserAttributeRepo,
     ApplicationEmailVerificationService,
+    WebhookRepo,
 >;
 
 #[derive(Clone, Debug)]

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -60,6 +60,10 @@ use crate::domain::{
         },
         value_objects::CreateUserRequest,
     },
+    webhook::{
+        entities::{webhook_payload::WebhookPayload, webhook_trigger::WebhookTrigger},
+        ports::WebhookRepository,
+    },
 };
 use ferriskey_domain::token_lifetime::TokenLifetimes;
 use ferriskey_security::jwt::entities::DEFAULT_ACCESS_TOKEN_LIFETIME;
@@ -91,6 +95,7 @@ pub struct AuthServiceImpl<
     RMW,
     UAR,
     EV,
+    W,
 > where
     R: RealmRepository,
     C: ClientRepository,
@@ -115,6 +120,7 @@ pub struct AuthServiceImpl<
     RMW: RealmMaintenanceWhitelistRepository,
     UAR: UserAttributeRepository,
     EV: EmailVerificationService,
+    W: WebhookRepository,
 {
     pub(crate) realm_repository: Arc<R>,
     pub(crate) client_repository: Arc<C>,
@@ -139,12 +145,13 @@ pub struct AuthServiceImpl<
     pub(crate) realm_maintenance_whitelist_repository: Arc<RMW>,
     pub(crate) user_attribute_repository: Arc<UAR>,
     pub(crate) email_verification_service: EV,
+    pub(crate) webhook_repository: Arc<W>,
     pub(crate) mapper_engine: Arc<MapperEngine>,
     pub(crate) ldap_client: LdapClientImpl,
     pub(crate) flow_recorder: FlowRecorder,
 }
 
-impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA, MW, RMW, UAR, EV>
+impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA, MW, RMW, UAR, EV, W>
     AuthServiceImpl<
         R,
         C,
@@ -169,6 +176,7 @@ impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA,
         RMW,
         UAR,
         EV,
+        W,
     >
 where
     R: RealmRepository,
@@ -194,6 +202,7 @@ where
     RMW: RealmMaintenanceWhitelistRepository,
     UAR: UserAttributeRepository,
     EV: EmailVerificationService,
+    W: WebhookRepository,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -220,6 +229,7 @@ where
         realm_maintenance_whitelist_repository: Arc<RMW>,
         user_attribute_repository: Arc<UAR>,
         email_verification_service: EV,
+        webhook_repository: Arc<W>,
         mapper_engine: Arc<MapperEngine>,
         flow_recorder: FlowRecorder,
     ) -> Self {
@@ -247,6 +257,7 @@ where
             realm_maintenance_whitelist_repository,
             user_attribute_repository,
             email_verification_service,
+            webhook_repository,
             mapper_engine,
             ldap_client: LdapClientImpl,
             flow_recorder,
@@ -254,7 +265,7 @@ where
     }
 }
 
-impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA, MW, RMW, UAR, EV>
+impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA, MW, RMW, UAR, EV, W>
     AuthServiceImpl<
         R,
         C,
@@ -279,6 +290,7 @@ impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA,
         RMW,
         UAR,
         EV,
+        W,
     >
 where
     R: RealmRepository,
@@ -304,6 +316,7 @@ where
     RMW: RealmMaintenanceWhitelistRepository,
     UAR: UserAttributeRepository,
     EV: EmailVerificationService,
+    W: WebhookRepository,
 {
     fn expires_in_from(exp: i64) -> u32 {
         let now = Utc::now().timestamp();
@@ -1736,7 +1749,7 @@ This is a server error that should be investigated. Do not forward back this mes
     }
 }
 
-impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA, MW, RMW, UAR, EV>
+impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA, MW, RMW, UAR, EV, W>
     AuthService
     for AuthServiceImpl<
         R,
@@ -1762,6 +1775,7 @@ impl<R, C, RU, PLRU, U, UR, CR, H, AS, KS, RT, AT, F, CSM, PM, OM, OR, OAR, URA,
         RMW,
         UAR,
         EV,
+        W,
     >
 where
     R: RealmRepository,
@@ -1787,6 +1801,7 @@ where
     RMW: RealmMaintenanceWhitelistRepository,
     UAR: UserAttributeRepository,
     EV: EmailVerificationService,
+    W: WebhookRepository,
 {
     async fn auth(&self, input: AuthInput) -> Result<AuthOutput, CoreError> {
         let realm = self
@@ -2194,11 +2209,33 @@ where
                 return Err(err);
             }
 
+            self.webhook_repository
+                .notify(
+                    realm.id,
+                    WebhookPayload::new(
+                        WebhookTrigger::UserCreated,
+                        realm.id.into(),
+                        Some(user.clone()),
+                    ),
+                )
+                .await?;
+
             return Ok(RegisterUserOutput::PendingVerification {
                 message: "Please check your email to verify your account.".to_string(),
                 user_id: user.id,
             });
         }
+
+        self.webhook_repository
+            .notify(
+                realm.id,
+                WebhookPayload::new(
+                    WebhookTrigger::UserCreated,
+                    realm.id.into(),
+                    Some(user.clone()),
+                ),
+            )
+            .await?;
 
         // If the registration happened inside an active OIDC authorization flow
         // (a FERRISKEY_SESSION cookie was present), resume that flow by

--- a/core/src/domain/organization/services.rs
+++ b/core/src/domain/organization/services.rs
@@ -23,10 +23,14 @@ use crate::domain::{
     },
     realm::ports::RealmRepository,
     user::ports::{UserRepository, UserRoleRepository},
+    webhook::{
+        entities::{webhook_payload::WebhookPayload, webhook_trigger::WebhookTrigger},
+        ports::WebhookRepository,
+    },
 };
 
 #[derive(Clone, Debug)]
-pub struct OrganizationServiceImpl<R, U, C, UR, OR, OAR, OMR>
+pub struct OrganizationServiceImpl<R, U, C, UR, OR, OAR, OMR, W>
 where
     R: RealmRepository,
     U: UserRepository,
@@ -35,6 +39,7 @@ where
     OR: OrganizationRepository,
     OAR: OrganizationAttributeRepository,
     OMR: OrganizationMemberRepository,
+    W: WebhookRepository,
 {
     pub(crate) realm_repository: Arc<R>,
     pub(crate) user_repository: Arc<U>,
@@ -42,9 +47,10 @@ where
     pub(crate) organization_attribute_repository: Arc<OAR>,
     pub(crate) organization_member_repository: Arc<OMR>,
     pub(crate) policy: Arc<FerriskeyPolicy<U, C, UR>>,
+    pub(crate) webhook_repository: Arc<W>,
 }
 
-impl<R, U, C, UR, OR, OAR, OMR> OrganizationServiceImpl<R, U, C, UR, OR, OAR, OMR>
+impl<R, U, C, UR, OR, OAR, OMR, W> OrganizationServiceImpl<R, U, C, UR, OR, OAR, OMR, W>
 where
     R: RealmRepository,
     U: UserRepository,
@@ -53,6 +59,7 @@ where
     OR: OrganizationRepository,
     OAR: OrganizationAttributeRepository,
     OMR: OrganizationMemberRepository,
+    W: WebhookRepository,
 {
     pub fn new(
         realm_repository: Arc<R>,
@@ -61,6 +68,7 @@ where
         organization_attribute_repository: Arc<OAR>,
         organization_member_repository: Arc<OMR>,
         policy: Arc<FerriskeyPolicy<U, C, UR>>,
+        webhook_repository: Arc<W>,
     ) -> Self {
         Self {
             realm_repository,
@@ -69,6 +77,7 @@ where
             organization_attribute_repository,
             organization_member_repository,
             policy,
+            webhook_repository,
         }
     }
 
@@ -102,8 +111,8 @@ where
     }
 }
 
-impl<R, U, C, UR, OR, OAR, OMR> OrganizationService
-    for OrganizationServiceImpl<R, U, C, UR, OR, OAR, OMR>
+impl<R, U, C, UR, OR, OAR, OMR, W> OrganizationService
+    for OrganizationServiceImpl<R, U, C, UR, OR, OAR, OMR, W>
 where
     R: RealmRepository,
     U: UserRepository,
@@ -112,6 +121,7 @@ where
     OR: OrganizationRepository,
     OAR: OrganizationAttributeRepository,
     OMR: OrganizationMemberRepository,
+    W: WebhookRepository,
 {
     async fn create_organization(
         &self,
@@ -148,7 +158,8 @@ where
         let org = ferriskey_organization::Organization::new(org_config)
             .map_err(|_| CoreError::Invalid)?;
 
-        self.organization_repository
+        let org = self
+            .organization_repository
             .create_organization(ferriskey_organization::CreateOrganizationParams {
                 realm_id: org.realm_id,
                 name: org.name.clone(),
@@ -158,7 +169,20 @@ where
                 description: org.description.clone(),
                 enabled: org.enabled,
             })
-            .await
+            .await?;
+
+        self.webhook_repository
+            .notify(
+                realm.id,
+                WebhookPayload::new(
+                    WebhookTrigger::OrganizationCreated,
+                    realm.id.into(),
+                    Some(org.clone()),
+                ),
+            )
+            .await?;
+
+        Ok(org)
     }
 
     async fn get_organization(
@@ -232,9 +256,23 @@ where
             enabled: input.enabled,
         };
 
-        self.organization_repository
+        let org = self
+            .organization_repository
             .update_organization(org.id, params)
-            .await
+            .await?;
+
+        self.webhook_repository
+            .notify(
+                realm.id,
+                WebhookPayload::new(
+                    WebhookTrigger::OrganizationUpdated,
+                    realm.id.into(),
+                    Some(org.clone()),
+                ),
+            )
+            .await?;
+
+        Ok(org)
     }
 
     async fn delete_organization(
@@ -254,7 +292,20 @@ where
 
         self.organization_repository
             .delete_organization(org.id)
-            .await
+            .await?;
+
+        self.webhook_repository
+            .notify(
+                realm.id,
+                WebhookPayload::new(
+                    WebhookTrigger::OrganizationDeleted,
+                    realm.id.into(),
+                    Some(org),
+                ),
+            )
+            .await?;
+
+        Ok(())
     }
 
     async fn list_attributes(
@@ -366,9 +417,23 @@ where
             return Err(CoreError::AlreadyExists);
         }
 
-        self.organization_member_repository
+        let member = self
+            .organization_member_repository
             .add_member(org.id, input.user_id)
-            .await
+            .await?;
+
+        self.webhook_repository
+            .notify(
+                realm.id,
+                WebhookPayload::new(
+                    WebhookTrigger::OrganizationMemberAdded,
+                    realm.id.into(),
+                    Some(member.clone()),
+                ),
+            )
+            .await?;
+
+        Ok(member)
     }
 
     async fn remove_member(
@@ -387,14 +452,28 @@ where
         )?;
 
         // Verify the membership exists before attempting removal
-        self.organization_member_repository
+        let member = self
+            .organization_member_repository
             .get_member(org.id, input.user_id)
             .await?
             .ok_or(CoreError::NotFound)?;
 
         self.organization_member_repository
             .remove_member(org.id, input.user_id)
-            .await
+            .await?;
+
+        self.webhook_repository
+            .notify(
+                realm.id,
+                WebhookPayload::new(
+                    WebhookTrigger::OrganizationMemberRemoved,
+                    realm.id.into(),
+                    Some(member),
+                ),
+            )
+            .await?;
+
+        Ok(())
     }
 
     async fn list_members(
@@ -460,6 +539,7 @@ mod tests {
             entities::User,
             ports::{MockUserRepository, MockUserRoleRepository},
         },
+        webhook::ports::MockWebhookRepository,
     };
 
     use super::*;
@@ -539,6 +619,7 @@ mod tests {
         MockOrganizationRepository,
         MockOrganizationAttributeRepository,
         MockOrganizationMemberRepository,
+        MockWebhookRepository,
     >;
 
     fn build_service(
@@ -548,6 +629,7 @@ mod tests {
         org_repo: MockOrganizationRepository,
         attr_repo: MockOrganizationAttributeRepository,
         member_repo: MockOrganizationMemberRepository,
+        webhook_repo: MockWebhookRepository,
     ) -> TestService {
         let user_arc = Arc::new(user_repo);
         let policy = Arc::new(FerriskeyPolicy::new(
@@ -563,6 +645,7 @@ mod tests {
             Arc::new(attr_repo),
             Arc::new(member_repo),
             policy,
+            Arc::new(webhook_repo),
         )
     }
 
@@ -605,6 +688,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             MockOrganizationMemberRepository::new(),
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -658,6 +742,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             MockOrganizationMemberRepository::new(),
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -717,6 +802,7 @@ mod tests {
             org_repo,
             attr_repo,
             MockOrganizationMemberRepository::new(),
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -771,6 +857,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             MockOrganizationMemberRepository::new(),
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -830,6 +917,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             MockOrganizationMemberRepository::new(),
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -904,6 +992,11 @@ mod tests {
             Box::pin(async move { Ok(vec![role]) })
         });
 
+        let mut webhook_repo = MockWebhookRepository::new();
+        webhook_repo
+            .expect_notify::<OrganizationMember>()
+            .return_once(|_, _| Box::pin(async { Ok(()) }));
+
         let service = build_service(
             realm_repo,
             user_repo,
@@ -911,6 +1004,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             member_repo,
+            webhook_repo,
         );
 
         let result = service
@@ -968,6 +1062,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             MockOrganizationMemberRepository::new(),
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -1035,6 +1130,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             MockOrganizationMemberRepository::new(),
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -1105,6 +1201,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             member_repo,
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -1165,6 +1262,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             member_repo,
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -1226,6 +1324,7 @@ mod tests {
             org_repo,
             MockOrganizationAttributeRepository::new(),
             member_repo,
+            MockWebhookRepository::new(),
         );
 
         let result = service
@@ -1281,6 +1380,7 @@ mod tests {
             MockOrganizationRepository::new(),
             MockOrganizationAttributeRepository::new(),
             member_repo,
+            MockWebhookRepository::new(),
         );
 
         let result = service

--- a/core/src/domain/webhook/entities/webhook_trigger.rs
+++ b/core/src/domain/webhook/entities/webhook_trigger.rs
@@ -64,6 +64,16 @@ pub enum WebhookTrigger {
     ClientMaintenanceEnabled,
     #[serde(rename = "client.maintenance.disabled")]
     ClientMaintenanceDisabled,
+    #[serde(rename = "organization.created")]
+    OrganizationCreated,
+    #[serde(rename = "organization.updated")]
+    OrganizationUpdated,
+    #[serde(rename = "organization.deleted")]
+    OrganizationDeleted,
+    #[serde(rename = "organization.member.added")]
+    OrganizationMemberAdded,
+    #[serde(rename = "organization.member.removed")]
+    OrganizationMemberRemoved,
 }
 
 impl Display for WebhookTrigger {
@@ -102,6 +112,11 @@ impl Display for WebhookTrigger {
             WebhookTrigger::ClientMaintenanceDisabled => {
                 write!(f, "client.maintenance.disabled")
             }
+            WebhookTrigger::OrganizationCreated => write!(f, "organization.created"),
+            WebhookTrigger::OrganizationUpdated => write!(f, "organization.updated"),
+            WebhookTrigger::OrganizationDeleted => write!(f, "organization.deleted"),
+            WebhookTrigger::OrganizationMemberAdded => write!(f, "organization.member.added"),
+            WebhookTrigger::OrganizationMemberRemoved => write!(f, "organization.member.removed"),
         }
     }
 }
@@ -140,6 +155,11 @@ impl TryFrom<String> for WebhookTrigger {
             "webhook.deleted" => Ok(WebhookTrigger::WebhookDeleted),
             "client.maintenance.enabled" => Ok(WebhookTrigger::ClientMaintenanceEnabled),
             "client.maintenance.disabled" => Ok(WebhookTrigger::ClientMaintenanceDisabled),
+            "organization.created" => Ok(WebhookTrigger::OrganizationCreated),
+            "organization.updated" => Ok(WebhookTrigger::OrganizationUpdated),
+            "organization.deleted" => Ok(WebhookTrigger::OrganizationDeleted),
+            "organization.member.added" => Ok(WebhookTrigger::OrganizationMemberAdded),
+            "organization.member.removed" => Ok(WebhookTrigger::OrganizationMemberRemoved),
             _ => Err("Invalid webhook trigger".to_string()),
         }
     }

--- a/front/nginx-standalone.conf
+++ b/front/nginx-standalone.conf
@@ -25,7 +25,7 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header Connection "";
     proxy_buffering off;
     proxy_read_timeout 300s;

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -435,6 +435,11 @@ export namespace Schemas {
     | 'webhook.deleted'
     | 'client.maintenance.enabled'
     | 'client.maintenance.disabled'
+    | 'organization.created'
+    | 'organization.updated'
+    | 'organization.deleted'
+    | 'organization.member.added'
+    | 'organization.member.removed'
   export type WebhookSubscriber = { id: string; name: WebhookTrigger; webhook_id: string }
   export type Webhook = {
     created_at: string

--- a/front/src/utils/webhook-utils.ts
+++ b/front/src/utils/webhook-utils.ts
@@ -26,6 +26,13 @@ export const WEBHOOK_CATEGORIES: Record<string, Schemas.WebhookTrigger[]> = {
     'auth.reset_password',
   ],
   Webhook: ['webhook.created', 'webhook.deleted', 'webhook.updated'],
+  Organization: [
+    'organization.created',
+    'organization.updated',
+    'organization.deleted',
+    'organization.member.added',
+    'organization.member.removed',
+  ],
 }
 
 export const WEBHOOK_TRIGGER_LABELS: Record<Schemas.WebhookTrigger, string> = {
@@ -62,6 +69,11 @@ export const WEBHOOK_TRIGGER_LABELS: Record<Schemas.WebhookTrigger, string> = {
   'webhook.updated': 'Webhook Updated',
   'client.maintenance.enabled': 'Client Maintenance Enabled',
   'client.maintenance.disabled': 'Client Maintenance Disabled',
+  'organization.created': 'Organization Created',
+  'organization.updated': 'Organization Updated',
+  'organization.deleted': 'Organization Deleted',
+  'organization.member.added': 'Organization Member Added',
+  'organization.member.removed': 'Organization Member Removed',
 }
 
 export const WEBHOOK_TRIGGER_DESCRIPTIONS: Record<Schemas.WebhookTrigger, string> = {
@@ -98,6 +110,11 @@ export const WEBHOOK_TRIGGER_DESCRIPTIONS: Record<Schemas.WebhookTrigger, string
   'webhook.updated': 'A webhook has been updated.',
   'client.maintenance.enabled': 'Maintenance mode has been enabled on a client.',
   'client.maintenance.disabled': 'Maintenance mode has been disabled on a client.',
+  'organization.created': 'A new organization has been created.',
+  'organization.updated': 'An organization has been updated.',
+  'organization.deleted': 'An organization has been deleted.',
+  'organization.member.added': 'A user has been added to an organization.',
+  'organization.member.removed': 'A user has been removed from an organization.',
 }
 
 export type WebhookCategory = {


### PR DESCRIPTION
## Summary

- Adds `--otlp-protocol` / `OTLP_PROTOCOL` env var (`grpc` | `http`, default: `grpc`) to select the OTLP transport at runtime
- Both `grpc-tonic` and `http-proto` Cargo features are compiled in — no separate builds needed
- Enables exporting to HTTP-only collectors such as **PostHog** without breaking existing gRPC deployments (Tempo, Jaeger)
- Helm chart: new `opentelemetry.protocol` value (default `grpc`) injected as `OTLP_PROTOCOL`

## Changed files

| File | Change |
|------|--------|
| `api/Cargo.toml` | Add `http-proto` feature to `opentelemetry-otlp` |
| `api/src/args.rs` | New `OtlpProtocol` enum + `otlp_protocol` field on `ObservabilityArgs` |
| `api/src/main.rs` | Match on protocol for all three exporters (spans, metrics, logs) |
| `charts/ferriskey/values.yaml` | New `opentelemetry.protocol` field (default `grpc`) |
| `charts/ferriskey/templates/_helpers.yaml` | Inject `OTLP_PROTOCOL` env var |

## Test plan

- [ ] `cargo check -p ferriskey-api` passes with both features compiled in
- [ ] `cargo test -p ferriskey-api` passes
- [ ] `cargo run -- --help` shows `--otlp-protocol` in help output
- [ ] Set `OTLP_PROTOCOL=http ACTIVE_OBSERVABILITY=true OTLP_ENDPOINT=http://localhost:4318` — server starts without errors
- [ ] Set `OTLP_PROTOCOL=grpc ACTIVE_OBSERVABILITY=true OTLP_ENDPOINT=http://localhost:4317` — existing gRPC behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization webhooks now emit events for creation, updates, deletion, and member additions/removals
  * OpenTelemetry exporter now supports HTTP protocol option alongside gRPC for flexible configuration
  * Organization webhook event categories integrated into the webhook management interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->