### PR TITLE
feat: ciam application detail

### DIFF
--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -1,16 +1,26 @@
 import { useDeleteClient, useGetClient, useUpdateClient } from '@/api/client.api'
 import { useCreateRedirectUri, useDeleteRedirectUri } from '@/api/redirect_uris.api'
+import { Skeleton } from '@/components/ui/skeleton'
+import PageClientMaintenanceFeature from '@/pages/client/feature/page-client-maintenance-feature'
+import PageClientRolesFeature from '@/pages/client/feature/page-client-roles-feature'
 import { RouterParams } from '@/routes/router'
 import { APPLICATIONS_URL } from '@/routes/sub-router/applications.router'
-import { Skeleton } from '@/components/ui/skeleton'
+import { Globe, Palette, Puzzle } from 'lucide-react'
 import { useState } from 'react'
-import { useNavigate, useParams } from 'react-router'
+import { useNavigate, useParams, useSearchParams } from 'react-router'
 import { toast } from 'sonner'
-import PageApplicationDetail, { ApplicationSettingsValues } from '../ui/page-application-detail'
+import ApplicationDetailShell, { AppTab, TabDef } from '../ui/application-detail-shell'
+import ApiAccessTab from '../ui/tabs/api-access-tab'
+import ComingSoonTab from '../ui/tabs/coming-soon-tab'
+import CredentialsTab from '../ui/tabs/credentials-tab'
+import QuickstartTab from '../ui/tabs/quickstart-tab'
+import SettingsTab, { ApplicationSettingsValues } from '../ui/tabs/settings-tab'
+import { inferApplicationType } from '../types'
 
 export default function PageApplicationDetailFeature() {
   const { realm_name, client_id } = useParams<RouterParams>()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const realm = realm_name ?? 'master'
 
   const { data: clientResponse, isLoading, refetch } = useGetClient({
@@ -95,17 +105,113 @@ export default function PageApplicationDetailFeature() {
     )
   }
 
+  const appType = inferApplicationType(client)
+  // Interactive (browser) clients can have IdP connections, branding and addons.
+  // Machine-to-machine and device clients have no human login surface for these.
+  const isInteractive = appType !== 'm2m' && appType !== 'device'
+
+  const tabs: TabDef[] = [
+    { id: 'quickstart', label: 'Quickstart' },
+    { id: 'settings', label: 'Settings' },
+    { id: 'credentials', label: 'Credentials' },
+    ...(isInteractive ? [{ id: 'connections', label: 'Connections', soon: true } as TabDef] : []),
+    { id: 'api-access', label: 'API Access' },
+    ...(isInteractive ? [{ id: 'addons', label: 'Addons', soon: true } as TabDef] : []),
+    ...(isInteractive
+      ? [{ id: 'login-experience', label: 'Login Experience', soon: true } as TabDef]
+      : []),
+    { id: 'roles', label: 'Roles' },
+    { id: 'maintenance', label: 'Maintenance' },
+  ]
+
+  const requested = searchParams.get('tab') as AppTab | null
+  const isSelectable = (t: AppTab | null): t is AppTab =>
+    !!t && tabs.some((tab) => tab.id === t && !tab.soon)
+  const activeTab: AppTab = isSelectable(requested) ? requested : 'quickstart'
+
+  const handleSelectTab = (tab: AppTab) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.set('tab', tab)
+        return next
+      },
+      { replace: true },
+    )
+  }
+
+  const renderTab = () => {
+    switch (activeTab) {
+      case 'quickstart':
+        return <QuickstartTab client={client} realm={realm} />
+      case 'settings':
+        return (
+          <SettingsTab
+            client={client}
+            isSaving={isSaving}
+            uriPending={uriPending}
+            onSave={handleSave}
+            onDelete={handleDelete}
+            onAddRedirectUri={handleAddRedirectUri}
+            onDeleteRedirectUri={handleDeleteRedirectUri}
+          />
+        )
+      case 'credentials':
+        return <CredentialsTab client={client} />
+      case 'api-access':
+        return <ApiAccessTab realm={realm} clientId={client.id} />
+      case 'roles':
+        return <PageClientRolesFeature />
+      case 'maintenance':
+        return <PageClientMaintenanceFeature />
+      case 'connections':
+        return (
+          <ComingSoonTab
+            icon={Globe}
+            title='Connections'
+            description='Choose which identity providers and login methods this application can use.'
+            points={[
+              'Enable or disable realm identity providers per application',
+              'Restrict social / enterprise connections to specific apps',
+            ]}
+          />
+        )
+      case 'login-experience':
+        return (
+          <ComingSoonTab
+            icon={Palette}
+            title='Login Experience'
+            description='Customize the sign-in page branding shown for this application.'
+            points={[
+              'Per-application logo, colors and theme overrides',
+              'Currently branding is configured at the realm level',
+            ]}
+          />
+        )
+      case 'addons':
+        return (
+          <ComingSoonTab
+            icon={Puzzle}
+            title='Addons'
+            description='Enable protocol addons such as SAML and WS-Federation for this application.'
+            points={['SAML 2.0 service provider', 'WS-Federation', 'Token customization addons']}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
   return (
-    <PageApplicationDetail
+    <ApplicationDetailShell
       key={client.id}
       client={client}
-      isSaving={isSaving}
-      uriPending={uriPending}
+      tabs={tabs}
+      activeTab={activeTab}
+      onSelectTab={handleSelectTab}
       onBack={handleBack}
-      onSave={handleSave}
-      onDelete={handleDelete}
-      onAddRedirectUri={handleAddRedirectUri}
-      onDeleteRedirectUri={handleDeleteRedirectUri}
-    />
+    >
+      {renderTab()}
+    </ApplicationDetailShell>
   )
 }

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -35,9 +35,11 @@ export default function PageApplicationDetailFeature() {
 
   const client = clientResponse?.data
 
-  const handleBack = () => navigate(APPLICATIONS_URL(realm))
+  function handleBack() {
+    navigate(APPLICATIONS_URL(realm))
+  }
 
-  const handleSave = async (values: ApplicationSettingsValues) => {
+  async function handleSave(values: ApplicationSettingsValues) {
     if (!client) return
     await updateClient({
       body: {
@@ -55,7 +57,7 @@ export default function PageApplicationDetailFeature() {
     })
   }
 
-  const handleDelete = async () => {
+  async function handleDelete() {
     if (!client) return
     try {
       await deleteClient({ path: { client_id: client.id, realm_name: realm } })
@@ -66,7 +68,7 @@ export default function PageApplicationDetailFeature() {
     }
   }
 
-  const handleAddRedirectUri = async (value: string) => {
+  async function handleAddRedirectUri(value: string) {
     if (!client) return
     setUriPending(true)
     try {
@@ -80,7 +82,7 @@ export default function PageApplicationDetailFeature() {
     }
   }
 
-  const handleDeleteRedirectUri = async (redirectUriId: string) => {
+  async function handleDeleteRedirectUri(redirectUriId: string) {
     if (!client) return
     setUriPending(true)
     try {
@@ -123,11 +125,12 @@ export default function PageApplicationDetailFeature() {
   ]
 
   const requested = searchParams.get('tab') as AppTab | null
-  const isSelectable = (t: AppTab | null): t is AppTab =>
-    !!t && tabs.some((tab) => tab.id === t && !tab.soon)
+  function isSelectable(t: AppTab | null): t is AppTab {
+    return !!t && tabs.some((tab) => tab.id === t && !tab.soon)
+  }
   const activeTab: AppTab = isSelectable(requested) ? requested : 'quickstart'
 
-  const handleSelectTab = (tab: AppTab) => {
+  function handleSelectTab(tab: AppTab) {
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev)
@@ -138,7 +141,7 @@ export default function PageApplicationDetailFeature() {
     )
   }
 
-  const renderTab = () => {
+  function renderTab() {
     switch (activeTab) {
       case 'quickstart':
         return <QuickstartTab client={client} realm={realm} />

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -1,0 +1,111 @@
+import { useDeleteClient, useGetClient, useUpdateClient } from '@/api/client.api'
+import { useCreateRedirectUri, useDeleteRedirectUri } from '@/api/redirect_uris.api'
+import { RouterParams } from '@/routes/router'
+import { APPLICATIONS_URL } from '@/routes/sub-router/applications.router'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
+import { toast } from 'sonner'
+import PageApplicationDetail, { ApplicationSettingsValues } from '../ui/page-application-detail'
+
+export default function PageApplicationDetailFeature() {
+  const { realm_name, client_id } = useParams<RouterParams>()
+  const navigate = useNavigate()
+  const realm = realm_name ?? 'master'
+
+  const { data: clientResponse, isLoading, refetch } = useGetClient({
+    realm,
+    clientId: client_id ?? '',
+  })
+
+  const { mutateAsync: updateClient, isPending: isSaving } = useUpdateClient()
+  const { mutateAsync: deleteClient } = useDeleteClient()
+  const { mutateAsync: createRedirectUri } = useCreateRedirectUri()
+  const { mutateAsync: deleteRedirectUri } = useDeleteRedirectUri()
+  const [uriPending, setUriPending] = useState(false)
+
+  const client = clientResponse?.data
+
+  const handleBack = () => navigate(APPLICATIONS_URL(realm))
+
+  const handleSave = async (values: ApplicationSettingsValues) => {
+    if (!client) return
+    await updateClient({
+      body: {
+        client_id: client.client_id,
+        name: values.name,
+        enabled: values.enabled,
+        direct_access_grants_enabled: values.directAccessGrantsEnabled,
+        oauth_device_code_grant_enabled: values.oauthDeviceCodeGrantEnabled,
+        access_token_lifetime: values.accessTokenLifetime,
+        refresh_token_lifetime: values.refreshTokenLifetime,
+        id_token_lifetime: values.idTokenLifetime,
+        temporary_token_lifetime: values.temporaryTokenLifetime,
+      },
+      path: { client_id: client.id, realm_name: realm },
+    })
+  }
+
+  const handleDelete = async () => {
+    if (!client) return
+    try {
+      await deleteClient({ path: { client_id: client.id, realm_name: realm } })
+      toast.success('Application deleted')
+      navigate(APPLICATIONS_URL(realm))
+    } catch {
+      // error surfaced by the mutation hook
+    }
+  }
+
+  const handleAddRedirectUri = async (value: string) => {
+    if (!client) return
+    setUriPending(true)
+    try {
+      await createRedirectUri({ realmName: realm, clientId: client.id, payload: { value } })
+      await refetch()
+      toast.success('Redirect URI added')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add redirect URI')
+    } finally {
+      setUriPending(false)
+    }
+  }
+
+  const handleDeleteRedirectUri = async (redirectUriId: string) => {
+    if (!client) return
+    setUriPending(true)
+    try {
+      await deleteRedirectUri({ realmName: realm, clientId: client.id, redirectUriId })
+      await refetch()
+      toast.success('Redirect URI removed')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove redirect URI')
+    } finally {
+      setUriPending(false)
+    }
+  }
+
+  if (isLoading || !client) {
+    return (
+      <div className='flex flex-col gap-6 p-8 md:p-12 max-w-3xl'>
+        <Skeleton className='h-6 w-48' />
+        <Skeleton className='h-40 w-full rounded-md' />
+        <Skeleton className='h-40 w-full rounded-md' />
+      </div>
+    )
+  }
+
+  return (
+    <PageApplicationDetail
+      key={client.id}
+      client={client}
+      isSaving={isSaving}
+      uriPending={uriPending}
+      onBack={handleBack}
+      onSave={handleSave}
+      onDelete={handleDelete}
+      onAddRedirectUri={handleAddRedirectUri}
+      onDeleteRedirectUri={handleDeleteRedirectUri}
+    />
+  )
+}

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -141,7 +141,9 @@ export default function PageApplicationDetailFeature() {
     )
   }
 
-  function renderTab() {
+  // Arrow function on purpose: it relies on `client` being narrowed to non-null
+  // by the guard above. A hoisted `function` declaration would lose that narrowing.
+  const renderTab = () => {
     switch (activeTab) {
       case 'quickstart':
         return <QuickstartTab client={client} realm={realm} />

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -2,7 +2,6 @@ import { useDeleteClient, useGetClient, useUpdateClient } from '@/api/client.api
 import { useCreateRedirectUri, useDeleteRedirectUri } from '@/api/redirect_uris.api'
 import { Skeleton } from '@/components/ui/skeleton'
 import PageClientMaintenanceFeature from '@/pages/client/feature/page-client-maintenance-feature'
-import PageClientRolesFeature from '@/pages/client/feature/page-client-roles-feature'
 import { RouterParams } from '@/routes/router'
 import { APPLICATIONS_URL } from '@/routes/sub-router/applications.router'
 import { Globe, Palette, Puzzle } from 'lucide-react'
@@ -120,7 +119,6 @@ export default function PageApplicationDetailFeature() {
     ...(isInteractive
       ? [{ id: 'login-experience', label: 'Login Experience', soon: true } as TabDef]
       : []),
-    { id: 'roles', label: 'Roles' },
     { id: 'maintenance', label: 'Maintenance' },
   ]
 
@@ -160,8 +158,6 @@ export default function PageApplicationDetailFeature() {
         return <CredentialsTab client={client} />
       case 'api-access':
         return <ApiAccessTab realm={realm} clientId={client.id} />
-      case 'roles':
-        return <PageClientRolesFeature />
       case 'maintenance':
         return <PageClientMaintenanceFeature />
       case 'connections':

--- a/front/src/pages/console-applications/feature/page-applications-list-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-applications-list-feature.tsx
@@ -1,6 +1,6 @@
 import { useGetClients } from '@/api/client.api'
 import { RouterParams } from '@/routes/router'
-import { APPLICATION_CREATE_URL, APPLICATIONS_URL } from '@/routes/sub-router/applications.router'
+import { APPLICATION_CREATE_URL, APPLICATION_DETAIL_URL } from '@/routes/sub-router/applications.router'
 import { useNavigate, useParams } from 'react-router'
 import PageApplicationsList from '../ui/page-applications-list'
 
@@ -16,9 +16,7 @@ export default function PageApplicationsListFeature() {
 
   const handleSelect = (clientId: string) => {
     if (!realm_name) return
-    // Detail page lives in admin for now; we'll add a CIAM detail later.
-    navigate(`${APPLICATIONS_URL(realm_name)}`)
-    void clientId
+    navigate(APPLICATION_DETAIL_URL(realm_name, clientId))
   }
 
   return (

--- a/front/src/pages/console-applications/page-console-applications.tsx
+++ b/front/src/pages/console-applications/page-console-applications.tsx
@@ -1,4 +1,5 @@
 import { Route, Routes } from 'react-router'
+import PageApplicationDetailFeature from './feature/page-application-detail-feature'
 import PageApplicationsListFeature from './feature/page-applications-list-feature'
 import PageCreateApplicationFeature from './feature/page-create-application-feature'
 import PageCreateApplicationTypeFeature from './feature/page-create-application-type-feature'
@@ -9,6 +10,7 @@ export default function PageConsoleApplications() {
       <Route index element={<PageApplicationsListFeature />} />
       <Route path='create' element={<PageCreateApplicationTypeFeature />} />
       <Route path='create/:type' element={<PageCreateApplicationFeature />} />
+      <Route path=':client_id' element={<PageApplicationDetailFeature />} />
     </Routes>
   )
 }

--- a/front/src/pages/console-applications/ui/application-detail-shell.tsx
+++ b/front/src/pages/console-applications/ui/application-detail-shell.tsx
@@ -1,0 +1,116 @@
+import { Schemas } from '@/api/api.client'
+import { ArrowLeft, ShieldOff } from 'lucide-react'
+import { APPLICATION_TONE, getApplicationTypeMeta, inferApplicationType } from '../types'
+
+import Client = Schemas.Client
+
+export type AppTab =
+  | 'quickstart'
+  | 'settings'
+  | 'credentials'
+  | 'api-access'
+  | 'roles'
+  | 'connections'
+  | 'login-experience'
+  | 'addons'
+  | 'maintenance'
+
+export interface TabDef {
+  id: AppTab
+  label: string
+  /** Disabled tabs render a "Soon" badge and can't be selected. */
+  soon?: boolean
+}
+
+interface Props {
+  client: Client
+  tabs: TabDef[]
+  activeTab: AppTab
+  onSelectTab: (tab: AppTab) => void
+  onBack: () => void
+  children: React.ReactNode
+}
+
+export default function ApplicationDetailShell({
+  client,
+  tabs,
+  activeTab,
+  onSelectTab,
+  onBack,
+  children,
+}: Props) {
+  const meta = getApplicationTypeMeta(inferApplicationType(client))
+  const tone = APPLICATION_TONE[meta.tone]
+
+  return (
+    <div className='flex flex-col'>
+      {/* Header */}
+      <div className='px-8 md:px-12 pt-8 md:pt-12'>
+        <button
+          type='button'
+          onClick={onBack}
+          className='inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mb-4'
+        >
+          <ArrowLeft className='h-3.5 w-3.5' />
+          Back to applications
+        </button>
+        <div className='flex items-start gap-4'>
+          <div className={`h-12 w-12 rounded-md flex items-center justify-center shrink-0 ${tone.bg}`}>
+            <meta.icon className={`h-5 w-5 ${tone.fg}`} />
+          </div>
+          <div className='flex-1 min-w-0'>
+            <div className='flex items-center gap-2'>
+              <h1 className='text-2xl font-medium tracking-tight truncate'>
+                {client.name || client.client_id}
+              </h1>
+              <span className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${tone.bg} ${tone.fg}`}>
+                {meta.short}
+              </span>
+              {!client.enabled && (
+                <span className='inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium bg-muted text-muted-foreground border border-border uppercase tracking-wide'>
+                  <ShieldOff className='h-2.5 w-2.5' />
+                  Off
+                </span>
+              )}
+            </div>
+            <p className='text-xs text-muted-foreground font-mono mt-1'>{client.client_id}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Tab nav */}
+      <div className='mt-6 px-8 md:px-12 border-b border-border'>
+        <nav className='flex items-center gap-1 overflow-x-auto'>
+          {tabs.map((tab) => {
+            const active = tab.id === activeTab
+            return (
+              <button
+                key={tab.id}
+                type='button'
+                disabled={tab.soon}
+                onClick={() => !tab.soon && onSelectTab(tab.id)}
+                className={`relative inline-flex items-center gap-1.5 whitespace-nowrap px-3 py-2.5 text-sm font-medium transition-colors -mb-px border-b-2 ${
+                  active
+                    ? 'border-primary text-foreground'
+                    : tab.soon
+                      ? 'border-transparent text-muted-foreground/50 cursor-not-allowed'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {tab.label}
+                {tab.soon && (
+                  <span className='rounded-md bg-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground'>
+                    Soon
+                  </span>
+                )}
+              </button>
+            )
+          })}
+        </nav>
+      </div>
+
+      {/* Tab body */}
+      <div className='p-8 md:p-12 max-w-3xl'>{children}</div>
+    </div>
+  )
+}

--- a/front/src/pages/console-applications/ui/application-detail-shell.tsx
+++ b/front/src/pages/console-applications/ui/application-detail-shell.tsx
@@ -9,7 +9,6 @@ export type AppTab =
   | 'settings'
   | 'credentials'
   | 'api-access'
-  | 'roles'
   | 'connections'
   | 'login-experience'
   | 'addons'

--- a/front/src/pages/console-applications/ui/page-application-detail.tsx
+++ b/front/src/pages/console-applications/ui/page-application-detail.tsx
@@ -1,0 +1,491 @@
+import { Schemas } from '@/api/api.client'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Switch } from '@/components/ui/switch'
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  Eye,
+  EyeOff,
+  Loader2,
+  Plus,
+  ShieldOff,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { APPLICATION_TONE, getApplicationTypeMeta, inferApplicationType } from '../types'
+
+import Client = Schemas.Client
+
+export interface ApplicationSettingsValues {
+  name: string
+  enabled: boolean
+  directAccessGrantsEnabled: boolean
+  oauthDeviceCodeGrantEnabled: boolean
+  accessTokenLifetime: number | null
+  refreshTokenLifetime: number | null
+  idTokenLifetime: number | null
+  temporaryTokenLifetime: number | null
+}
+
+interface Props {
+  client: Client
+  isSaving: boolean
+  uriPending: boolean
+  onBack: () => void
+  onSave: (values: ApplicationSettingsValues) => Promise<void>
+  onDelete: () => void
+  onAddRedirectUri: (value: string) => void
+  onDeleteRedirectUri: (redirectUriId: string) => void
+}
+
+const isValidUrl = (s: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/.+/.test(s.trim())
+
+function settingsFromClient(c: Client): ApplicationSettingsValues {
+  return {
+    name: c.name ?? '',
+    enabled: c.enabled,
+    directAccessGrantsEnabled: c.direct_access_grants_enabled,
+    oauthDeviceCodeGrantEnabled: c.oauth_device_code_grant_enabled,
+    accessTokenLifetime: c.access_token_lifetime ?? null,
+    refreshTokenLifetime: c.refresh_token_lifetime ?? null,
+    idTokenLifetime: c.id_token_lifetime ?? null,
+    temporaryTokenLifetime: c.temporary_token_lifetime ?? null,
+  }
+}
+
+export default function PageApplicationDetail({
+  client,
+  isSaving,
+  uriPending,
+  onBack,
+  onSave,
+  onDelete,
+  onAddRedirectUri,
+  onDeleteRedirectUri,
+}: Props) {
+  // The parent remounts this component (key={client.id}) when navigating to a
+  // different application, so lazy-initialising from the client is sufficient.
+  const [values, setValues] = useState<ApplicationSettingsValues>(() => settingsFromClient(client))
+  const [newUri, setNewUri] = useState('')
+
+  const baseline = useMemo(() => settingsFromClient(client), [client])
+  const hasChanges = useMemo(
+    () => JSON.stringify(values) !== JSON.stringify(baseline),
+    [values, baseline],
+  )
+
+  const appType = inferApplicationType(client)
+  const meta = getApplicationTypeMeta(appType)
+  const tone = APPLICATION_TONE[meta.tone]
+  const isConfidential = client.client_type === 'confidential'
+  // Browserless (device) and machine-to-machine clients don't use redirect URIs.
+  const showRedirectUris = appType !== 'm2m' && appType !== 'device'
+
+  const set = <K extends keyof ApplicationSettingsValues>(key: K, value: ApplicationSettingsValues[K]) =>
+    setValues((prev) => ({ ...prev, [key]: value }))
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!hasChanges || isSaving) return
+    void onSave(values)
+  }
+
+  const handleAddUri = () => {
+    const v = newUri.trim()
+    if (!v || !isValidUrl(v)) return
+    onAddRedirectUri(v)
+    setNewUri('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className='flex flex-col gap-6 p-8 md:p-12 max-w-3xl'>
+      {/* Header */}
+      <div>
+        <button
+          type='button'
+          onClick={onBack}
+          className='inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mb-4'
+        >
+          <ArrowLeft className='h-3.5 w-3.5' />
+          Back to applications
+        </button>
+        <div className='flex items-start gap-4'>
+          <div className={`h-12 w-12 rounded-md flex items-center justify-center shrink-0 ${tone.bg}`}>
+            <meta.icon className={`h-5 w-5 ${tone.fg}`} />
+          </div>
+          <div className='flex-1 min-w-0'>
+            <div className='flex items-center gap-2'>
+              <h1 className='text-2xl font-medium tracking-tight truncate'>{client.name || client.client_id}</h1>
+              <span className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${tone.bg} ${tone.fg}`}>
+                {meta.short}
+              </span>
+              {!values.enabled && (
+                <span className='inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium bg-muted text-muted-foreground border border-border uppercase tracking-wide'>
+                  <ShieldOff className='h-2.5 w-2.5' />
+                  Off
+                </span>
+              )}
+            </div>
+            <p className='text-sm text-muted-foreground mt-1'>
+              {meta.description} Auth flow: <span className='font-medium text-foreground'>{meta.flow}</span>.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* General */}
+      <Section title='General' description='Name and availability of this application.'>
+        <Field label='Application name' hint='How users see this application during sign-in.'>
+          <input
+            type='text'
+            value={values.name}
+            onChange={(e) => set('name', e.target.value)}
+            className='w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
+          />
+        </Field>
+        <ToggleRow
+          label='Enabled'
+          description='Disabled applications cannot start a sign-in flow.'
+          checked={values.enabled}
+          onChange={(v) => set('enabled', v)}
+        />
+      </Section>
+
+      {/* Credentials */}
+      <Section title='Credentials' description='Identifiers used in OAuth / OIDC requests.'>
+        <CopyField label='Client ID' value={client.client_id} mono />
+        {isConfidential && (
+          client.secret ? (
+            <SecretField label='Client secret' value={client.secret} />
+          ) : (
+            <p className='text-xs text-muted-foreground'>
+              The client secret is hidden. Rotate or reveal it from the admin console.
+            </p>
+          )
+        )}
+      </Section>
+
+      {/* Redirect URIs */}
+      {showRedirectUris && (
+        <Section
+          title='Redirect URIs'
+          description='Allowed callback URLs FerrisKey may redirect to after sign-in.'
+        >
+          <div className='flex flex-col gap-2'>
+            {(client.redirect_uris ?? []).length === 0 && (
+              <p className='text-xs text-muted-foreground'>No redirect URIs registered yet.</p>
+            )}
+            {(client.redirect_uris ?? []).map((uri) => (
+              <div
+                key={uri.id}
+                className='flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2'
+              >
+                <span className='flex-1 text-sm font-mono truncate'>{uri.value}</span>
+                <button
+                  type='button'
+                  onClick={() => onDeleteRedirectUri(uri.id)}
+                  disabled={uriPending}
+                  className='inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-muted transition-colors disabled:opacity-40'
+                  aria-label='Remove redirect URI'
+                >
+                  <X className='h-3.5 w-3.5' />
+                </button>
+              </div>
+            ))}
+            <div className='flex items-center gap-2'>
+              <input
+                type='text'
+                value={newUri}
+                onChange={(e) => setNewUri(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleAddUri()
+                  }
+                }}
+                placeholder='https://app.acme.com/callback'
+                className='flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm font-mono outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
+              />
+              <button
+                type='button'
+                onClick={handleAddUri}
+                disabled={uriPending || !newUri.trim() || !isValidUrl(newUri)}
+                className='inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed'
+              >
+                {uriPending ? <Loader2 className='h-3.5 w-3.5 animate-spin' /> : <Plus className='h-3.5 w-3.5' />}
+                Add
+              </button>
+            </div>
+          </div>
+        </Section>
+      )}
+
+      {/* OAuth grants */}
+      <Section title='Grants' description='OAuth grant types this application is allowed to use.'>
+        <ToggleRow
+          label='Direct access grants'
+          description='Allow exchanging a username/password directly for tokens (Resource Owner Password Credentials).'
+          checked={values.directAccessGrantsEnabled}
+          onChange={(v) => set('directAccessGrantsEnabled', v)}
+        />
+        <ToggleRow
+          label='Device authorization grant'
+          description='Allow browserless clients (CLI, IoT) to obtain tokens via a verification code (RFC 8628).'
+          checked={values.oauthDeviceCodeGrantEnabled}
+          onChange={(v) => set('oauthDeviceCodeGrantEnabled', v)}
+        />
+      </Section>
+
+      {/* Token lifetimes */}
+      <Section
+        title='Token lifetimes'
+        description='Override realm defaults for this application. Leave empty to inherit the realm setting.'
+      >
+        <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
+          <DurationField
+            label='Access token'
+            value={values.accessTokenLifetime}
+            onChange={(v) => set('accessTokenLifetime', v)}
+          />
+          <DurationField
+            label='Refresh token'
+            value={values.refreshTokenLifetime}
+            onChange={(v) => set('refreshTokenLifetime', v)}
+          />
+          <DurationField
+            label='ID token'
+            value={values.idTokenLifetime}
+            onChange={(v) => set('idTokenLifetime', v)}
+          />
+          <DurationField
+            label='Temporary token'
+            value={values.temporaryTokenLifetime}
+            onChange={(v) => set('temporaryTokenLifetime', v)}
+          />
+        </div>
+      </Section>
+
+      {/* Danger zone */}
+      <Section title='Danger zone' description='Irreversible actions.' tone='danger'>
+        <div className='flex items-center justify-between gap-4'>
+          <div>
+            <p className='text-sm font-medium'>Delete this application</p>
+            <p className='text-xs text-muted-foreground mt-0.5'>
+              Removes the client and revokes its ability to authenticate. This cannot be undone.
+            </p>
+          </div>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <button
+                type='button'
+                className='inline-flex items-center gap-1.5 rounded-md border border-red-500/40 bg-background px-3 py-2 text-sm font-medium text-red-500 hover:bg-red-500/10 transition-colors shrink-0'
+              >
+                <Trash2 className='h-3.5 w-3.5' />
+                Delete
+              </button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete {client.name || client.client_id}?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This permanently deletes the application and all of its configuration. Any
+                  integration using this client will stop working immediately.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={onDelete}
+                  className='bg-red-500 text-white hover:bg-red-500/90'
+                >
+                  Delete application
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </Section>
+
+      {/* Save bar */}
+      <div className='sticky bottom-0 -mx-8 md:-mx-12 px-8 md:px-12 py-4 border-t border-border bg-background/80 backdrop-blur flex items-center justify-end gap-3'>
+        {hasChanges && (
+          <button
+            type='button'
+            onClick={() => setValues(baseline)}
+            className='rounded-md border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-muted transition-colors'
+          >
+            Discard
+          </button>
+        )}
+        <button
+          type='submit'
+          disabled={!hasChanges || isSaving}
+          className='inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+        >
+          {isSaving && <Loader2 className='h-3.5 w-3.5 animate-spin' />}
+          {isSaving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+interface SectionProps {
+  title: string
+  description?: string
+  tone?: 'default' | 'danger'
+  children: React.ReactNode
+}
+
+function Section({ title, description, tone = 'default', children }: SectionProps) {
+  return (
+    <section
+      className={`rounded-md border bg-card/40 p-5 flex flex-col gap-4 ${
+        tone === 'danger' ? 'border-red-500/30' : 'border-border'
+      }`}
+    >
+      <div>
+        <h2 className='text-sm font-semibold'>{title}</h2>
+        {description && <p className='text-xs text-muted-foreground mt-0.5'>{description}</p>}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+interface FieldProps {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}
+
+function Field({ label, hint, children }: FieldProps) {
+  return (
+    <label className='flex flex-col gap-1.5'>
+      <span className='text-sm font-medium'>{label}</span>
+      {children}
+      {hint && <p className='text-xs text-muted-foreground'>{hint}</p>}
+    </label>
+  )
+}
+
+interface ToggleRowProps {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}
+
+function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
+  return (
+    <div className='flex items-center justify-between gap-5 rounded-md border border-border p-3'>
+      <div className='space-y-0.5'>
+        <p className='text-sm font-medium'>{label}</p>
+        <p className='text-xs text-muted-foreground'>{description}</p>
+      </div>
+      <Switch checked={checked} onCheckedChange={onChange} />
+    </div>
+  )
+}
+
+function CopyField({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    void navigator.clipboard.writeText(value)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <Field label={label}>
+      <div className='flex items-center gap-2'>
+        <input
+          readOnly
+          value={value}
+          className={`flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm outline-none ${mono ? 'font-mono' : ''}`}
+        />
+        <button
+          type='button'
+          onClick={copy}
+          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+          aria-label={`Copy ${label}`}
+        >
+          {copied ? <Check className='h-3.5 w-3.5 text-emerald-500' /> : <Copy className='h-3.5 w-3.5' />}
+        </button>
+      </div>
+    </Field>
+  )
+}
+
+function SecretField({ label, value }: { label: string; value: string }) {
+  const [revealed, setRevealed] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    void navigator.clipboard.writeText(value)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <Field label={label} hint='Keep this secret safe — it grants full access on behalf of the application.'>
+      <div className='flex items-center gap-2'>
+        <input
+          readOnly
+          type={revealed ? 'text' : 'password'}
+          value={value}
+          className='flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm font-mono outline-none'
+        />
+        <button
+          type='button'
+          onClick={() => setRevealed((r) => !r)}
+          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+          aria-label={revealed ? 'Hide secret' : 'Reveal secret'}
+        >
+          {revealed ? <EyeOff className='h-3.5 w-3.5' /> : <Eye className='h-3.5 w-3.5' />}
+        </button>
+        <button
+          type='button'
+          onClick={copy}
+          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+          aria-label='Copy secret'
+        >
+          {copied ? <Check className='h-3.5 w-3.5 text-emerald-500' /> : <Copy className='h-3.5 w-3.5' />}
+        </button>
+      </div>
+    </Field>
+  )
+}
+
+interface DurationFieldProps {
+  label: string
+  value: number | null
+  onChange: (value: number | null) => void
+}
+
+function DurationField({ label, value, onChange }: DurationFieldProps) {
+  return (
+    <Field label={label} hint='Seconds. Empty = realm default.'>
+      <input
+        type='number'
+        min={0}
+        value={value ?? ''}
+        onChange={(e) => {
+          const raw = e.target.value
+          onChange(raw === '' ? null : Number(raw))
+        }}
+        placeholder='Inherit'
+        className='w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
+      />
+    </Field>
+  )
+}

--- a/front/src/pages/console-applications/ui/tabs/api-access-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/api-access-tab.tsx
@@ -8,8 +8,9 @@ import { Section } from './primitives'
 
 type ScopeKind = 'default' | 'optional'
 
-const scopeKind = (s: Schemas.ClientScope): ScopeKind =>
-  s.default_scope_type === 'DEFAULT' ? 'default' : 'optional'
+function scopeKind(s: Schemas.ClientScope): ScopeKind {
+  return s.default_scope_type === 'DEFAULT' ? 'default' : 'optional'
+}
 
 interface Props {
   realm: string
@@ -48,7 +49,7 @@ export default function ApiAccessTab({ realm, clientId }: Props) {
     [available],
   )
 
-  const handleAdd = async () => {
+  async function handleAdd() {
     if (picked.length === 0) return
     setAdding(true)
     try {
@@ -63,7 +64,7 @@ export default function ApiAccessTab({ realm, clientId }: Props) {
     }
   }
 
-  const handleChangeKind = async (scopeId: string, from: ScopeKind) => {
+  async function handleChangeKind(scopeId: string, from: ScopeKind) {
     const to: ScopeKind = from === 'default' ? 'optional' : 'default'
     setPendingId(scopeId)
     try {
@@ -74,7 +75,7 @@ export default function ApiAccessTab({ realm, clientId }: Props) {
     }
   }
 
-  const handleRemove = async (scopeId: string, kind: ScopeKind) => {
+  async function handleRemove(scopeId: string, kind: ScopeKind) {
     setPendingId(scopeId)
     try {
       await unassignScope.mutateAsync({ realm, clientId, scopeId, type: kind })

--- a/front/src/pages/console-applications/ui/tabs/api-access-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/api-access-tab.tsx
@@ -1,0 +1,262 @@
+import { Schemas } from '@/api/api.client'
+import { useGetClientScopes, useAssignScope, useUnassignScope } from '@/api/client.api'
+import { useGetClientScopes as useGetRealmScopes } from '@/api/client-scope.api'
+import MultipleSelector, { type Option } from '@/components/ui/multiselect'
+import { KeyRound, Loader2, Plus, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Section } from './primitives'
+
+type ScopeKind = 'default' | 'optional'
+
+const scopeKind = (s: Schemas.ClientScope): ScopeKind =>
+  s.default_scope_type === 'DEFAULT' ? 'default' : 'optional'
+
+interface Props {
+  realm: string
+  clientId: string
+}
+
+export default function ApiAccessTab({ realm, clientId }: Props) {
+  const { data: assignedRaw, isLoading } = useGetClientScopes({ realm, clientId })
+  const { data: realmScopes } = useGetRealmScopes({ realm })
+  const assignScope = useAssignScope()
+  const unassignScope = useUnassignScope()
+
+  // The assigned-scopes endpoint may return a bare array or a {data} envelope.
+  const assigned: Schemas.ClientScope[] = useMemo(() => {
+    if (Array.isArray(assignedRaw)) return assignedRaw
+    const maybe = assignedRaw as { data?: Schemas.ClientScope[] } | undefined
+    return maybe?.data ?? []
+  }, [assignedRaw])
+
+  const assignedIds = useMemo(() => new Set(assigned.map((s) => s.id)), [assigned])
+  const available = useMemo(
+    () => (realmScopes?.data ?? []).filter((s) => !assignedIds.has(s.id)),
+    [realmScopes, assignedIds],
+  )
+
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [picked, setPicked] = useState<Option[]>([])
+  const [pickKind, setPickKind] = useState<ScopeKind>('default')
+  const [adding, setAdding] = useState(false)
+
+  const defaults = assigned.filter((s) => scopeKind(s) === 'default')
+  const optionals = assigned.filter((s) => scopeKind(s) === 'optional')
+
+  const options: Option[] = useMemo(
+    () => available.map((s) => ({ value: s.id, label: s.name })),
+    [available],
+  )
+
+  const handleAdd = async () => {
+    if (picked.length === 0) return
+    setAdding(true)
+    try {
+      // Assign sequentially so a mid-list failure surfaces a toast but the
+      // earlier scopes still land.
+      for (const opt of picked) {
+        await assignScope.mutateAsync({ realm, clientId, scopeId: opt.value, type: pickKind })
+      }
+      setPicked([])
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const handleChangeKind = async (scopeId: string, from: ScopeKind) => {
+    const to: ScopeKind = from === 'default' ? 'optional' : 'default'
+    setPendingId(scopeId)
+    try {
+      await unassignScope.mutateAsync({ realm, clientId, scopeId, type: from })
+      await assignScope.mutateAsync({ realm, clientId, scopeId, type: to })
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  const handleRemove = async (scopeId: string, kind: ScopeKind) => {
+    setPendingId(scopeId)
+    try {
+      await unassignScope.mutateAsync({ realm, clientId, scopeId, type: kind })
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <Section
+        title='Client scopes'
+        description='Scopes decide which claims and permissions land in the tokens issued to this application. Default scopes are always granted; optional scopes must be requested via the scope parameter.'
+      >
+        {/* Add composer — pick one or many scopes, assign them all as the chosen kind */}
+        <div className='flex items-start gap-2'>
+          <MultipleSelector
+            className='flex-1'
+            value={picked}
+            onChange={setPicked}
+            options={options}
+            disabled={available.length === 0 || adding}
+            hidePlaceholderWhenSelected
+            placeholder={
+              available.length === 0 ? 'No more scopes available' : 'Select scopes to add…'
+            }
+            emptyIndicator={
+              <p className='text-center text-xs text-muted-foreground py-2'>No matching scopes.</p>
+            }
+          />
+          <Segmented value={pickKind} onChange={setPickKind} />
+          <button
+            type='button'
+            onClick={handleAdd}
+            disabled={picked.length === 0 || adding}
+            className='inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0'
+          >
+            {adding ? <Loader2 className='h-3.5 w-3.5 animate-spin' /> : <Plus className='h-3.5 w-3.5' />}
+            Add{picked.length > 0 ? ` (${picked.length})` : ''}
+          </button>
+        </div>
+
+        {/* Lists */}
+        {isLoading ? (
+          <p className='text-xs text-muted-foreground'>Loading scopes…</p>
+        ) : assigned.length === 0 ? (
+          <div className='rounded-md border border-dashed border-border bg-muted/20 p-6 text-center'>
+            <KeyRound className='mx-auto h-5 w-5 text-muted-foreground' />
+            <p className='text-sm font-medium mt-2'>No scopes assigned</p>
+            <p className='text-xs text-muted-foreground mt-0.5'>
+              Add a scope above to control what this application can request.
+            </p>
+          </div>
+        ) : (
+          <div className='flex flex-col gap-5'>
+            <ScopeGroup
+              label='Default'
+              hint='Always granted'
+              scopes={defaults}
+              pendingId={pendingId}
+              onChangeKind={handleChangeKind}
+              onRemove={handleRemove}
+            />
+            <ScopeGroup
+              label='Optional'
+              hint='Granted only when requested'
+              scopes={optionals}
+              pendingId={pendingId}
+              onChangeKind={handleChangeKind}
+              onRemove={handleRemove}
+            />
+          </div>
+        )}
+      </Section>
+
+      {/* Token preview */}
+      <Section
+        title='Token preview'
+        description='Scopes included in a token issued without an explicit scope request.'
+      >
+        {defaults.length === 0 ? (
+          <p className='text-xs text-muted-foreground'>
+            No default scopes — tokens carry only the base claims.
+          </p>
+        ) : (
+          <div className='flex flex-wrap gap-1.5'>
+            {defaults.map((s) => (
+              <span
+                key={s.id}
+                className='inline-flex items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-mono text-primary'
+              >
+                {s.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </Section>
+    </div>
+  )
+}
+
+interface ScopeGroupProps {
+  label: string
+  hint: string
+  scopes: Schemas.ClientScope[]
+  pendingId: string | null
+  onChangeKind: (scopeId: string, from: ScopeKind) => void
+  onRemove: (scopeId: string, kind: ScopeKind) => void
+}
+
+function ScopeGroup({ label, hint, scopes, pendingId, onChangeKind, onRemove }: ScopeGroupProps) {
+  if (scopes.length === 0) return null
+  return (
+    <div className='flex flex-col gap-2'>
+      <div className='flex items-center gap-2'>
+        <h3 className='text-xs font-semibold uppercase tracking-wide text-muted-foreground'>{label}</h3>
+        <span className='text-[10px] text-muted-foreground/70'>· {hint}</span>
+      </div>
+      <div className='flex flex-col divide-y divide-border rounded-md border border-border'>
+        {scopes.map((scope) => {
+          const kind = scopeKind(scope)
+          const busy = pendingId === scope.id
+          return (
+            <div key={scope.id} className='flex items-center gap-3 px-3 py-2.5'>
+              <div className='flex-1 min-w-0'>
+                <div className='flex items-center gap-2'>
+                  <span className='text-sm font-medium truncate'>{scope.name}</span>
+                  <span className='rounded bg-muted px-1 py-0.5 text-[10px] font-mono text-muted-foreground'>
+                    {scope.protocol}
+                  </span>
+                </div>
+                <p className='text-xs text-muted-foreground truncate'>
+                  {scope.description || 'No description'}
+                </p>
+              </div>
+              {busy ? (
+                <Loader2 className='h-4 w-4 animate-spin text-muted-foreground' />
+              ) : (
+                <>
+                  <Segmented
+                    value={kind}
+                    onChange={(next) => next !== kind && onChangeKind(scope.id, kind)}
+                  />
+                  <button
+                    type='button'
+                    onClick={() => onRemove(scope.id, kind)}
+                    className='inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-muted transition-colors shrink-0'
+                    aria-label={`Remove ${scope.name}`}
+                  >
+                    <X className='h-3.5 w-3.5' />
+                  </button>
+                </>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function Segmented({ value, onChange }: { value: ScopeKind; onChange: (v: ScopeKind) => void }) {
+  const opts: { key: ScopeKind; label: string }[] = [
+    { key: 'default', label: 'Default' },
+    { key: 'optional', label: 'Optional' },
+  ]
+  return (
+    <div className='inline-flex rounded-md border border-border bg-muted/40 p-0.5'>
+      {opts.map((o) => (
+        <button
+          key={o.key}
+          type='button'
+          onClick={() => onChange(o.key)}
+          className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+            value === o.key
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/front/src/pages/console-applications/ui/tabs/coming-soon-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/coming-soon-tab.tsx
@@ -1,0 +1,38 @@
+import { Construction, type LucideIcon } from 'lucide-react'
+
+interface Props {
+  icon?: LucideIcon
+  title: string
+  description: string
+  /** Bullet points describing what the tab will offer once shipped. */
+  points?: string[]
+}
+
+export default function ComingSoonTab({ icon: Icon = Construction, title, description, points }: Props) {
+  return (
+    <div className='rounded-md border border-dashed border-border bg-muted/20 p-10 flex flex-col items-center text-center gap-4 max-w-xl'>
+      <div className='h-12 w-12 rounded-md bg-muted flex items-center justify-center'>
+        <Icon className='h-6 w-6 text-muted-foreground' />
+      </div>
+      <div>
+        <div className='flex items-center justify-center gap-2'>
+          <h2 className='text-base font-semibold'>{title}</h2>
+          <span className='rounded-md bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary'>
+            Coming soon
+          </span>
+        </div>
+        <p className='text-sm text-muted-foreground mt-1'>{description}</p>
+      </div>
+      {points && points.length > 0 && (
+        <ul className='text-left text-sm text-muted-foreground space-y-1.5'>
+          {points.map((p) => (
+            <li key={p} className='flex items-start gap-2'>
+              <span className='mt-1.5 h-1 w-1 rounded-full bg-muted-foreground/50 shrink-0' />
+              {p}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/front/src/pages/console-applications/ui/tabs/credentials-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/credentials-tab.tsx
@@ -1,0 +1,98 @@
+import { Schemas } from '@/api/api.client'
+import { Check, Copy, Eye, EyeOff, RefreshCw } from 'lucide-react'
+import { useState } from 'react'
+import { CopyRow, Field, Section } from './primitives'
+
+import Client = Schemas.Client
+
+export default function CredentialsTab({ client }: { client: Client }) {
+  const isConfidential = client.client_type === 'confidential'
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <Section title='Client ID' description='Public identifier used in OAuth / OIDC requests.'>
+        <CopyRow value={client.client_id} />
+      </Section>
+
+      {isConfidential ? (
+        <Section
+          title='Client secret'
+          description='Confidential credential used to authenticate this application to FerrisKey.'
+        >
+          {client.secret ? (
+            <SecretField value={client.secret} />
+          ) : (
+            <p className='text-xs text-muted-foreground'>
+              The client secret is hidden for this view.
+            </p>
+          )}
+          <div className='flex items-center justify-between gap-4 rounded-md border border-dashed border-border p-3'>
+            <div>
+              <p className='text-sm font-medium'>Rotate secret</p>
+              <p className='text-xs text-muted-foreground mt-0.5'>
+                Generate a new secret and invalidate the current one.
+              </p>
+            </div>
+            <button
+              type='button'
+              disabled
+              title='Coming soon'
+              className='inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-muted-foreground/60 cursor-not-allowed'
+            >
+              <RefreshCw className='h-3.5 w-3.5' />
+              Rotate
+              <span className='rounded-md bg-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide'>
+                Soon
+              </span>
+            </button>
+          </div>
+        </Section>
+      ) : (
+        <Section title='Client secret' description='Public clients do not use a secret.'>
+          <p className='text-xs text-muted-foreground'>
+            This is a public client (SPA, native or device app). It authenticates using
+            Authorization Code + PKCE rather than a client secret.
+          </p>
+        </Section>
+      )}
+    </div>
+  )
+}
+
+function SecretField({ value }: { value: string }) {
+  const [revealed, setRevealed] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    void navigator.clipboard.writeText(value)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <Field label='Secret' hint='Keep this safe — it grants full access on behalf of the application.'>
+      <div className='flex items-center gap-2'>
+        <input
+          readOnly
+          type={revealed ? 'text' : 'password'}
+          value={value}
+          className='flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm font-mono outline-none'
+        />
+        <button
+          type='button'
+          onClick={() => setRevealed((r) => !r)}
+          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+          aria-label={revealed ? 'Hide secret' : 'Reveal secret'}
+        >
+          {revealed ? <EyeOff className='h-3.5 w-3.5' /> : <Eye className='h-3.5 w-3.5' />}
+        </button>
+        <button
+          type='button'
+          onClick={copy}
+          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+          aria-label='Copy secret'
+        >
+          {copied ? <Check className='h-3.5 w-3.5 text-emerald-500' /> : <Copy className='h-3.5 w-3.5' />}
+        </button>
+      </div>
+    </Field>
+  )
+}

--- a/front/src/pages/console-applications/ui/tabs/primitives.tsx
+++ b/front/src/pages/console-applications/ui/tabs/primitives.tsx
@@ -1,0 +1,68 @@
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+
+interface SectionProps {
+  title: string
+  description?: string
+  tone?: 'default' | 'danger'
+  children: React.ReactNode
+}
+
+export function Section({ title, description, tone = 'default', children }: SectionProps) {
+  return (
+    <section
+      className={`rounded-md border bg-card/40 p-5 flex flex-col gap-4 ${
+        tone === 'danger' ? 'border-red-500/30' : 'border-border'
+      }`}
+    >
+      <div>
+        <h2 className='text-sm font-semibold'>{title}</h2>
+        {description && <p className='text-xs text-muted-foreground mt-0.5'>{description}</p>}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+interface FieldProps {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}
+
+export function Field({ label, hint, children }: FieldProps) {
+  return (
+    <label className='flex flex-col gap-1.5'>
+      <span className='text-sm font-medium'>{label}</span>
+      {children}
+      {hint && <p className='text-xs text-muted-foreground'>{hint}</p>}
+    </label>
+  )
+}
+
+/** Read-only value with a copy-to-clipboard affordance. */
+export function CopyRow({ value, mono = true }: { value: string; mono?: boolean }) {
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    void navigator.clipboard.writeText(value)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <div className='flex items-center gap-2'>
+      <input
+        readOnly
+        value={value}
+        className={`flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm outline-none ${mono ? 'font-mono' : ''}`}
+      />
+      <button
+        type='button'
+        onClick={copy}
+        className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0'
+        aria-label='Copy'
+      >
+        {copied ? <Check className='h-3.5 w-3.5 text-emerald-500' /> : <Copy className='h-3.5 w-3.5' />}
+      </button>
+    </div>
+  )
+}

--- a/front/src/pages/console-applications/ui/tabs/quickstart-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/quickstart-tab.tsx
@@ -1,0 +1,120 @@
+import { Schemas } from '@/api/api.client'
+import { Check, Copy } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { inferApplicationType } from '../../types'
+import { CopyRow, Section } from './primitives'
+
+import Client = Schemas.Client
+
+interface Props {
+  client: Client
+  realm: string
+}
+
+function buildEndpoints(realm: string) {
+  // window.apiUrl is the resolved API origin (set during app bootstrap).
+  const base = (window.apiUrl ?? '').replace(/\/$/, '')
+  const issuer = `${base}/realms/${realm}`
+  return {
+    issuer,
+    discovery: `${issuer}/.well-known/openid-configuration`,
+    authorization: `${issuer}/protocol/openid-connect/auth`,
+    token: `${issuer}/protocol/openid-connect/token`,
+    userinfo: `${issuer}/protocol/openid-connect/userinfo`,
+    jwks: `${issuer}/protocol/openid-connect/certs`,
+    logout: `${issuer}/protocol/openid-connect/logout`,
+  }
+}
+
+export default function QuickstartTab({ client, realm }: Props) {
+  const endpoints = useMemo(() => buildEndpoints(realm), [realm])
+  const appType = inferApplicationType(client)
+  const isM2M = appType === 'm2m'
+
+  const firstRedirect = client.redirect_uris?.[0]?.value ?? 'https://your-app.example.com/callback'
+
+  const snippet = isM2M
+    ? `curl -s -X POST '${endpoints.token}' \\
+  -H 'Content-Type: application/x-www-form-urlencoded' \\
+  -d 'grant_type=client_credentials' \\
+  -d 'client_id=${client.client_id}' \\
+  -d 'client_secret=<YOUR_CLIENT_SECRET>'`
+    : `# 1. Send the user to the authorization endpoint
+${endpoints.authorization}?response_type=code
+  &client_id=${client.client_id}
+  &redirect_uri=${encodeURIComponent(firstRedirect)}
+  &scope=openid%20profile%20email
+
+# 2. Exchange the returned code for tokens
+curl -s -X POST '${endpoints.token}' \\
+  -H 'Content-Type: application/x-www-form-urlencoded' \\
+  -d 'grant_type=authorization_code' \\
+  -d 'client_id=${client.client_id}' \\
+  -d 'redirect_uri=${firstRedirect}' \\
+  -d 'code=<AUTHORIZATION_CODE>'`
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <Section
+        title='OpenID Connect endpoints'
+        description={`Point your ${isM2M ? 'service' : 'app'}'s OIDC/OAuth library at these URLs.`}
+      >
+        <EndpointRow label='Issuer' value={endpoints.issuer} />
+        <EndpointRow label='Discovery document' value={endpoints.discovery} />
+        <EndpointRow label='Authorization' value={endpoints.authorization} />
+        <EndpointRow label='Token' value={endpoints.token} />
+        <EndpointRow label='User info' value={endpoints.userinfo} />
+        <EndpointRow label='JWKS' value={endpoints.jwks} />
+        <EndpointRow label='Logout' value={endpoints.logout} />
+      </Section>
+
+      <Section title='Client ID'>
+        <CopyRow value={client.client_id} />
+      </Section>
+
+      <Section
+        title={isM2M ? 'Get a token (client credentials)' : 'Authorization Code flow'}
+        description={
+          isM2M
+            ? 'Exchange your client credentials directly for an access token.'
+            : 'Redirect the user to authorize, then swap the code for tokens on your server.'
+        }
+      >
+        <CodeBlock code={snippet} />
+      </Section>
+    </div>
+  )
+}
+
+function EndpointRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <span className='text-xs font-medium text-muted-foreground'>{label}</span>
+      <CopyRow value={value} />
+    </div>
+  )
+}
+
+function CodeBlock({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    void navigator.clipboard.writeText(code)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <div className='relative'>
+      <pre className='overflow-x-auto rounded-md border border-border bg-muted/40 p-4 text-xs font-mono leading-relaxed'>
+        {code}
+      </pre>
+      <button
+        type='button'
+        onClick={copy}
+        className='absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+        aria-label='Copy snippet'
+      >
+        {copied ? <Check className='h-3.5 w-3.5 text-emerald-500' /> : <Copy className='h-3.5 w-3.5' />}
+      </button>
+    </div>
+  )
+}

--- a/front/src/pages/console-applications/ui/tabs/settings-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/settings-tab.tsx
@@ -11,20 +11,10 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Switch } from '@/components/ui/switch'
-import {
-  ArrowLeft,
-  Check,
-  Copy,
-  Eye,
-  EyeOff,
-  Loader2,
-  Plus,
-  ShieldOff,
-  Trash2,
-  X,
-} from 'lucide-react'
+import { Loader2, Plus, Trash2, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { APPLICATION_TONE, getApplicationTypeMeta, inferApplicationType } from '../types'
+import { inferApplicationType } from '../../types'
+import { Field, Section } from './primitives'
 
 import Client = Schemas.Client
 
@@ -39,19 +29,6 @@ export interface ApplicationSettingsValues {
   temporaryTokenLifetime: number | null
 }
 
-interface Props {
-  client: Client
-  isSaving: boolean
-  uriPending: boolean
-  onBack: () => void
-  onSave: (values: ApplicationSettingsValues) => Promise<void>
-  onDelete: () => void
-  onAddRedirectUri: (value: string) => void
-  onDeleteRedirectUri: (redirectUriId: string) => void
-}
-
-const isValidUrl = (s: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/.+/.test(s.trim())
-
 function settingsFromClient(c: Client): ApplicationSettingsValues {
   return {
     name: c.name ?? '',
@@ -65,18 +42,27 @@ function settingsFromClient(c: Client): ApplicationSettingsValues {
   }
 }
 
-export default function PageApplicationDetail({
+const isValidUrl = (s: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/.+/.test(s.trim())
+
+interface Props {
+  client: Client
+  isSaving: boolean
+  uriPending: boolean
+  onSave: (values: ApplicationSettingsValues) => Promise<void>
+  onDelete: () => void
+  onAddRedirectUri: (value: string) => void
+  onDeleteRedirectUri: (redirectUriId: string) => void
+}
+
+export default function SettingsTab({
   client,
   isSaving,
   uriPending,
-  onBack,
   onSave,
   onDelete,
   onAddRedirectUri,
   onDeleteRedirectUri,
 }: Props) {
-  // The parent remounts this component (key={client.id}) when navigating to a
-  // different application, so lazy-initialising from the client is sufficient.
   const [values, setValues] = useState<ApplicationSettingsValues>(() => settingsFromClient(client))
   const [newUri, setNewUri] = useState('')
 
@@ -87,14 +73,12 @@ export default function PageApplicationDetail({
   )
 
   const appType = inferApplicationType(client)
-  const meta = getApplicationTypeMeta(appType)
-  const tone = APPLICATION_TONE[meta.tone]
-  const isConfidential = client.client_type === 'confidential'
-  // Browserless (device) and machine-to-machine clients don't use redirect URIs.
   const showRedirectUris = appType !== 'm2m' && appType !== 'device'
 
-  const set = <K extends keyof ApplicationSettingsValues>(key: K, value: ApplicationSettingsValues[K]) =>
-    setValues((prev) => ({ ...prev, [key]: value }))
+  const set = <K extends keyof ApplicationSettingsValues>(
+    key: K,
+    value: ApplicationSettingsValues[K],
+  ) => setValues((prev) => ({ ...prev, [key]: value }))
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -110,42 +94,7 @@ export default function PageApplicationDetail({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-6 p-8 md:p-12 max-w-3xl'>
-      {/* Header */}
-      <div>
-        <button
-          type='button'
-          onClick={onBack}
-          className='inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mb-4'
-        >
-          <ArrowLeft className='h-3.5 w-3.5' />
-          Back to applications
-        </button>
-        <div className='flex items-start gap-4'>
-          <div className={`h-12 w-12 rounded-md flex items-center justify-center shrink-0 ${tone.bg}`}>
-            <meta.icon className={`h-5 w-5 ${tone.fg}`} />
-          </div>
-          <div className='flex-1 min-w-0'>
-            <div className='flex items-center gap-2'>
-              <h1 className='text-2xl font-medium tracking-tight truncate'>{client.name || client.client_id}</h1>
-              <span className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${tone.bg} ${tone.fg}`}>
-                {meta.short}
-              </span>
-              {!values.enabled && (
-                <span className='inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium bg-muted text-muted-foreground border border-border uppercase tracking-wide'>
-                  <ShieldOff className='h-2.5 w-2.5' />
-                  Off
-                </span>
-              )}
-            </div>
-            <p className='text-sm text-muted-foreground mt-1'>
-              {meta.description} Auth flow: <span className='font-medium text-foreground'>{meta.flow}</span>.
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* General */}
+    <form onSubmit={handleSubmit} className='flex flex-col gap-6'>
       <Section title='General' description='Name and availability of this application.'>
         <Field label='Application name' hint='How users see this application during sign-in.'>
           <input
@@ -163,21 +112,6 @@ export default function PageApplicationDetail({
         />
       </Section>
 
-      {/* Credentials */}
-      <Section title='Credentials' description='Identifiers used in OAuth / OIDC requests.'>
-        <CopyField label='Client ID' value={client.client_id} mono />
-        {isConfidential && (
-          client.secret ? (
-            <SecretField label='Client secret' value={client.secret} />
-          ) : (
-            <p className='text-xs text-muted-foreground'>
-              The client secret is hidden. Rotate or reveal it from the admin console.
-            </p>
-          )
-        )}
-      </Section>
-
-      {/* Redirect URIs */}
       {showRedirectUris && (
         <Section
           title='Redirect URIs'
@@ -232,7 +166,6 @@ export default function PageApplicationDetail({
         </Section>
       )}
 
-      {/* OAuth grants */}
       <Section title='Grants' description='OAuth grant types this application is allowed to use.'>
         <ToggleRow
           label='Direct access grants'
@@ -248,36 +181,18 @@ export default function PageApplicationDetail({
         />
       </Section>
 
-      {/* Token lifetimes */}
       <Section
         title='Token lifetimes'
         description='Override realm defaults for this application. Leave empty to inherit the realm setting.'
       >
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
-          <DurationField
-            label='Access token'
-            value={values.accessTokenLifetime}
-            onChange={(v) => set('accessTokenLifetime', v)}
-          />
-          <DurationField
-            label='Refresh token'
-            value={values.refreshTokenLifetime}
-            onChange={(v) => set('refreshTokenLifetime', v)}
-          />
-          <DurationField
-            label='ID token'
-            value={values.idTokenLifetime}
-            onChange={(v) => set('idTokenLifetime', v)}
-          />
-          <DurationField
-            label='Temporary token'
-            value={values.temporaryTokenLifetime}
-            onChange={(v) => set('temporaryTokenLifetime', v)}
-          />
+          <DurationField label='Access token' value={values.accessTokenLifetime} onChange={(v) => set('accessTokenLifetime', v)} />
+          <DurationField label='Refresh token' value={values.refreshTokenLifetime} onChange={(v) => set('refreshTokenLifetime', v)} />
+          <DurationField label='ID token' value={values.idTokenLifetime} onChange={(v) => set('idTokenLifetime', v)} />
+          <DurationField label='Temporary token' value={values.temporaryTokenLifetime} onChange={(v) => set('temporaryTokenLifetime', v)} />
         </div>
       </Section>
 
-      {/* Danger zone */}
       <Section title='Danger zone' description='Irreversible actions.' tone='danger'>
         <div className='flex items-center justify-between gap-4'>
           <div>
@@ -306,10 +221,7 @@ export default function PageApplicationDetail({
               </AlertDialogHeader>
               <AlertDialogFooter>
                 <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={onDelete}
-                  className='bg-red-500 text-white hover:bg-red-500/90'
-                >
+                <AlertDialogAction onClick={onDelete} className='bg-red-500 text-white hover:bg-red-500/90'>
                   Delete application
                 </AlertDialogAction>
               </AlertDialogFooter>
@@ -318,7 +230,6 @@ export default function PageApplicationDetail({
         </div>
       </Section>
 
-      {/* Save bar */}
       <div className='sticky bottom-0 -mx-8 md:-mx-12 px-8 md:px-12 py-4 border-t border-border bg-background/80 backdrop-blur flex items-center justify-end gap-3'>
         {hasChanges && (
           <button
@@ -342,45 +253,6 @@ export default function PageApplicationDetail({
   )
 }
 
-interface SectionProps {
-  title: string
-  description?: string
-  tone?: 'default' | 'danger'
-  children: React.ReactNode
-}
-
-function Section({ title, description, tone = 'default', children }: SectionProps) {
-  return (
-    <section
-      className={`rounded-md border bg-card/40 p-5 flex flex-col gap-4 ${
-        tone === 'danger' ? 'border-red-500/30' : 'border-border'
-      }`}
-    >
-      <div>
-        <h2 className='text-sm font-semibold'>{title}</h2>
-        {description && <p className='text-xs text-muted-foreground mt-0.5'>{description}</p>}
-      </div>
-      {children}
-    </section>
-  )
-}
-
-interface FieldProps {
-  label: string
-  hint?: string
-  children: React.ReactNode
-}
-
-function Field({ label, hint, children }: FieldProps) {
-  return (
-    <label className='flex flex-col gap-1.5'>
-      <span className='text-sm font-medium'>{label}</span>
-      {children}
-      {hint && <p className='text-xs text-muted-foreground'>{hint}</p>}
-    </label>
-  )
-}
-
 interface ToggleRowProps {
   label: string
   description: string
@@ -397,72 +269,6 @@ function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
       </div>
       <Switch checked={checked} onCheckedChange={onChange} />
     </div>
-  )
-}
-
-function CopyField({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
-  const [copied, setCopied] = useState(false)
-  const copy = () => {
-    void navigator.clipboard.writeText(value)
-    setCopied(true)
-    window.setTimeout(() => setCopied(false), 1500)
-  }
-  return (
-    <Field label={label}>
-      <div className='flex items-center gap-2'>
-        <input
-          readOnly
-          value={value}
-          className={`flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm outline-none ${mono ? 'font-mono' : ''}`}
-        />
-        <button
-          type='button'
-          onClick={copy}
-          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
-          aria-label={`Copy ${label}`}
-        >
-          {copied ? <Check className='h-3.5 w-3.5 text-emerald-500' /> : <Copy className='h-3.5 w-3.5' />}
-        </button>
-      </div>
-    </Field>
-  )
-}
-
-function SecretField({ label, value }: { label: string; value: string }) {
-  const [revealed, setRevealed] = useState(false)
-  const [copied, setCopied] = useState(false)
-  const copy = () => {
-    void navigator.clipboard.writeText(value)
-    setCopied(true)
-    window.setTimeout(() => setCopied(false), 1500)
-  }
-  return (
-    <Field label={label} hint='Keep this secret safe — it grants full access on behalf of the application.'>
-      <div className='flex items-center gap-2'>
-        <input
-          readOnly
-          type={revealed ? 'text' : 'password'}
-          value={value}
-          className='flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm font-mono outline-none'
-        />
-        <button
-          type='button'
-          onClick={() => setRevealed((r) => !r)}
-          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
-          aria-label={revealed ? 'Hide secret' : 'Reveal secret'}
-        >
-          {revealed ? <EyeOff className='h-3.5 w-3.5' /> : <Eye className='h-3.5 w-3.5' />}
-        </button>
-        <button
-          type='button'
-          onClick={copy}
-          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
-          aria-label='Copy secret'
-        >
-          {copied ? <Check className='h-3.5 w-3.5 text-emerald-500' /> : <Copy className='h-3.5 w-3.5' />}
-        </button>
-      </div>
-    </Field>
   )
 }
 

--- a/front/src/routes/sub-router/applications.router.ts
+++ b/front/src/routes/sub-router/applications.router.ts
@@ -6,6 +6,11 @@ export const APPLICATIONS_URL = (realmName = ':realmName') =>
 export const APPLICATION_CREATE_URL = (realmName = ':realmName') =>
   `${APPLICATIONS_URL(realmName)}/create`
 
+export const APPLICATION_DETAIL_URL = (
+  realmName = ':realmName',
+  clientId = ':clientId',
+) => `${APPLICATIONS_URL(realmName)}/${clientId}`
+
 export const APPLICATION_CREATE_TYPE_URL = (
   realmName = ':realmName',
   type = ':type',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new application detail page accessible via `:client_id`, with skeleton loading, a type-aware header, and tabbed navigation driven by the `tab` query parameter.
  * Implemented new tabs: Quickstart (copyable endpoints), Settings (toggles, token lifetimes, redirect URI management), Credentials (secret display/copy with visibility controls), and API access scope assignment.
  * Added “Coming soon” placeholders for select tabs based on application type.

* **Bug Fixes**
  * Fixed navigation to open the correct application detail URL from the applications list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->