### PR TITLE
feat(device-flow): add Postgres DeviceAuthRepository and wire DeviceFlowService into DI

### DIFF
--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -11,7 +11,11 @@ use crate::{
         aegis::services::{
             ClientScopeServiceImpl, ProtocolMapperServiceImpl, ScopeMappingServiceImpl,
         },
-        authentication::{mapper_engine::MapperEngine, services::AuthServiceImpl},
+        authentication::{
+            device_flow::services::{DeviceFlowConfig, DeviceFlowServiceImpl},
+            mapper_engine::MapperEngine,
+            services::AuthServiceImpl,
+        },
         client::services::ClientServiceImpl,
         common::{
             FerriskeyConfig, entities::app_errors::CoreError, policies::FerriskeyPolicy,
@@ -79,6 +83,7 @@ use crate::{
             argon2_hasher::Argon2HasherRepository,
             auth_session_repository::PostgresAuthSessionRepository,
             credential_repository::PostgresCredentialRepository,
+            device_auth_repository::PostgresDeviceAuthRepository,
             email_verification_token_repository::PostgresEmailVerificationTokenRepository,
             keystore_repository::PostgresKeyStoreRepository,
             magic_link_repository::PostgresMagicLinkRepository,
@@ -151,6 +156,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
     let credential = Arc::new(PostgresCredentialRepository::new(postgres.get_db()));
     let hasher = Arc::new(Argon2HasherRepository::new());
     let auth_session = Arc::new(PostgresAuthSessionRepository::new(postgres.get_db()));
+    let device_auth = Arc::new(PostgresDeviceAuthRepository::new(postgres.get_db()));
     let redirect_uri = Arc::new(PostgresRedirectUriRepository::new(postgres.get_db()));
     let post_logout_redirect_uri = Arc::new(PostgresPostLogoutRedirectUriRepository::new(
         postgres.get_db(),
@@ -233,6 +239,44 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
         security_event.clone(),
     );
 
+    let auth_service = AuthServiceImpl::new(
+        realm.clone(),
+        client.clone(),
+        redirect_uri.clone(),
+        post_logout_redirect_uri.clone(),
+        user.clone(),
+        user_role.clone(),
+        credential.clone(),
+        hasher.clone(),
+        auth_session.clone(),
+        keystore.clone(),
+        refresh_token.clone(),
+        access_token.clone(),
+        federation.clone(),
+        scope_mapping.clone(),
+        protocol_mapper.clone(),
+        organization_member.clone(),
+        organization.clone(),
+        organization_attribute.clone(),
+        user_required_action.clone(),
+        maintenance_whitelist.clone(),
+        realm_maintenance_whitelist.clone(),
+        user_attribute.clone(),
+        email_verification_service.clone(),
+        webhook.clone(),
+        security_event.clone(),
+        Arc::new(MapperEngine::new()),
+        flow_recorder.clone(),
+    );
+
+    // The auth service doubles as the device flow's token issuer.
+    let device_flow_service = DeviceFlowServiceImpl::new(
+        device_auth.clone(),
+        webhook.clone(),
+        Arc::new(auth_service.clone()),
+        DeviceFlowConfig::default(),
+    );
+
     let app = ApplicationService {
         maintenance_service: MaintenanceServiceImpl::new(
             realm.clone(),
@@ -243,35 +287,8 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             realm_maintenance_whitelist.clone(),
             policy.clone(),
         ),
-        auth_service: AuthServiceImpl::new(
-            realm.clone(),
-            client.clone(),
-            redirect_uri.clone(),
-            post_logout_redirect_uri.clone(),
-            user.clone(),
-            user_role.clone(),
-            credential.clone(),
-            hasher.clone(),
-            auth_session.clone(),
-            keystore.clone(),
-            refresh_token.clone(),
-            access_token.clone(),
-            federation.clone(),
-            scope_mapping.clone(),
-            protocol_mapper.clone(),
-            organization_member.clone(),
-            organization.clone(),
-            organization_attribute.clone(),
-            user_required_action.clone(),
-            maintenance_whitelist.clone(),
-            realm_maintenance_whitelist.clone(),
-            user_attribute.clone(),
-            email_verification_service.clone(),
-            webhook.clone(),
-            security_event.clone(),
-            Arc::new(MapperEngine::new()),
-            flow_recorder.clone(),
-        ),
+        auth_service,
+        device_flow_service,
         client_service: ClientServiceImpl::new(
             realm.clone(),
             user.clone(),

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -9,7 +9,13 @@ use crate::{
         aegis::services::{
             ClientScopeServiceImpl, ProtocolMapperServiceImpl, ScopeMappingServiceImpl,
         },
-        authentication::{services::AuthServiceImpl, value_objects::Identity},
+        authentication::{
+            device_flow::{ports::DeviceTokenIssuer, services::DeviceFlowServiceImpl},
+            entities::JwtToken,
+            ports::AuthService,
+            services::AuthServiceImpl,
+            value_objects::{GenerateTokensForUserInput, Identity},
+        },
         client::services::ClientServiceImpl,
         common::{
             entities::{InitializationResult, StartupConfig, app_errors::CoreError},
@@ -77,6 +83,7 @@ use crate::{
             argon2_hasher::Argon2HasherRepository,
             auth_session_repository::PostgresAuthSessionRepository,
             credential_repository::PostgresCredentialRepository,
+            device_auth_repository::PostgresDeviceAuthRepository,
             email_verification_token_repository::PostgresEmailVerificationTokenRepository,
             keystore_repository::PostgresKeyStoreRepository,
             magic_link_repository::PostgresMagicLinkRepository,
@@ -215,6 +222,22 @@ type ApplicationAuthService = AuthServiceImpl<
     SecurityEventRepo,
 >;
 
+type DeviceAuthRepo = PostgresDeviceAuthRepository;
+
+/// The auth service is the concrete token issuer for the device flow: an
+/// approved session mints tokens through its existing issuance path.
+impl DeviceTokenIssuer for ApplicationAuthService {
+    async fn issue_tokens_for_user(
+        &self,
+        input: GenerateTokensForUserInput,
+    ) -> Result<JwtToken, CoreError> {
+        self.generate_tokens_for_user(input).await
+    }
+}
+
+type ApplicationDeviceFlowService =
+    DeviceFlowServiceImpl<DeviceAuthRepo, WebhookRepo, ApplicationAuthService>;
+
 #[derive(Clone, Debug)]
 pub struct ApplicationService {
     pub(crate) security_event_service:
@@ -278,6 +301,9 @@ pub struct ApplicationService {
 
     pub(crate) maintenance_service: ApplicationMaintenanceService,
     pub(crate) auth_service: ApplicationAuthService,
+    // Wired for DI; consumed once the device flow HTTP endpoints land.
+    #[allow(dead_code)]
+    pub(crate) device_flow_service: ApplicationDeviceFlowService,
     pub(crate) core_service: CoreServiceImpl<
         RealmRepo,
         KeystoreRepo,

--- a/core/src/domain/authentication/device_flow/entities.rs
+++ b/core/src/domain/authentication/device_flow/entities.rs
@@ -85,14 +85,32 @@ pub enum DeviceAuthStatus {
     Expired,
 }
 
+impl DeviceAuthStatus {
+    /// Canonical string stored in the database / used by `Display`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DeviceAuthStatus::Pending => "pending",
+            DeviceAuthStatus::Approved => "approved",
+            DeviceAuthStatus::Denied => "denied",
+            DeviceAuthStatus::Expired => "expired",
+        }
+    }
+
+    /// Parse a status back from its persisted string form.
+    pub fn from_db_value(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(DeviceAuthStatus::Pending),
+            "approved" => Some(DeviceAuthStatus::Approved),
+            "denied" => Some(DeviceAuthStatus::Denied),
+            "expired" => Some(DeviceAuthStatus::Expired),
+            _ => None,
+        }
+    }
+}
+
 impl Display for DeviceAuthStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DeviceAuthStatus::Pending => write!(f, "pending"),
-            DeviceAuthStatus::Approved => write!(f, "approved"),
-            DeviceAuthStatus::Denied => write!(f, "denied"),
-            DeviceAuthStatus::Expired => write!(f, "expired"),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/core/src/domain/authentication/device_flow/services.rs
+++ b/core/src/domain/authentication/device_flow/services.rs
@@ -41,7 +41,7 @@ impl Default for DeviceFlowConfig {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DeviceFlowServiceImpl<DR, WR, I>
 where
     DR: DeviceAuthRepository,

--- a/core/src/infrastructure/repositories.rs
+++ b/core/src/infrastructure/repositories.rs
@@ -2,6 +2,7 @@ pub mod access_token_repository;
 pub mod argon2_hasher;
 pub mod auth_session_repository;
 pub mod credential_repository;
+pub mod device_auth_repository;
 pub mod email_verification_token_repository;
 pub mod keystore_repository;
 pub mod magic_link_repository;

--- a/core/src/infrastructure/repositories/device_auth_repository.rs
+++ b/core/src/infrastructure/repositories/device_auth_repository.rs
@@ -1,0 +1,174 @@
+use chrono::{DateTime, Utc};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    prelude::Expr,
+};
+use tracing::error;
+use uuid::Uuid;
+
+use crate::domain::authentication::device_flow::entities::{
+    DeviceAuthSession, DeviceAuthStatus, UserCode,
+};
+use crate::domain::authentication::device_flow::ports::DeviceAuthRepository;
+use crate::domain::authentication::entities::AuthenticationError;
+use crate::entity::device_auth_sessions::{
+    ActiveModel as DasActiveModel, Column as DasColumn, Entity as DasEntity, Model as DasModel,
+};
+
+impl From<DasModel> for DeviceAuthSession {
+    fn from(model: DasModel) -> Self {
+        let created_at: DateTime<Utc> = model.created_at.into();
+        let expires_at: DateTime<Utc> = model.expires_at.into();
+        let last_polled_at: Option<DateTime<Utc>> = model.last_polled_at.map(Into::into);
+
+        DeviceAuthSession {
+            // The schema uses `device_code` as the primary key; there is no
+            // separate `id` column, so the two coincide once persisted.
+            id: model.device_code,
+            realm_id: model.realm_id.into(),
+            client_id: model.client_id,
+            device_code: model.device_code,
+            user_code: UserCode::new(model.user_code),
+            scope: model.scope,
+            status: DeviceAuthStatus::from_db_value(&model.status)
+                .unwrap_or(DeviceAuthStatus::Pending),
+            user_id: model.user_id,
+            interval: i64::from(model.interval_seconds),
+            created_at,
+            expires_at,
+            last_polled_at,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PostgresDeviceAuthRepository {
+    pub db: DatabaseConnection,
+}
+
+impl PostgresDeviceAuthRepository {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Delete all sessions whose lifetime has elapsed. Returns the number of
+    /// rows removed. Intended to be run periodically by a background job.
+    #[allow(dead_code)]
+    pub async fn purge_expired(&self) -> Result<u64, AuthenticationError> {
+        let now = Utc::now().fixed_offset();
+        let result = DasEntity::delete_many()
+            .filter(DasColumn::ExpiresAt.lt(now))
+            .exec(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error purging expired device auth sessions: {e:?}");
+                AuthenticationError::InternalServerError
+            })?;
+
+        Ok(result.rows_affected)
+    }
+}
+
+impl DeviceAuthRepository for PostgresDeviceAuthRepository {
+    async fn create(
+        &self,
+        session: &DeviceAuthSession,
+    ) -> Result<DeviceAuthSession, AuthenticationError> {
+        let model = DasActiveModel {
+            device_code: Set(session.device_code),
+            user_code: Set(session.user_code.as_str().to_string()),
+            client_id: Set(session.client_id),
+            realm_id: Set(session.realm_id.into()),
+            user_id: Set(session.user_id),
+            scope: Set(session.scope.clone()),
+            status: Set(session.status.as_str().to_string()),
+            interval_seconds: Set(session.interval as i32),
+            expires_at: Set(session.expires_at.fixed_offset()),
+            last_polled_at: Set(session.last_polled_at.map(|d| d.fixed_offset())),
+            created_at: Set(session.created_at.fixed_offset()),
+        };
+
+        let model = model.insert(&self.db).await.map_err(|e| {
+            error!("Error creating device auth session: {e:?}");
+            AuthenticationError::InternalServerError
+        })?;
+
+        Ok(model.into())
+    }
+
+    async fn find_by_device_code(
+        &self,
+        device_code: Uuid,
+    ) -> Result<Option<DeviceAuthSession>, AuthenticationError> {
+        let model = DasEntity::find_by_id(device_code)
+            .one(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error finding device auth session by device_code: {e:?}");
+                AuthenticationError::InternalServerError
+            })?;
+
+        Ok(model.map(Into::into))
+    }
+
+    async fn find_by_user_code(
+        &self,
+        user_code: String,
+    ) -> Result<Option<DeviceAuthSession>, AuthenticationError> {
+        let model = DasEntity::find()
+            .filter(DasColumn::UserCode.eq(user_code))
+            .one(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error finding device auth session by user_code: {e:?}");
+                AuthenticationError::InternalServerError
+            })?;
+
+        Ok(model.map(Into::into))
+    }
+
+    async fn update_status(
+        &self,
+        device_code: Uuid,
+        status: DeviceAuthStatus,
+        user_id: Option<Uuid>,
+    ) -> Result<DeviceAuthSession, AuthenticationError> {
+        let mut update = DasEntity::update_many()
+            .col_expr(DasColumn::Status, Expr::value(status.as_str().to_string()));
+
+        if let Some(user_id) = user_id {
+            update = update.col_expr(DasColumn::UserId, Expr::value(user_id));
+        }
+
+        let model = update
+            .filter(DasColumn::DeviceCode.eq(device_code))
+            .exec_with_returning(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error updating device auth session status: {e:?}");
+                AuthenticationError::InternalServerError
+            })?
+            .into_iter()
+            .next()
+            .ok_or(AuthenticationError::NotFound)?;
+
+        Ok(model.into())
+    }
+
+    async fn mark_polled(&self, device_code: Uuid) -> Result<(), AuthenticationError> {
+        DasEntity::update_many()
+            .col_expr(
+                DasColumn::LastPolledAt,
+                Expr::value(Utc::now().fixed_offset()),
+            )
+            .filter(DasColumn::DeviceCode.eq(device_code))
+            .exec(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error marking device auth session as polled: {e:?}");
+                AuthenticationError::InternalServerError
+            })?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device flow authentication, enabling authorization on devices without browsers
  * Device authentication sessions with full status lifecycle management (pending, approved, denied, expired)
  * Automatic cleanup of expired sessions
  * Token generation for approved device requests
  * Device code and user code handling for authorization workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->