### PR TITLE
feat(device-flow): include device_code + user_id in webhook payload

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 sha1 = "0.10.6"
 sha2 = "0.10.9"
+hex = "0.4.3"
 thiserror = "2.0.12"
 tracing = { version = "0.1.41", features = ["attributes"] } # Attribute is for the instrument macro
 urlencoding = "2.1.3"
@@ -58,7 +59,6 @@ subtle = "2.6.1"
 mockall = "0.13.1"
 serde_plain = "1.0.2"
 x509-parser = "0.18.0"
-hex = "0.4.3"
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 signature = "2.2.0"
 sha2 = "0.10.9"

--- a/core/src/domain/authentication/device_flow/entities.rs
+++ b/core/src/domain/authentication/device_flow/entities.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use chrono::{DateTime, Duration, Utc};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::domain::common::generate_uuid_v7;
@@ -157,15 +158,32 @@ pub struct DeviceFlowEventPayload {
     pub realm_id: Uuid,
     pub client_id: Uuid,
     pub status: DeviceAuthStatus,
+    /// Full device code on `Initiated` (already returned to the device in the
+    /// HTTP response); SHA-256 hex for all other events to avoid leaking it.
+    pub device_code: String,
+    pub user_id: Option<Uuid>,
 }
 
-impl From<&DeviceAuthSession> for DeviceFlowEventPayload {
-    fn from(session: &DeviceAuthSession) -> Self {
+/// SHA-256 hex digest of a device code UUID's raw bytes.
+fn hash_device_code(device_code: &Uuid) -> String {
+    hex::encode(Sha256::digest(device_code.as_bytes()))
+}
+
+impl DeviceFlowEventPayload {
+    pub fn new(session: &DeviceAuthSession, reveal_device_code: bool) -> Self {
+        let device_code = if reveal_device_code {
+            session.device_code.to_string()
+        } else {
+            hash_device_code(&session.device_code)
+        };
+
         Self {
             session_id: session.id,
             realm_id: session.realm_id.into(),
             client_id: session.client_id,
             status: session.status,
+            device_code,
+            user_id: session.user_id,
         }
     }
 }
@@ -199,6 +217,77 @@ impl DeviceAuthSession {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_session() -> DeviceAuthSession {
+        DeviceAuthSession::new(DeviceAuthSessionConfig {
+            realm_id: RealmId::from(Uuid::new_v4()),
+            client_id: Uuid::new_v4(),
+            scope: None,
+            interval: 5,
+            expires_in: 600,
+        })
+    }
+
+    #[test]
+    fn payload_initiated_reveals_full_device_code() {
+        let session = test_session();
+        let payload = DeviceFlowEventPayload::new(&session, true);
+
+        assert_eq!(payload.device_code, session.device_code.to_string());
+        assert_eq!(payload.session_id, session.id);
+        assert_eq!(payload.realm_id, Uuid::from(session.realm_id));
+        assert_eq!(payload.client_id, session.client_id);
+        assert_eq!(payload.status, session.status);
+        assert_eq!(payload.user_id, None);
+    }
+
+    #[test]
+    fn payload_initiated_carries_user_id_when_set() {
+        let mut session = test_session();
+        let user_id = Uuid::new_v4();
+        session.user_id = Some(user_id);
+
+        let payload = DeviceFlowEventPayload::new(&session, true);
+        assert_eq!(payload.user_id, Some(user_id));
+    }
+
+    #[test]
+    fn payload_non_initiated_hashes_device_code() {
+        let session = test_session();
+        let payload = DeviceFlowEventPayload::new(&session, false);
+
+        let raw = session.device_code.to_string();
+        assert_ne!(payload.device_code, raw);
+
+        // Must be a 64-char lowercase hex string (SHA-256).
+        assert_eq!(payload.device_code.len(), 64);
+        assert!(
+            payload
+                .device_code
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase())
+        );
+
+        // Must equal the expected SHA-256 hex of the UUID bytes.
+        let expected = hex::encode(sha2::Sha256::digest(session.device_code.as_bytes()));
+        assert_eq!(payload.device_code, expected);
+    }
+
+    #[test]
+    fn payload_denied_session_with_user_id_carries_through() {
+        let mut session = test_session();
+        session.status = DeviceAuthStatus::Denied;
+        let user_id = Uuid::new_v4();
+        session.user_id = Some(user_id);
+
+        let payload = DeviceFlowEventPayload::new(&session, false);
+
+        assert_eq!(payload.user_id, Some(user_id));
+        assert_eq!(payload.status, DeviceAuthStatus::Denied);
+        // device_code is hashed (64 hex chars), not the raw UUID string.
+        assert_ne!(payload.device_code, session.device_code.to_string());
+        assert_eq!(payload.device_code.len(), 64);
+    }
 
     #[test]
     fn user_code_has_expected_format() {

--- a/core/src/domain/authentication/device_flow/services.rs
+++ b/core/src/domain/authentication/device_flow/services.rs
@@ -96,10 +96,11 @@ where
     /// propagated (mirrors the rest of the codebase).
     async fn fire_event(&self, session: &DeviceAuthSession, trigger: WebhookTrigger) {
         let realm_id = session.realm_id;
+        let reveal_device_code = matches!(trigger, WebhookTrigger::AuthDeviceFlowInitiated);
         let payload = WebhookPayload::new(
             trigger,
             realm_id.into(),
-            Some(DeviceFlowEventPayload::from(session)),
+            Some(DeviceFlowEventPayload::new(session, reveal_device_code)),
         );
 
         if let Err(err) = self.webhook_repository.notify(realm_id, payload).await {


### PR DESCRIPTION
## Summary

Completes the last open task of #1028: enriching the `auth.device_flow.*` webhook payload.

The trigger enum, the event firing in `initiate()` / `deny()` / `poll()`, and the
frontend trigger listings were already merged through the earlier device-flow PRs
(#1071–#1081). The only remaining gap was task 3 — the payload itself did not carry
`device_code` or `user_id`.

- Add `device_code: String` and `user_id: Option<Uuid>` to `DeviceFlowEventPayload`.
- `device_code` is **revealed in full only on `auth.device_flow.initiated`** (it is
  already returned to the device in the HTTP response, so it leaks nothing new).
- For **non-initiated** events (`denied`, `expired`) the code is sent as a **SHA-256
  hex digest** to avoid leaking the bearer-like device code. `session_id` stays in
  clear so subscribers can still correlate the lifecycle.
- Replace the trigger-agnostic `From<&DeviceAuthSession>` with a trigger-aware
  `DeviceFlowEventPayload::new(session, reveal_device_code)` constructor.

Domain-only change — the payload has no `ToSchema`, so no OpenAPI/frontend codegen is required.

## Test plan

- [x] `cargo test -p ferriskey-core --lib device_flow` — 22 passed, 0 failed
- [x] `cargo clippy -p ferriskey-core --all-targets` — no new warnings
- [x] `cargo fmt` — clean (pre-commit hooks pass)
- [x] Subscribe a webhook to `auth.device_flow.initiated`, trigger a device authorization request, confirm the payload now includes `device_code` (full) and `user_id`
- [x] Trigger a `denied` / `expired` event, confirm `device_code` is a 64-char SHA-256 hex digest

Closes #1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device flow event payloads now include device code and user ID information.

* **Bug Fixes**
  * Enhanced security for device authorization webhooks by hashing device codes in non-initiated events to prevent unintended code exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->