### PR TITLE
feat(token-exchange): advertise grant in openid-configuration

### DIFF
--- a/api/src/application/http/authentication/handlers/openid_configuration.rs
+++ b/api/src/application/http/authentication/handlers/openid_configuration.rs
@@ -75,6 +75,7 @@ pub async fn get_openid_configuration(
             "refresh_token".to_string(),
             "client_credentials".to_string(),
             "password".to_string(),
+            "urn:ietf:params:oauth:grant-type:token-exchange".to_string(),
         ],
         token_endpoint_auth_methods_supported: vec![
             "client_secret_basic".to_string(),


### PR DESCRIPTION
Closes #1055

## Summary

- Adds `urn:ietf:params:oauth:grant-type:token-exchange` to `grant_types_supported` in `GET /:realm/.well-known/openid-configuration`
- All 4 existing grant types are preserved unchanged
- One-line change in `api/src/application/http/authentication/handlers/openid_configuration.rs`

## Testing

Tested end-to-end by building from source with `docker compose --profile build up --build` and calling the discovery endpoint:

```
GET /realms/master/.well-known/openid-configuration
```

Response confirmed:

```json
"grant_types_supported": [
    "authorization_code",
    "refresh_token",
    "client_credentials",
    "password",
    "urn:ietf:params:oauth:grant-type:token-exchange"
]
```

All 5 grant types present, no regressions on the existing 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OAuth 2.0 Token Exchange grant type in OpenID Connect configuration, enabling additional authentication mechanisms for client applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->