### PR TITLE
feat(device-flow): add device flow lifecycle service (initiate/verify/deny/poll)

### DIFF
--- a/core/src/domain/authentication/device_flow/entities.rs
+++ b/core/src/domain/authentication/device_flow/entities.rs
@@ -130,6 +130,28 @@ pub struct DeviceAuthSessionConfig {
     pub expires_in: i64,
 }
 
+/// Non-sensitive projection of a [`DeviceAuthSession`] sent as the body of
+/// `auth.device_flow.*` webhooks. Deliberately excludes the `user_code` so it
+/// can never leak through a webhook subscriber.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceFlowEventPayload {
+    pub session_id: Uuid,
+    pub realm_id: Uuid,
+    pub client_id: Uuid,
+    pub status: DeviceAuthStatus,
+}
+
+impl From<&DeviceAuthSession> for DeviceFlowEventPayload {
+    fn from(session: &DeviceAuthSession) -> Self {
+        Self {
+            session_id: session.id,
+            realm_id: session.realm_id.into(),
+            client_id: session.client_id,
+            status: session.status,
+        }
+    }
+}
+
 impl DeviceAuthSession {
     pub fn new(config: DeviceAuthSessionConfig) -> Self {
         let now = Utc::now();

--- a/core/src/domain/authentication/device_flow/error.rs
+++ b/core/src/domain/authentication/device_flow/error.rs
@@ -1,0 +1,73 @@
+use thiserror::Error;
+
+use crate::domain::authentication::entities::AuthenticationError;
+use crate::domain::common::entities::app_errors::CoreError;
+
+/// Errors surfaced by the device authorization grant (RFC 8628).
+///
+/// The `Display` strings of the polling variants intentionally match the
+/// `error` codes defined by RFC 8628 §3.5 so the HTTP layer can forward them
+/// verbatim in the token endpoint response.
+#[derive(Debug, Clone, Error)]
+pub enum DeviceFlowError {
+    /// The authorization request is still pending — the user has not yet
+    /// approved or denied it (RFC 8628 §3.5 `authorization_pending`).
+    #[error("authorization_pending")]
+    AuthorizationPending,
+
+    /// The device polled faster than the allowed interval (RFC 8628 §3.5
+    /// `slow_down`).
+    #[error("slow_down")]
+    SlowDown,
+
+    /// The session lifetime elapsed before approval (RFC 8628 §3.5
+    /// `expired_token`).
+    #[error("expired_token")]
+    ExpiredToken,
+
+    /// The end user denied the authorization request (RFC 8628 §3.5
+    /// `access_denied`).
+    #[error("access_denied")]
+    AccessDenied,
+
+    /// No session matches the supplied device code.
+    #[error("invalid device code")]
+    InvalidDeviceCode,
+
+    /// No session matches the supplied user code.
+    #[error("invalid user code")]
+    InvalidUserCode,
+
+    /// The polling client does not match the client that initiated the flow.
+    #[error("invalid client")]
+    InvalidClient,
+
+    /// Could not generate a collision-free user code within the retry budget.
+    #[error("failed to generate a unique user code")]
+    UserCodeGenerationExhausted,
+
+    /// Token issuance failed once the session was approved.
+    #[error("token issuance failed: {0}")]
+    TokenIssuance(String),
+
+    /// An underlying repository error.
+    #[error(transparent)]
+    Repository(#[from] AuthenticationError),
+}
+
+impl From<DeviceFlowError> for CoreError {
+    fn from(err: DeviceFlowError) -> Self {
+        match err {
+            DeviceFlowError::AuthorizationPending => CoreError::InvalidRequest,
+            DeviceFlowError::SlowDown => CoreError::InvalidRequest,
+            DeviceFlowError::ExpiredToken => CoreError::ExpiredToken,
+            DeviceFlowError::AccessDenied => CoreError::Forbidden("access_denied".to_string()),
+            DeviceFlowError::InvalidDeviceCode => CoreError::InvalidToken,
+            DeviceFlowError::InvalidUserCode => CoreError::InvalidToken,
+            DeviceFlowError::InvalidClient => CoreError::InvalidClient,
+            DeviceFlowError::UserCodeGenerationExhausted => CoreError::InternalServerError,
+            DeviceFlowError::TokenIssuance(msg) => CoreError::TokenGenerationError(msg),
+            DeviceFlowError::Repository(err) => err.into(),
+        }
+    }
+}

--- a/core/src/domain/authentication/device_flow/mod.rs
+++ b/core/src/domain/authentication/device_flow/mod.rs
@@ -1,11 +1,18 @@
 //! Domain model for the OAuth 2.0 Device Authorization Grant (RFC 8628).
 
 pub mod entities;
+pub mod error;
 pub mod ports;
+pub mod services;
 pub mod value_objects;
 
-pub use entities::{DeviceAuthSession, DeviceAuthSessionConfig, DeviceAuthStatus, UserCode};
-pub use ports::DeviceAuthRepository;
+pub use entities::{
+    DeviceAuthSession, DeviceAuthSessionConfig, DeviceAuthStatus, DeviceFlowEventPayload, UserCode,
+};
+pub use error::DeviceFlowError;
+pub use ports::{DeviceAuthRepository, DeviceFlowService, DeviceTokenIssuer};
+pub use services::{DeviceFlowConfig, DeviceFlowServiceImpl};
 pub use value_objects::{
-    InitiateDeviceFlowInput, InitiateDeviceFlowOutput, PollDeviceTokenInput, VerifyUserCodeInput,
+    InitiateDeviceFlowInput, InitiateDeviceFlowOutput, InitiateDeviceFlowParams,
+    PollDeviceTokenInput, PollDeviceTokenParams, VerifyUserCodeInput,
 };

--- a/core/src/domain/authentication/device_flow/ports.rs
+++ b/core/src/domain/authentication/device_flow/ports.rs
@@ -1,7 +1,13 @@
 use uuid::Uuid;
 
 use crate::domain::authentication::device_flow::entities::{DeviceAuthSession, DeviceAuthStatus};
-use crate::domain::authentication::entities::AuthenticationError;
+use crate::domain::authentication::device_flow::error::DeviceFlowError;
+use crate::domain::authentication::device_flow::value_objects::{
+    InitiateDeviceFlowOutput, InitiateDeviceFlowParams, PollDeviceTokenParams,
+};
+use crate::domain::authentication::entities::{AuthenticationError, JwtToken};
+use crate::domain::authentication::value_objects::GenerateTokensForUserInput;
+use crate::domain::common::entities::app_errors::CoreError;
 
 /// Persistence contract for device authorization sessions (RFC 8628).
 #[cfg_attr(test, mockall::automock)]
@@ -38,4 +44,51 @@ pub trait DeviceAuthRepository: Send + Sync {
         &self,
         device_code: Uuid,
     ) -> impl Future<Output = Result<(), AuthenticationError>> + Send;
+}
+
+/// Token issuance seam for the device flow.
+///
+/// Lets the device flow service mint tokens for an approved session without
+/// depending on the full `AuthService` surface. Implemented by the
+/// authentication service (delegating to its `generate_tokens_for_user` /
+/// `exchange_token` issuance path).
+#[cfg_attr(test, mockall::automock)]
+pub trait DeviceTokenIssuer: Send + Sync {
+    fn issue_tokens_for_user(
+        &self,
+        input: GenerateTokensForUserInput,
+    ) -> impl Future<Output = Result<JwtToken, CoreError>> + Send;
+}
+
+/// Business logic for the OAuth 2.0 Device Authorization Grant (RFC 8628).
+pub trait DeviceFlowService: Send + Sync {
+    /// Device authorization endpoint: create a session, generate a unique
+    /// `user_code`, persist it, and fire `auth.device_flow.initiated`.
+    fn initiate(
+        &self,
+        params: InitiateDeviceFlowParams,
+    ) -> impl Future<Output = Result<InitiateDeviceFlowOutput, DeviceFlowError>> + Send;
+
+    /// Verification page: bind the approving user and mark the session
+    /// approved.
+    fn verify_user_code(
+        &self,
+        user_code: String,
+        user_id: Uuid,
+    ) -> impl Future<Output = Result<(), DeviceFlowError>> + Send;
+
+    /// Verification page: mark the session denied and fire
+    /// `auth.device_flow.denied`.
+    fn deny(
+        &self,
+        user_code: String,
+        user_id: Uuid,
+    ) -> impl Future<Output = Result<(), DeviceFlowError>> + Send;
+
+    /// Token endpoint: advance the polling state machine, returning a
+    /// [`JwtToken`] once the session is approved.
+    fn poll(
+        &self,
+        params: PollDeviceTokenParams,
+    ) -> impl Future<Output = Result<JwtToken, DeviceFlowError>> + Send;
 }

--- a/core/src/domain/authentication/device_flow/services.rs
+++ b/core/src/domain/authentication/device_flow/services.rs
@@ -1,0 +1,803 @@
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use tracing::warn;
+
+use crate::domain::authentication::device_flow::entities::{
+    DeviceAuthSession, DeviceAuthSessionConfig, DeviceAuthStatus, DeviceFlowEventPayload, UserCode,
+};
+use crate::domain::authentication::device_flow::error::DeviceFlowError;
+use crate::domain::authentication::device_flow::ports::{
+    DeviceAuthRepository, DeviceFlowService, DeviceTokenIssuer,
+};
+use crate::domain::authentication::device_flow::value_objects::{
+    InitiateDeviceFlowOutput, InitiateDeviceFlowParams, PollDeviceTokenParams,
+};
+use crate::domain::authentication::entities::JwtToken;
+use crate::domain::authentication::value_objects::GenerateTokensForUserInput;
+use crate::domain::webhook::entities::webhook_payload::WebhookPayload;
+use crate::domain::webhook::entities::webhook_trigger::WebhookTrigger;
+use crate::domain::webhook::ports::WebhookRepository;
+
+/// Maximum number of attempts to find a collision-free user code.
+const MAX_USER_CODE_ATTEMPTS: usize = 5;
+const DEFAULT_INTERVAL_SECONDS: i64 = 5;
+const DEFAULT_EXPIRES_IN_SECONDS: i64 = 600;
+
+/// Tunable policy for the device flow: how long a session lives and how often
+/// a device may poll.
+#[derive(Debug, Clone, Copy)]
+pub struct DeviceFlowConfig {
+    pub interval_seconds: i64,
+    pub expires_in_seconds: i64,
+}
+
+impl Default for DeviceFlowConfig {
+    fn default() -> Self {
+        Self {
+            interval_seconds: DEFAULT_INTERVAL_SECONDS,
+            expires_in_seconds: DEFAULT_EXPIRES_IN_SECONDS,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DeviceFlowServiceImpl<DR, WR, I>
+where
+    DR: DeviceAuthRepository,
+    WR: WebhookRepository,
+    I: DeviceTokenIssuer,
+{
+    pub(crate) device_auth_repository: Arc<DR>,
+    pub(crate) webhook_repository: Arc<WR>,
+    pub(crate) token_issuer: Arc<I>,
+    pub(crate) config: DeviceFlowConfig,
+}
+
+impl<DR, WR, I> DeviceFlowServiceImpl<DR, WR, I>
+where
+    DR: DeviceAuthRepository,
+    WR: WebhookRepository,
+    I: DeviceTokenIssuer,
+{
+    pub fn new(
+        device_auth_repository: Arc<DR>,
+        webhook_repository: Arc<WR>,
+        token_issuer: Arc<I>,
+        config: DeviceFlowConfig,
+    ) -> Self {
+        Self {
+            device_auth_repository,
+            webhook_repository,
+            token_issuer,
+            config,
+        }
+    }
+
+    /// Draw user codes until one is free in the repository, bounded by
+    /// [`MAX_USER_CODE_ATTEMPTS`].
+    async fn generate_unique_user_code(&self) -> Result<UserCode, DeviceFlowError> {
+        for _ in 0..MAX_USER_CODE_ATTEMPTS {
+            let candidate = UserCode::generate();
+            let existing = self
+                .device_auth_repository
+                .find_by_user_code(candidate.as_str().to_string())
+                .await?;
+
+            if existing.is_none() {
+                return Ok(candidate);
+            }
+        }
+
+        Err(DeviceFlowError::UserCodeGenerationExhausted)
+    }
+
+    /// Fire a device flow webhook. Best-effort: failures are logged, never
+    /// propagated (mirrors the rest of the codebase).
+    async fn fire_event(&self, session: &DeviceAuthSession, trigger: WebhookTrigger) {
+        let realm_id = session.realm_id;
+        let payload = WebhookPayload::new(
+            trigger,
+            realm_id.into(),
+            Some(DeviceFlowEventPayload::from(session)),
+        );
+
+        if let Err(err) = self.webhook_repository.notify(realm_id, payload).await {
+            warn!("failed to fire device flow webhook: {err}");
+        }
+    }
+}
+
+impl<DR, WR, I> DeviceFlowService for DeviceFlowServiceImpl<DR, WR, I>
+where
+    DR: DeviceAuthRepository,
+    WR: WebhookRepository,
+    I: DeviceTokenIssuer,
+{
+    async fn initiate(
+        &self,
+        params: InitiateDeviceFlowParams,
+    ) -> Result<InitiateDeviceFlowOutput, DeviceFlowError> {
+        let user_code = self.generate_unique_user_code().await?;
+
+        let mut session = DeviceAuthSession::new(DeviceAuthSessionConfig {
+            realm_id: params.realm_id,
+            client_id: params.client_id,
+            scope: params.scope,
+            interval: self.config.interval_seconds,
+            expires_in: self.config.expires_in_seconds,
+        });
+        session.user_code = user_code;
+
+        let session = self.device_auth_repository.create(&session).await?;
+
+        self.fire_event(&session, WebhookTrigger::AuthDeviceFlowInitiated)
+            .await;
+
+        let verification_uri_complete = format!(
+            "{}?user_code={}",
+            params.verification_uri,
+            session.user_code.as_str()
+        );
+
+        Ok(InitiateDeviceFlowOutput {
+            device_code: session.device_code.to_string(),
+            user_code: session.user_code.into_inner(),
+            verification_uri: params.verification_uri,
+            verification_uri_complete,
+            expires_in: self.config.expires_in_seconds,
+            interval: self.config.interval_seconds,
+        })
+    }
+
+    async fn verify_user_code(
+        &self,
+        user_code: String,
+        user_id: uuid::Uuid,
+    ) -> Result<(), DeviceFlowError> {
+        let session = self
+            .device_auth_repository
+            .find_by_user_code(user_code)
+            .await?
+            .ok_or(DeviceFlowError::InvalidUserCode)?;
+
+        match session.status {
+            DeviceAuthStatus::Denied => return Err(DeviceFlowError::AccessDenied),
+            DeviceAuthStatus::Expired => return Err(DeviceFlowError::ExpiredToken),
+            // Idempotent: re-approving an already approved session is a no-op.
+            DeviceAuthStatus::Approved => return Ok(()),
+            DeviceAuthStatus::Pending => {}
+        }
+
+        if session.is_expired() {
+            return Err(DeviceFlowError::ExpiredToken);
+        }
+
+        self.device_auth_repository
+            .update_status(
+                session.device_code,
+                DeviceAuthStatus::Approved,
+                Some(user_id),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn deny(&self, user_code: String, user_id: uuid::Uuid) -> Result<(), DeviceFlowError> {
+        let session = self
+            .device_auth_repository
+            .find_by_user_code(user_code)
+            .await?
+            .ok_or(DeviceFlowError::InvalidUserCode)?;
+
+        let session = self
+            .device_auth_repository
+            .update_status(session.device_code, DeviceAuthStatus::Denied, Some(user_id))
+            .await?;
+
+        self.fire_event(&session, WebhookTrigger::AuthDeviceFlowDenied)
+            .await;
+
+        Ok(())
+    }
+
+    async fn poll(&self, params: PollDeviceTokenParams) -> Result<JwtToken, DeviceFlowError> {
+        let session = self
+            .device_auth_repository
+            .find_by_device_code(params.device_code)
+            .await?
+            .ok_or(DeviceFlowError::InvalidDeviceCode)?;
+
+        // The device_code is bound to the client that initiated the flow.
+        if session.client_id != params.client_id {
+            return Err(DeviceFlowError::InvalidClient);
+        }
+
+        match session.status {
+            DeviceAuthStatus::Approved => {
+                let user_id = session.user_id.ok_or_else(|| {
+                    DeviceFlowError::TokenIssuance(
+                        "approved session has no associated user".to_string(),
+                    )
+                })?;
+
+                self.token_issuer
+                    .issue_tokens_for_user(GenerateTokensForUserInput {
+                        user_id,
+                        realm_id: session.realm_id.into(),
+                        base_url: params.base_url,
+                        client_id: Some(session.client_id),
+                    })
+                    .await
+                    .map_err(|err| DeviceFlowError::TokenIssuance(err.to_string()))
+            }
+            DeviceAuthStatus::Denied => Err(DeviceFlowError::AccessDenied),
+            DeviceAuthStatus::Expired => Err(DeviceFlowError::ExpiredToken),
+            DeviceAuthStatus::Pending => {
+                // Time-based expiry takes precedence: terminate the session.
+                if session.is_expired() {
+                    let session = self
+                        .device_auth_repository
+                        .update_status(session.device_code, DeviceAuthStatus::Expired, None)
+                        .await?;
+
+                    self.fire_event(&session, WebhookTrigger::AuthDeviceFlowExpired)
+                        .await;
+
+                    return Err(DeviceFlowError::ExpiredToken);
+                }
+
+                // Anti-bruteforce: reject polls arriving faster than `interval`.
+                if let Some(last_polled_at) = session.last_polled_at {
+                    let next_allowed = last_polled_at + Duration::seconds(session.interval);
+                    if Utc::now() < next_allowed {
+                        return Err(DeviceFlowError::SlowDown);
+                    }
+                }
+
+                self.device_auth_repository
+                    .mark_polled(session.device_code)
+                    .await?;
+
+                Err(DeviceFlowError::AuthorizationPending)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chrono::{Duration, Utc};
+    use uuid::Uuid;
+
+    use crate::domain::authentication::device_flow::entities::{
+        DeviceAuthSession, DeviceAuthSessionConfig, DeviceAuthStatus, DeviceFlowEventPayload,
+    };
+    use crate::domain::authentication::device_flow::ports::{
+        MockDeviceAuthRepository, MockDeviceTokenIssuer,
+    };
+    use crate::domain::authentication::device_flow::value_objects::{
+        InitiateDeviceFlowParams, PollDeviceTokenParams,
+    };
+    use crate::domain::common::entities::app_errors::CoreError;
+    use crate::domain::realm::entities::RealmId;
+    use crate::domain::webhook::entities::webhook_payload::WebhookPayload;
+    use crate::domain::webhook::ports::MockWebhookRepository;
+
+    fn pending_session(client_id: Uuid) -> DeviceAuthSession {
+        DeviceAuthSession::new(DeviceAuthSessionConfig {
+            realm_id: RealmId::from(Uuid::new_v4()),
+            client_id,
+            scope: None,
+            interval: 5,
+            expires_in: 600,
+        })
+    }
+
+    fn dummy_token() -> JwtToken {
+        JwtToken::new(
+            "access".to_string(),
+            "Bearer".to_string(),
+            "refresh".to_string(),
+            300,
+            3600,
+            None,
+            None,
+        )
+    }
+
+    fn build(
+        device_repo: MockDeviceAuthRepository,
+        webhook_repo: MockWebhookRepository,
+        issuer: MockDeviceTokenIssuer,
+    ) -> DeviceFlowServiceImpl<MockDeviceAuthRepository, MockWebhookRepository, MockDeviceTokenIssuer>
+    {
+        DeviceFlowServiceImpl::new(
+            Arc::new(device_repo),
+            Arc::new(webhook_repo),
+            Arc::new(issuer),
+            DeviceFlowConfig::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn initiate_generates_session_and_fires_webhook() {
+        let mut device_repo = MockDeviceAuthRepository::new();
+        let mut webhook_repo = MockWebhookRepository::new();
+        let issuer = MockDeviceTokenIssuer::new();
+
+        device_repo
+            .expect_find_by_user_code()
+            .times(1)
+            .returning(|_| Box::pin(async move { Ok(None) }));
+        device_repo
+            .expect_create()
+            .times(1)
+            .returning(|s: &DeviceAuthSession| {
+                let s = s.clone();
+                Box::pin(async move { Ok(s) })
+            });
+        webhook_repo
+            .expect_notify::<DeviceFlowEventPayload>()
+            .times(1)
+            .returning(|_, _: WebhookPayload<DeviceFlowEventPayload>| {
+                Box::pin(async move { Ok(()) })
+            });
+
+        let service = build(device_repo, webhook_repo, issuer);
+        let out = service
+            .initiate(InitiateDeviceFlowParams {
+                realm_id: RealmId::from(Uuid::new_v4()),
+                client_id: Uuid::new_v4(),
+                scope: Some("openid".to_string()),
+                verification_uri: "https://auth.example.com/realms/master/device".to_string(),
+            })
+            .await
+            .expect("initiate should succeed");
+
+        assert_eq!(out.interval, DEFAULT_INTERVAL_SECONDS);
+        assert_eq!(out.expires_in, DEFAULT_EXPIRES_IN_SECONDS);
+        assert!(out.verification_uri_complete.contains("user_code="));
+        assert!(out.verification_uri_complete.contains(&out.user_code));
+        // device_code is a UUID rendered as a string.
+        assert!(Uuid::parse_str(&out.device_code).is_ok());
+    }
+
+    #[tokio::test]
+    async fn initiate_retries_on_user_code_collision() {
+        let mut device_repo = MockDeviceAuthRepository::new();
+        let mut webhook_repo = MockWebhookRepository::new();
+        let issuer = MockDeviceTokenIssuer::new();
+
+        // First candidate collides, second is free.
+        let mut calls = 0;
+        device_repo
+            .expect_find_by_user_code()
+            .times(2)
+            .returning(move |_| {
+                calls += 1;
+                let collide = calls == 1;
+                Box::pin(async move {
+                    if collide {
+                        Ok(Some(pending_session(Uuid::new_v4())))
+                    } else {
+                        Ok(None)
+                    }
+                })
+            });
+        device_repo
+            .expect_create()
+            .times(1)
+            .returning(|s: &DeviceAuthSession| {
+                let s = s.clone();
+                Box::pin(async move { Ok(s) })
+            });
+        webhook_repo
+            .expect_notify::<DeviceFlowEventPayload>()
+            .returning(|_, _: WebhookPayload<DeviceFlowEventPayload>| {
+                Box::pin(async move { Ok(()) })
+            });
+
+        let service = build(device_repo, webhook_repo, issuer);
+        let res = service
+            .initiate(InitiateDeviceFlowParams {
+                realm_id: RealmId::from(Uuid::new_v4()),
+                client_id: Uuid::new_v4(),
+                scope: None,
+                verification_uri: "https://auth.example.com/device".to_string(),
+            })
+            .await;
+
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn verify_user_code_marks_session_approved() {
+        let user_id = Uuid::new_v4();
+        let session = pending_session(Uuid::new_v4());
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        let webhook_repo = MockWebhookRepository::new();
+        let issuer = MockDeviceTokenIssuer::new();
+
+        device_repo
+            .expect_find_by_user_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        device_repo
+            .expect_update_status()
+            .withf(move |dc, status, uid| {
+                *dc == device_code && *status == DeviceAuthStatus::Approved && *uid == Some(user_id)
+            })
+            .times(1)
+            .return_once(move |_, _, _| {
+                let mut s = pending_session(Uuid::new_v4());
+                s.status = DeviceAuthStatus::Approved;
+                s.user_id = Some(user_id);
+                Box::pin(async move { Ok(s) })
+            });
+
+        let service = build(device_repo, webhook_repo, issuer);
+        service
+            .verify_user_code("BCDF-GHJK".to_string(), user_id)
+            .await
+            .expect("verify should succeed");
+    }
+
+    #[tokio::test]
+    async fn verify_unknown_user_code_is_invalid() {
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_user_code()
+            .times(1)
+            .returning(|_| Box::pin(async move { Ok(None) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .verify_user_code("ZZZZ-ZZZZ".to_string(), Uuid::new_v4())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::InvalidUserCode));
+    }
+
+    #[tokio::test]
+    async fn deny_marks_denied_and_fires_webhook() {
+        let user_id = Uuid::new_v4();
+        let session = pending_session(Uuid::new_v4());
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        let mut webhook_repo = MockWebhookRepository::new();
+        let issuer = MockDeviceTokenIssuer::new();
+
+        device_repo
+            .expect_find_by_user_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        device_repo
+            .expect_update_status()
+            .withf(move |dc, status, _| *dc == device_code && *status == DeviceAuthStatus::Denied)
+            .times(1)
+            .return_once(move |_, _, _| {
+                let mut s = pending_session(Uuid::new_v4());
+                s.status = DeviceAuthStatus::Denied;
+                Box::pin(async move { Ok(s) })
+            });
+        webhook_repo
+            .expect_notify::<DeviceFlowEventPayload>()
+            .times(1)
+            .returning(|_, _: WebhookPayload<DeviceFlowEventPayload>| {
+                Box::pin(async move { Ok(()) })
+            });
+
+        let service = build(device_repo, webhook_repo, issuer);
+        service
+            .deny("BCDF-GHJK".to_string(), user_id)
+            .await
+            .expect("deny should succeed");
+    }
+
+    #[tokio::test]
+    async fn poll_returns_token_when_approved() {
+        let user_id = Uuid::new_v4();
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        session.status = DeviceAuthStatus::Approved;
+        session.user_id = Some(user_id);
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        let mut issuer = MockDeviceTokenIssuer::new();
+
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        issuer
+            .expect_issue_tokens_for_user()
+            .withf(move |input| input.user_id == user_id && input.client_id == Some(client_id))
+            .times(1)
+            .return_once(|_| Box::pin(async move { Ok(dummy_token()) }));
+
+        let service = build(device_repo, MockWebhookRepository::new(), issuer);
+        let token = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .expect("poll should issue a token");
+
+        assert_eq!(token, dummy_token());
+    }
+
+    #[tokio::test]
+    async fn poll_pending_returns_authorization_pending_and_records_poll() {
+        let client_id = Uuid::new_v4();
+        let session = pending_session(client_id); // last_polled_at = None
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        device_repo
+            .expect_mark_polled()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(()) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::AuthorizationPending));
+    }
+
+    #[tokio::test]
+    async fn poll_too_fast_returns_slow_down() {
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        // Just polled — interval has not yet elapsed.
+        session.last_polled_at = Some(Utc::now());
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        // mark_polled must NOT be called on a slow_down.
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::SlowDown));
+    }
+
+    #[tokio::test]
+    async fn poll_after_interval_is_accepted_again() {
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        // Last poll was long enough ago (interval = 5s).
+        session.last_polled_at = Some(Utc::now() - Duration::seconds(30));
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        device_repo
+            .expect_mark_polled()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(()) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::AuthorizationPending));
+    }
+
+    #[tokio::test]
+    async fn poll_expired_marks_expired_and_fires_webhook() {
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        session.expires_at = Utc::now() - Duration::seconds(10);
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        let mut webhook_repo = MockWebhookRepository::new();
+
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        device_repo
+            .expect_update_status()
+            .withf(move |dc, status, _| *dc == device_code && *status == DeviceAuthStatus::Expired)
+            .times(1)
+            .return_once(move |_, _, _| {
+                let mut s = pending_session(client_id);
+                s.status = DeviceAuthStatus::Expired;
+                Box::pin(async move { Ok(s) })
+            });
+        webhook_repo
+            .expect_notify::<DeviceFlowEventPayload>()
+            .times(1)
+            .returning(|_, _: WebhookPayload<DeviceFlowEventPayload>| {
+                Box::pin(async move { Ok(()) })
+            });
+
+        let service = build(device_repo, webhook_repo, MockDeviceTokenIssuer::new());
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::ExpiredToken));
+    }
+
+    #[tokio::test]
+    async fn poll_denied_returns_access_denied() {
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        session.status = DeviceAuthStatus::Denied;
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::AccessDenied));
+    }
+
+    #[tokio::test]
+    async fn poll_unknown_device_code_is_invalid() {
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .returning(|_| Box::pin(async move { Ok(None) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code: Uuid::new_v4(),
+                client_id: Uuid::new_v4(),
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::InvalidDeviceCode));
+    }
+
+    #[tokio::test]
+    async fn poll_with_mismatched_client_is_rejected() {
+        let session = pending_session(Uuid::new_v4());
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id: Uuid::new_v4(), // different client
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::InvalidClient));
+    }
+
+    #[tokio::test]
+    async fn poll_token_issuance_failure_is_surfaced() {
+        let user_id = Uuid::new_v4();
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        session.status = DeviceAuthStatus::Approved;
+        session.user_id = Some(user_id);
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        let mut issuer = MockDeviceTokenIssuer::new();
+
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        issuer
+            .expect_issue_tokens_for_user()
+            .times(1)
+            .return_once(|_| Box::pin(async move { Err(CoreError::InvalidClient) }));
+
+        let service = build(device_repo, MockWebhookRepository::new(), issuer);
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::TokenIssuance(_)));
+    }
+}

--- a/core/src/domain/authentication/device_flow/value_objects.rs
+++ b/core/src/domain/authentication/device_flow/value_objects.rs
@@ -1,5 +1,28 @@
 //! DTOs for the device authorization grant use cases (RFC 8628).
 
+use uuid::Uuid;
+
+use crate::domain::realm::entities::RealmId;
+
+/// Domain command for [`DeviceFlowService::initiate`]. The realm and client are
+/// already resolved by the application layer; the domain only deals with ids.
+pub struct InitiateDeviceFlowParams {
+    pub realm_id: RealmId,
+    pub client_id: Uuid,
+    pub scope: Option<String>,
+    /// Absolute verification URI the user visits to enter the code, e.g.
+    /// `https://auth.example.com/realms/master/device`.
+    pub verification_uri: String,
+}
+
+/// Domain command for [`DeviceFlowService::poll`].
+pub struct PollDeviceTokenParams {
+    pub device_code: Uuid,
+    pub client_id: Uuid,
+    /// Issuer base URL used to mint tokens once the session is approved.
+    pub base_url: String,
+}
+
 /// Input for the device authorization endpoint (RFC 8628 §3.1).
 pub struct InitiateDeviceFlowInput {
     pub realm_name: String,

--- a/core/src/domain/webhook/entities/webhook_trigger.rs
+++ b/core/src/domain/webhook/entities/webhook_trigger.rs
@@ -24,6 +24,12 @@ pub enum WebhookTrigger {
     UserDeleteCredentials,
     #[serde(rename = "auth.reset_password")]
     AuthResetPassword,
+    #[serde(rename = "auth.device_flow.initiated")]
+    AuthDeviceFlowInitiated,
+    #[serde(rename = "auth.device_flow.denied")]
+    AuthDeviceFlowDenied,
+    #[serde(rename = "auth.device_flow.expired")]
+    AuthDeviceFlowExpired,
     #[serde(rename = "client.created")]
     ClientCreated,
     #[serde(rename = "client.updated")]
@@ -80,6 +86,9 @@ impl Display for WebhookTrigger {
             WebhookTrigger::UserRoleAssigned => write!(f, "user.role.assigned"),
             WebhookTrigger::UserRoleUnassigned => write!(f, "user.role.unassigned"),
             WebhookTrigger::AuthResetPassword => write!(f, "auth.reset_password"),
+            WebhookTrigger::AuthDeviceFlowInitiated => write!(f, "auth.device_flow.initiated"),
+            WebhookTrigger::AuthDeviceFlowDenied => write!(f, "auth.device_flow.denied"),
+            WebhookTrigger::AuthDeviceFlowExpired => write!(f, "auth.device_flow.expired"),
             WebhookTrigger::ClientCreated => write!(f, "client.created"),
             WebhookTrigger::ClientUpdated => write!(f, "client.updated"),
             WebhookTrigger::ClientDeleted => write!(f, "client.deleted"),
@@ -123,6 +132,9 @@ impl TryFrom<String> for WebhookTrigger {
             "user.role.assigned" => Ok(WebhookTrigger::UserRoleAssigned),
             "user.role.unassigned" => Ok(WebhookTrigger::UserRoleUnassigned),
             "auth.reset_password" => Ok(WebhookTrigger::AuthResetPassword),
+            "auth.device_flow.initiated" => Ok(WebhookTrigger::AuthDeviceFlowInitiated),
+            "auth.device_flow.denied" => Ok(WebhookTrigger::AuthDeviceFlowDenied),
+            "auth.device_flow.expired" => Ok(WebhookTrigger::AuthDeviceFlowExpired),
             "client.created" => Ok(WebhookTrigger::ClientCreated),
             "client.updated" => Ok(WebhookTrigger::ClientUpdated),
             "client.deleted" => Ok(WebhookTrigger::ClientDeleted),

--- a/core/src/infrastructure/repositories/auth_session_repository.rs
+++ b/core/src/infrastructure/repositories/auth_session_repository.rs
@@ -403,7 +403,7 @@ mod tests {
         let schema_pool = sqlx::PgPool::connect(&schema_url)
             .await
             .expect("connect schema pool");
-        sqlx::migrate!("migrations")
+        sqlx::migrate!("./migrations")
             .run(&schema_pool)
             .await
             .expect("run migrations");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device authentication flow support with complete lifecycle management (initiate, verify, approve, deny, and poll operations).
  * Added three new webhook event types for device authentication flow: initiated, denied, and expired states.
  * Enhanced error handling with specific, RFC-compliant error responses for device authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->