### PR TITLE
feat: add tamper-evident hash chaining to the SeaWatch audit log

### DIFF
--- a/core/migrations/20260718000003_add_seawatch_chain_fields.down.sql
+++ b/core/migrations/20260718000003_add_seawatch_chain_fields.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_security_events_realm_created;
+
+ALTER TABLE security_events
+    DROP COLUMN IF EXISTS event_hash,
+    DROP COLUMN IF EXISTS prev_hash;

--- a/core/migrations/20260718000003_add_seawatch_chain_fields.up.sql
+++ b/core/migrations/20260718000003_add_seawatch_chain_fields.up.sql
@@ -1,0 +1,11 @@
+-- Add tamper-evident hash-chain fields to security_events.
+-- event_hash = SHA-256(canonical_preimage || prev_hash_bytes)
+-- prev_hash  = event_hash of the previous event in the realm's chain;
+--              genesis event uses 32 zero bytes.
+ALTER TABLE security_events
+    ADD COLUMN IF NOT EXISTS event_hash TEXT,
+    ADD COLUMN IF NOT EXISTS prev_hash  TEXT;
+
+-- Index to efficiently locate the current chain head per realm.
+CREATE INDEX IF NOT EXISTS idx_security_events_realm_created
+    ON security_events (realm_id, created_at DESC);

--- a/core/src/application/seawatch/mod.rs
+++ b/core/src/application/seawatch/mod.rs
@@ -3,7 +3,10 @@ use crate::{
     domain::{
         authentication::value_objects::Identity,
         common::entities::app_errors::CoreError,
-        seawatch::{SecurityEvent, ports::SecurityEventService, value_objects::FetchEventsInput},
+        seawatch::{
+            SecurityEvent, VerifyResult, ports::SecurityEventService,
+            value_objects::FetchEventsInput,
+        },
     },
 };
 
@@ -15,6 +18,16 @@ impl SecurityEventService for ApplicationService {
     ) -> Result<Vec<SecurityEvent>, CoreError> {
         self.security_event_service
             .fetch_events(identity, input)
+            .await
+    }
+
+    async fn verify_realm_chain(
+        &self,
+        identity: Identity,
+        realm_name: String,
+    ) -> Result<VerifyResult, CoreError> {
+        self.security_event_service
+            .verify_realm_chain(identity, realm_name)
             .await
     }
 }

--- a/core/src/domain/seawatch/entities.rs
+++ b/core/src/domain/seawatch/entities.rs
@@ -189,6 +189,10 @@ pub struct SecurityEvent {
     pub ip_address: Option<String>,
     pub user_agent: Option<String>,
     pub details: Option<serde_json::Value>,
+    /// SHA-256 of the canonical preimage (hex). `None` for legacy rows without hashes.
+    pub event_hash: Option<[u8; 32]>,
+    /// Previous event's `event_hash` in the realm chain (hex-decoded). Genesis = `[0u8; 32]`.
+    pub prev_hash: Option<[u8; 32]>,
 }
 
 impl SecurityEvent {
@@ -213,6 +217,8 @@ impl SecurityEvent {
             ip_address: None,
             user_agent: None,
             details: None,
+            event_hash: None,
+            prev_hash: None,
         }
     }
 

--- a/core/src/domain/seawatch/hashing.rs
+++ b/core/src/domain/seawatch/hashing.rs
@@ -1,0 +1,287 @@
+//! Tamper-evident hash chaining for SeaWatch audit events.
+//!
+//! # Preimage format
+//!
+//! ```text
+//! {id}|{realm_id}|{actor_id}|{actor_type}|{event_type}|{status}|
+//! {target_type}|{target_id}|{resource}|{timestamp}|{trace_id}|
+//! {ip_address}|{user_agent}|{details}
+//! ```
+//!
+//! Fields use their `Display` representation. Optional fields that are `None`
+//! are encoded as the literal string `NONE`. The `details` JSON value is
+//! serialised with [`serde_json::to_string`] (compact, deterministic for the
+//! same value) when present.
+//!
+//! The 32-byte `prev_hash` is appended as raw bytes after the UTF-8 encoded
+//! preimage text, with no separator.
+//!
+//! The genesis event uses `prev_hash = [0u8; 32]`.
+//!
+//! # Chain scope
+//!
+//! Chains are per-realm. Events from different realms form independent chains.
+
+use sha2::{Digest, Sha256};
+
+use super::entities::SecurityEvent;
+
+/// 32 zero bytes used as the genesis `prev_hash`.
+pub const GENESIS_PREV_HASH: [u8; 32] = [0u8; 32];
+
+/// Compute `SHA-256(canonical_preimage(event) || prev_hash_bytes)`.
+///
+/// This is a **pure** function — no I/O, trivially unit-testable.
+pub fn compute_event_hash(event: &SecurityEvent, prev_hash: &[u8; 32]) -> [u8; 32] {
+    let preimage = build_preimage(event);
+    let mut hasher = Sha256::new();
+    hasher.update(preimage.as_bytes());
+    hasher.update(prev_hash);
+    hasher.finalize().into()
+}
+
+/// Result of a chain verification pass.
+#[derive(Debug, PartialEq)]
+pub enum VerifyResult {
+    /// All events verify correctly.
+    Ok,
+    /// A hash mismatch was detected at the given 0-based index.
+    Tampered { index: usize },
+    /// The `prev_hash` link is broken at the given index (deletion / reorder).
+    BrokenLink { index: usize },
+}
+
+/// Verify a slice of [`SecurityEvent`]s that form a contiguous per-realm chain.
+///
+/// Events must be ordered by insertion order (ascending). The first event's
+/// `prev_hash` must be [`GENESIS_PREV_HASH`] or the caller-supplied `expected_genesis`.
+///
+/// Returns [`VerifyResult::Ok`] when all hashes are consistent.
+pub fn verify_chain(events: &[SecurityEvent]) -> VerifyResult {
+    verify_chain_from(events, &GENESIS_PREV_HASH)
+}
+
+/// Like [`verify_chain`] but allows supplying a custom genesis hash (useful for
+/// verifying sub-chains that start after a known anchor).
+pub fn verify_chain_from(events: &[SecurityEvent], genesis: &[u8; 32]) -> VerifyResult {
+    let mut expected_prev = *genesis;
+
+    for (i, event) in events.iter().enumerate() {
+        let stored_prev = match event.prev_hash {
+            Some(h) => h,
+            None => return VerifyResult::Tampered { index: i },
+        };
+        let stored_hash = match event.event_hash {
+            Some(h) => h,
+            None => return VerifyResult::Tampered { index: i },
+        };
+
+        if stored_prev != expected_prev {
+            return VerifyResult::BrokenLink { index: i };
+        }
+
+        let recomputed = compute_event_hash(event, &stored_prev);
+        if recomputed != stored_hash {
+            return VerifyResult::Tampered { index: i };
+        }
+
+        expected_prev = stored_hash;
+    }
+
+    VerifyResult::Ok
+}
+
+/// Export a chain as JSONL (one JSON object per line).
+///
+/// Each line includes all event fields plus `event_hash` and `prev_hash` as
+/// lowercase hex strings. This provides a minimal WORM-style append-only export.
+pub fn export_chain_jsonl(events: &[SecurityEvent]) -> String {
+    use serde_json::json;
+
+    let lines: Vec<String> = events
+        .iter()
+        .map(|e| {
+            let id: uuid::Uuid = e.id.0;
+            let realm_id: uuid::Uuid = e.realm_id.into();
+            let obj = json!({
+                "id": id,
+                "realm_id": realm_id,
+                "actor_id": e.actor_id,
+                "actor_type": e.actor_type.as_ref().map(|t| t.to_string()),
+                "event_type": e.event_type.to_string(),
+                "status": e.status.to_string(),
+                "target_type": e.target_type,
+                "target_id": e.target_id,
+                "resource": e.resource,
+                "timestamp": e.timestamp.to_rfc3339(),
+                "trace_id": e.trace_id,
+                "ip_address": e.ip_address,
+                "user_agent": e.user_agent,
+                "details": e.details,
+                "prev_hash": e.prev_hash.map(hex::encode),
+                "event_hash": e.event_hash.map(hex::encode),
+            });
+            serde_json::to_string(&obj).unwrap_or_default()
+        })
+        .collect();
+    lines.join("\n")
+}
+
+fn build_preimage(event: &SecurityEvent) -> String {
+    let id: uuid::Uuid = event.id.0;
+    let id = id.to_string();
+    let realm_uuid: uuid::Uuid = event.realm_id.into();
+    let realm_id = realm_uuid.to_string();
+    let actor_id = opt_str(event.actor_id.map(|u| u.to_string()));
+    let actor_type = opt_str(event.actor_type.as_ref().map(|t| t.to_string()));
+    let event_type = event.event_type.to_string();
+    let status = event.status.to_string();
+    let target_type = opt_str(event.target_type.clone());
+    let target_id = opt_str(event.target_id.map(|u| u.to_string()));
+    let resource = opt_str(event.resource.clone());
+    let timestamp = event
+        .timestamp
+        .to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+    let trace_id = opt_str(event.trace_id.clone());
+    let ip_address = opt_str(event.ip_address.clone());
+    let user_agent = opt_str(event.user_agent.clone());
+    let details = opt_str(
+        event
+            .details
+            .as_ref()
+            .and_then(|v| serde_json::to_string(v).ok()),
+    );
+
+    format!(
+        "{id}|{realm_id}|{actor_id}|{actor_type}|{event_type}|{status}|\
+         {target_type}|{target_id}|{resource}|{timestamp}|{trace_id}|\
+         {ip_address}|{user_agent}|{details}"
+    )
+}
+
+fn opt_str(v: Option<String>) -> String {
+    v.unwrap_or_else(|| "NONE".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use crate::domain::realm::entities::RealmId;
+    use crate::domain::seawatch::entities::{
+        EventStatus, SecurityEvent, SecurityEventId, SecurityEventType,
+    };
+
+    use super::*;
+
+    fn make_event(realm_id: RealmId) -> SecurityEvent {
+        SecurityEvent {
+            id: SecurityEventId::new(),
+            realm_id,
+            actor_id: Some(Uuid::new_v4()),
+            actor_type: None,
+            event_type: SecurityEventType::LoginSuccess,
+            status: EventStatus::Success,
+            target_type: None,
+            target_id: None,
+            resource: None,
+            timestamp: Utc::now(),
+            trace_id: None,
+            ip_address: None,
+            user_agent: None,
+            details: None,
+            event_hash: None,
+            prev_hash: None,
+        }
+    }
+
+    fn chain_events(count: usize) -> Vec<SecurityEvent> {
+        let realm_id = RealmId::new(Uuid::new_v4());
+        let mut prev = GENESIS_PREV_HASH;
+        let mut events = Vec::with_capacity(count);
+        for _ in 0..count {
+            let mut e = make_event(realm_id.clone());
+            let hash = compute_event_hash(&e, &prev);
+            e.prev_hash = Some(prev);
+            e.event_hash = Some(hash);
+            prev = hash;
+            events.push(e);
+        }
+        events
+    }
+
+    #[test]
+    fn chain_of_n_events_verifies_ok() {
+        let events = chain_events(5);
+        assert_eq!(verify_chain(&events), VerifyResult::Ok);
+    }
+
+    #[test]
+    fn empty_chain_verifies_ok() {
+        assert_eq!(verify_chain(&[]), VerifyResult::Ok);
+    }
+
+    #[test]
+    fn single_genesis_event_verifies_ok() {
+        let events = chain_events(1);
+        assert_eq!(verify_chain(&events), VerifyResult::Ok);
+    }
+
+    #[test]
+    fn genesis_hash_is_deterministic() {
+        let realm_id = RealmId::new(Uuid::new_v4());
+        let mut e = make_event(realm_id);
+        // Fix timestamp so the preimage is stable across calls.
+        e.timestamp = chrono::DateTime::from_timestamp_nanos(1_000_000_000);
+        let h1 = compute_event_hash(&e, &GENESIS_PREV_HASH);
+        let h2 = compute_event_hash(&e, &GENESIS_PREV_HASH);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn mutating_event_field_breaks_chain_at_that_index() {
+        let mut events = chain_events(4);
+        // Tamper: change the event_type on index 1 without recomputing hashes.
+        events[1].event_type = SecurityEventType::LoginFailure;
+        assert_eq!(verify_chain(&events), VerifyResult::Tampered { index: 1 });
+    }
+
+    #[test]
+    fn removing_event_breaks_link() {
+        let mut events = chain_events(4);
+        // Remove event at index 1; event[1] (old index 2) now has a prev_hash
+        // pointing to old event[1] which is gone.
+        events.remove(1);
+        assert_eq!(verify_chain(&events), VerifyResult::BrokenLink { index: 1 });
+    }
+
+    #[test]
+    fn reordering_events_breaks_chain() {
+        let mut events = chain_events(3);
+        events.swap(0, 1);
+        // Event[0] (originally index 1) has prev_hash = event[0]'s hash, but
+        // expected genesis prev is [0u8;32].
+        assert!(verify_chain(&events) != VerifyResult::Ok);
+    }
+
+    #[test]
+    fn missing_event_hash_is_detected_as_tamper() {
+        let mut events = chain_events(3);
+        events[1].event_hash = None;
+        assert_eq!(verify_chain(&events), VerifyResult::Tampered { index: 1 });
+    }
+
+    #[test]
+    fn export_jsonl_produces_one_line_per_event() {
+        let events = chain_events(3);
+        let output = export_chain_jsonl(&events);
+        assert_eq!(output.lines().count(), 3);
+        // Each line must be valid JSON containing event_hash.
+        for line in output.lines() {
+            let v: serde_json::Value = serde_json::from_str(line).expect("valid JSON");
+            assert!(v.get("event_hash").is_some());
+            assert!(v.get("prev_hash").is_some());
+        }
+    }
+}

--- a/core/src/domain/seawatch/mod.rs
+++ b/core/src/domain/seawatch/mod.rs
@@ -1,4 +1,5 @@
 pub mod entities;
+pub mod hashing;
 pub mod pii;
 pub mod policies;
 pub mod ports;
@@ -6,6 +7,7 @@ pub mod services;
 pub mod value_objects;
 
 pub use entities::{ActorType, EventStatus, SecurityEvent, SecurityEventType};
+pub use hashing::{VerifyResult, compute_event_hash, verify_chain, verify_chain_from};
 pub use pii::{AuditPiiMode, PiiConfig};
 pub use ports::{SecurityEventPolicy, SecurityEventRepository};
 pub use value_objects::{EventExportRequest, ExportFormat, SecurityEventFilter};

--- a/core/src/domain/seawatch/ports.rs
+++ b/core/src/domain/seawatch/ports.rs
@@ -6,6 +6,7 @@ use crate::domain::common::entities::app_errors::CoreError;
 use crate::domain::realm::entities::{Realm, RealmId};
 
 use super::entities::SecurityEvent;
+use super::hashing::VerifyResult;
 use super::value_objects::{FetchEventsInput, SecurityEventFilter};
 
 pub trait SecurityEventService: Send + Sync {
@@ -14,25 +15,49 @@ pub trait SecurityEventService: Send + Sync {
         identity: Identity,
         input: FetchEventsInput,
     ) -> impl Future<Output = Result<Vec<SecurityEvent>, CoreError>> + Send;
+
+    fn verify_realm_chain(
+        &self,
+        identity: Identity,
+        realm_name: String,
+    ) -> impl Future<Output = Result<VerifyResult, CoreError>> + Send;
 }
 
 #[cfg_attr(test, mockall::automock)]
 pub trait SecurityEventRepository: Send + Sync {
+    /// Store an event that has already had its `event_hash` and `prev_hash` populated.
     fn store_event(
         &self,
         event: SecurityEvent,
     ) -> impl Future<Output = Result<(), CoreError>> + Send;
+
+    /// Atomically retrieve the current chain head hash for `realm_id`, compute and
+    /// store the new event with correct `event_hash` / `prev_hash` fields.
+    fn store_event_chained(
+        &self,
+        event: SecurityEvent,
+    ) -> impl Future<Output = Result<SecurityEvent, CoreError>> + Send;
+
     fn get_events(
         &self,
         realm_id: RealmId,
         filter: SecurityEventFilter,
     ) -> impl Future<Output = Result<Vec<SecurityEvent>, CoreError>> + Send;
+
     fn get_by_id(&self, id: Uuid) -> impl Future<Output = Result<SecurityEvent, CoreError>> + Send;
+
     fn count_events(
         &self,
         realm_id: Uuid,
         filter: SecurityEventFilter,
     ) -> impl Future<Output = Result<i64, CoreError>> + Send;
+
+    /// Return all events for the realm ordered by insertion (created_at ASC) for
+    /// chain verification.
+    fn get_events_ordered_for_verification(
+        &self,
+        realm_id: RealmId,
+    ) -> impl Future<Output = Result<Vec<SecurityEvent>, CoreError>> + Send;
 }
 
 pub trait SecurityEventPolicy: Send + Sync {

--- a/core/src/domain/seawatch/services.rs
+++ b/core/src/domain/seawatch/services.rs
@@ -10,7 +10,9 @@ use crate::domain::{
     realm::ports::RealmRepository,
     seawatch::{
         SecurityEvent, SecurityEventFilter, SecurityEventPolicy, SecurityEventRepository,
-        ports::SecurityEventService, value_objects::FetchEventsInput,
+        hashing::{VerifyResult, verify_chain},
+        ports::SecurityEventService,
+        value_objects::FetchEventsInput,
     },
     user::ports::{UserRepository, UserRoleRepository},
 };
@@ -87,5 +89,30 @@ where
             .await?;
 
         Ok(security_events)
+    }
+
+    async fn verify_realm_chain(
+        &self,
+        identity: Identity,
+        realm_name: String,
+    ) -> Result<VerifyResult, CoreError> {
+        let realm = self
+            .realm_repository
+            .get_by_name(&realm_name)
+            .await
+            .map_err(|_| CoreError::InvalidRealm)?
+            .ok_or(CoreError::InvalidRealm)?;
+
+        ensure_policy(
+            self.policy.can_view_events(&identity, &realm).await,
+            "insufficient permissions",
+        )?;
+
+        let events = self
+            .security_event_repository
+            .get_events_ordered_for_verification(realm.id)
+            .await?;
+
+        Ok(verify_chain(&events))
     }
 }

--- a/core/src/entity/security_events.rs
+++ b/core/src/entity/security_events.rs
@@ -28,6 +28,11 @@ pub struct Model {
     pub user_agent: Option<String>,
     pub details: Option<Json>,
     pub created_at: DateTime,
+    /// SHA-256 hash of the canonical preimage for this event (hex-encoded).
+    pub event_hash: Option<String>,
+    /// SHA-256 hash of the previous event in the realm chain (hex-encoded).
+    /// 32 zero bytes (hex) for the genesis event.
+    pub prev_hash: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -47,6 +52,8 @@ pub enum Column {
     UserAgent,
     Details,
     CreatedAt,
+    EventHash,
+    PrevHash,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -85,6 +92,8 @@ impl ColumnTrait for Column {
             Self::UserAgent => ColumnType::Text.def().null(),
             Self::Details => ColumnType::JsonBinary.def().null(),
             Self::CreatedAt => ColumnType::DateTime.def(),
+            Self::EventHash => ColumnType::Text.def().null(),
+            Self::PrevHash => ColumnType::Text.def().null(),
         }
     }
 }

--- a/core/src/infrastructure/seawatch/mapper.rs
+++ b/core/src/infrastructure/seawatch/mapper.rs
@@ -4,6 +4,13 @@ use sea_orm::ActiveValue::Set;
 use crate::domain::seawatch::entities::{ActorType, EventStatus, SecurityEvent, SecurityEventType};
 use crate::entity::security_events;
 
+fn decode_hash(hex_str: Option<String>) -> Option<[u8; 32]> {
+    let s = hex_str?;
+    let bytes = hex::decode(&s).ok()?;
+    let arr: [u8; 32] = bytes.try_into().ok()?;
+    Some(arr)
+}
+
 impl From<security_events::Model> for SecurityEvent {
     fn from(model: security_events::Model) -> Self {
         let actor_type = model.actor_type.and_then(|s| match s.as_str() {
@@ -56,6 +63,8 @@ impl From<security_events::Model> for SecurityEvent {
             ip_address: model.ip_address,
             user_agent: model.user_agent,
             details: model.details,
+            event_hash: decode_hash(model.event_hash),
+            prev_hash: decode_hash(model.prev_hash),
         }
     }
 }
@@ -78,6 +87,8 @@ impl From<SecurityEvent> for security_events::ActiveModel {
             user_agent: Set(event.user_agent),
             details: Set(event.details),
             created_at: Set(Utc::now().naive_utc()),
+            event_hash: Set(event.event_hash.map(hex::encode)),
+            prev_hash: Set(event.prev_hash.map(hex::encode)),
         }
     }
 }

--- a/core/src/infrastructure/seawatch/repositories/security_event_postgres_repository.rs
+++ b/core/src/infrastructure/seawatch/repositories/security_event_postgres_repository.rs
@@ -1,6 +1,6 @@
 use sea_orm::{
     ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect,
+    QuerySelect, TransactionTrait,
 };
 use uuid::Uuid;
 
@@ -8,6 +8,7 @@ use crate::domain::common::entities::app_errors::CoreError;
 use crate::domain::realm::entities::RealmId;
 use crate::domain::seawatch::{
     entities::SecurityEvent,
+    hashing::{GENESIS_PREV_HASH, compute_event_hash},
     pii::{AuditPiiMode, PiiConfig, apply_to_event},
     ports::SecurityEventRepository,
     value_objects::SecurityEventFilter,
@@ -63,6 +64,65 @@ impl SecurityEventRepository for PostgresSecurityEventRepository {
             })?;
 
         Ok(())
+    }
+
+    /// Atomically compute and persist the chained event.
+    ///
+    /// The implementation opens a transaction, fetches the current chain head
+    /// (latest event for the realm ordered by `created_at DESC`), computes
+    /// `event_hash = SHA-256(preimage || prev_hash)`, and inserts in the same
+    /// transaction to keep the chain linear even under concurrent writes from
+    /// multiple API workers (Postgres serialises the writes within the txn).
+    async fn store_event_chained(
+        &self,
+        mut event: SecurityEvent,
+    ) -> Result<SecurityEvent, CoreError> {
+        let db = &self.db;
+        let realm_uuid: Uuid = event.realm_id.into();
+
+        let txn = db.begin().await.map_err(|e| {
+            tracing::error!("Failed to begin transaction for chained event: {}", e);
+            CoreError::InternalServerError
+        })?;
+
+        // Lock the latest row for this realm so concurrent inserts are serialised.
+        let head = security_events::Entity::find()
+            .filter(security_events::Column::RealmId.eq(realm_uuid))
+            .order_by_desc(security_events::Column::CreatedAt)
+            .lock_exclusive()
+            .one(&txn)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to fetch chain head: {}", e);
+                CoreError::InternalServerError
+            })?;
+
+        let prev_hash: [u8; 32] = head
+            .and_then(|m| {
+                m.event_hash
+                    .and_then(|h| hex::decode(&h).ok().and_then(|b| b.try_into().ok()))
+            })
+            .unwrap_or(GENESIS_PREV_HASH);
+
+        let hash = compute_event_hash(&event, &prev_hash);
+        event.prev_hash = Some(prev_hash);
+        event.event_hash = Some(hash);
+
+        let active_model: security_events::ActiveModel = event.clone().into();
+        security_events::Entity::insert(active_model)
+            .exec(&txn)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to store chained security event: {}", e);
+                CoreError::InternalServerError
+            })?;
+
+        txn.commit().await.map_err(|e| {
+            tracing::error!("Failed to commit chained event transaction: {}", e);
+            CoreError::InternalServerError
+        })?;
+
+        Ok(event)
     }
 
     async fn get_events(
@@ -178,5 +238,22 @@ impl SecurityEventRepository for PostgresSecurityEventRepository {
 
             Ok(count as i64)
         }
+    }
+
+    async fn get_events_ordered_for_verification(
+        &self,
+        realm_id: RealmId,
+    ) -> Result<Vec<SecurityEvent>, CoreError> {
+        let models = security_events::Entity::find()
+            .filter(security_events::Column::RealmId.eq::<Uuid>(realm_id.into()))
+            .order_by_asc(security_events::Column::CreatedAt)
+            .all(&self.db)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to fetch events for chain verification: {}", e);
+                CoreError::InternalServerError
+            })?;
+
+        Ok(models.into_iter().map(|m| m.into()).collect())
     }
 }


### PR DESCRIPTION
## Summary
- Adds `event_hash` and `prev_hash` columns to `security_events` (migration), forming a per-realm SHA-256 hash chain so any modification, deletion, or reorder of audit events is detectable.
- New pure module `domain/seawatch/hashing.rs`: `event_hash = SHA256(canonical_preimage(event) || prev_hash)` with an explicit, documented field order (no reliance on map ordering). Genesis `prev_hash` = 32 zero bytes.
- `verify_chain` / `verify_realm_chain` detect tampering; `export_chain_jsonl` provides a WORM-style export.
- Chained append serialises per realm via `SELECT ... FOR UPDATE` to keep the chain linear.

## Tests
- Unit: 9 tests (N-event chain OK, field mutation → tamper at index, removal/reorder → broken link, genesis, deterministic hash, JSONL export).

## Reviewer notes
- SeaORM entity (`security_events`) was hand-edited (no live DB) — regenerate with `sea-orm-cli` after applying the migration.
- Legacy rows have NULL hashes (treated as unverified); callers should adopt `store_event_chained` going forward.
- #1098 (audit PII pseudonymisation) will build on this model.

Closes #1097
Part of #1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tamper-evident hash chaining for security events.
  - Added realm chain verification that reports whether chains are valid, tampered, or broken.
  - Added JSONL export that includes per-event chain hash details.
  - New events can now be stored with integrity links to the preceding event.
- **Database**
  - Added persistent storage for per-event hash fields and an index to efficiently retrieve events for verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->