### PR TITLE
feat(device-flow): handle device_code grant at the token endpoint (RFC 8628 §3.4)

### DIFF
--- a/api/src/application/http/authentication/handlers/token.rs
+++ b/api/src/application/http/authentication/handlers/token.rs
@@ -14,7 +14,7 @@ use axum::{
     response::IntoResponse,
 };
 use axum_extra::extract::cookie::{Cookie, SameSite};
-use ferriskey_core::domain::authentication::entities::JwtToken;
+use ferriskey_core::domain::authentication::entities::{GrantType, JwtToken};
 use ferriskey_core::domain::authentication::{entities::ExchangeTokenInput, ports::AuthService};
 use tracing::{instrument, warn};
 
@@ -72,36 +72,48 @@ pub async fn exchange_token(
 
     let is_secure = base_url.starts_with("https://");
     let base_url = root_scoped_base_url(&base_url, &state.args.server.root_path);
-    let token = match state
-        .service
-        .exchange_token(ExchangeTokenInput {
-            realm_name,
-            client_id: client_id.clone(),
-            client_secret,
-            code: payload.code,
-            username: payload.username,
-            password: payload.password,
-            refresh_token: payload.refresh_token,
-            base_url,
-            grant_type: payload.grant_type,
-            scope: payload.scope,
-        })
-        .await
-    {
-        Ok(token) => token,
-        Err(error) => {
-            warn!(
-                client_id = %client_id,
-                grant_type = ?grant_type,
-                has_client_secret,
-                has_username,
-                has_password,
-                has_code,
-                has_refresh_token,
-                error = ?error,
-                "Token exchange failed"
-            );
-            return Err(error.into());
+
+    let exchange_input = ExchangeTokenInput {
+        realm_name,
+        client_id: client_id.clone(),
+        client_secret,
+        code: payload.code,
+        username: payload.username,
+        password: payload.password,
+        refresh_token: payload.refresh_token,
+        base_url,
+        grant_type: payload.grant_type.clone(),
+        scope: payload.scope,
+        device_code: payload.device_code,
+    };
+
+    // The device_code grant is served by the device flow polling path so its
+    // RFC 8628 §3.5 error codes survive as an RFC 6749 §5.2 error response.
+    let token = if payload.grant_type == GrantType::DeviceCode {
+        match state.service.poll_device_token(exchange_input).await {
+            Ok(token) => token,
+            Err(error) => {
+                warn!(client_id = %client_id, error = ?error, "Device token poll failed");
+                return Err(error.into());
+            }
+        }
+    } else {
+        match state.service.exchange_token(exchange_input).await {
+            Ok(token) => token,
+            Err(error) => {
+                warn!(
+                    client_id = %client_id,
+                    grant_type = ?grant_type,
+                    has_client_secret,
+                    has_username,
+                    has_password,
+                    has_code,
+                    has_refresh_token,
+                    error = ?error,
+                    "Token exchange failed"
+                );
+                return Err(error.into());
+            }
         }
     };
 

--- a/api/src/application/http/authentication/validators.rs
+++ b/api/src/application/http/authentication/validators.rs
@@ -32,6 +32,10 @@ pub struct TokenRequestValidator {
     // Example: "openid profile email"
     #[serde(default)]
     pub scope: Option<String>,
+
+    // Used by the device_code grant (RFC 8628 §3.4)
+    #[serde(default)]
+    pub device_code: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]

--- a/api/src/application/http/error.rs
+++ b/api/src/application/http/error.rs
@@ -1,6 +1,6 @@
 use ferriskey_core::domain::{
-    common::entities::app_errors::CoreError, portal_theme::validation::MissingBlocks,
-    user::entities::RequiredAction,
+    authentication::device_flow::error::DeviceFlowError, common::entities::app_errors::CoreError,
+    portal_theme::validation::MissingBlocks, user::entities::RequiredAction,
 };
 use serde_json::{from_str, to_string};
 
@@ -267,6 +267,48 @@ impl From<CoreError> for ApiError {
             CoreError::PortalLayoutInUse => Self::BadRequest(
                 "Portal layout is referenced by one or more themes and cannot be deleted".into(),
             ),
+        }
+    }
+}
+
+impl From<DeviceFlowError> for ApiError {
+    fn from(error: DeviceFlowError) -> Self {
+        // Token endpoint errors follow the RFC 6749 §5.2 shape (HTTP 400):
+        // `{ "error": "...", "error_description": "..." }`. The device flow
+        // polling codes are defined by RFC 8628 §3.5.
+        let oauth = |code: &'static str, description: &str| Self::OAuthError {
+            error: code.into(),
+            error_description: description.to_string().into(),
+        };
+
+        match error {
+            DeviceFlowError::AuthorizationPending => oauth(
+                "authorization_pending",
+                "The authorization request is still pending.",
+            ),
+            DeviceFlowError::SlowDown => oauth("slow_down", "Polling too frequently; slow down."),
+            DeviceFlowError::ExpiredToken => oauth("expired_token", "The device code has expired."),
+            DeviceFlowError::AccessDenied => {
+                oauth("access_denied", "The authorization request was denied.")
+            }
+            DeviceFlowError::InvalidDeviceCode => {
+                oauth("invalid_grant", "The device code is invalid or unknown.")
+            }
+            DeviceFlowError::InvalidUserCode => {
+                oauth("invalid_grant", "The user code is invalid or unknown.")
+            }
+            DeviceFlowError::InvalidClient => {
+                oauth("invalid_client", "Client authentication failed.")
+            }
+            DeviceFlowError::UserCodeGenerationExhausted => {
+                Self::InternalServerError("Failed to generate a unique user code".into())
+            }
+            DeviceFlowError::TokenIssuance(msg) => {
+                Self::InternalServerError(format!("Token issuance failed: {msg}").into())
+            }
+            DeviceFlowError::Repository(_) => {
+                Self::InternalServerError("Internal server error".into())
+            }
         }
     }
 }

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -11,13 +11,15 @@ use crate::{
         },
         authentication::{
             device_flow::{
+                error::DeviceFlowError,
                 ports::{DeviceFlowService, DeviceTokenIssuer},
                 services::DeviceFlowServiceImpl,
                 value_objects::{
                     InitiateDeviceFlowInput, InitiateDeviceFlowOutput, InitiateDeviceFlowParams,
+                    PollDeviceTokenParams,
                 },
             },
-            entities::JwtToken,
+            entities::{ExchangeTokenInput, JwtToken},
             ports::AuthService,
             services::AuthServiceImpl,
             value_objects::{GenerateTokensForUserInput, Identity},
@@ -491,6 +493,47 @@ impl ApplicationService {
             .await?;
 
         Ok(output)
+    }
+
+    /// Token endpoint polling for the device_code grant (RFC 8628 §3.4).
+    ///
+    /// Resolves the realm and client, then advances the device flow state
+    /// machine. Errors are returned as [`DeviceFlowError`] so the HTTP layer
+    /// can render the RFC 6749 §5.2 error shape with the correct OAuth code.
+    /// `base_url` must already be root-path scoped by the caller.
+    pub async fn poll_device_token(
+        &self,
+        input: ExchangeTokenInput,
+    ) -> Result<JwtToken, DeviceFlowError> {
+        let device_code = input
+            .device_code
+            .as_deref()
+            .and_then(|code| uuid::Uuid::parse_str(code).ok())
+            .ok_or(DeviceFlowError::InvalidDeviceCode)?;
+
+        // An unresolvable realm/client at the token endpoint is `invalid_client`.
+        let realm = self
+            .realm_service
+            .realm_repository
+            .get_by_name(&input.realm_name)
+            .await
+            .map_err(|_| DeviceFlowError::InvalidClient)?
+            .ok_or(DeviceFlowError::InvalidClient)?;
+
+        let client = self
+            .client_service
+            .client_repository
+            .get_by_client_id(input.client_id, realm.id)
+            .await
+            .map_err(|_| DeviceFlowError::InvalidClient)?;
+
+        self.device_flow_service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id: client.id,
+                base_url: input.base_url,
+            })
+            .await
     }
 
     pub async fn run_data_migrations(&self) -> Result<MigrationReport, MigrationError> {

--- a/core/src/domain/authentication/entities.rs
+++ b/core/src/domain/authentication/entities.rs
@@ -145,6 +145,8 @@ pub struct ExchangeTokenInput {
     pub base_url: String,
     pub grant_type: GrantType,
     pub scope: Option<String>,
+    /// Set for the `urn:ietf:params:oauth:grant-type:device_code` grant.
+    pub device_code: Option<String>,
 }
 
 pub struct AuthorizeRequestInput {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device code flow authentication is now available, enabling authentication on devices without traditional browser access.
  * Token polling for device code grant type has been implemented to support asynchronous authentication workflows.
  * Device code parameter support added to token requests.

* **Improvements**
  * Device authentication errors now return standardized OAuth-compliant responses with appropriate error descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->