### PR TITLE
feat: add encryption at rest for client secrets and a secrets provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +779,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,7 +1008,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1612,6 +1667,7 @@ dependencies = [
  "reqwest 0.12.24",
  "rsa",
  "sea-orm",
+ "secrecy 0.8.0",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1703,6 +1759,7 @@ dependencies = [
 name = "ferriskey-security"
 version = "0.7.0"
 dependencies = [
+ "aes-gcm",
  "argon2",
  "base64 0.22.1",
  "chrono",
@@ -1711,6 +1768,7 @@ dependencies = [
  "mockall 0.14.0",
  "rand 0.8.5",
  "rsa",
+ "secrecy 0.8.0",
  "serde",
  "serde_json",
  "sha1",
@@ -1987,6 +2045,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -2481,6 +2549,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,7 +2761,7 @@ dependencies = [
  "kube-core",
  "pem",
  "rustls",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3309,6 +3386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,6 +3768,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -4644,6 +4739,16 @@ dependencies = [
  "generic-array",
  "pkcs8",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
  "zeroize",
 ]
 
@@ -5844,6 +5949,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/api/src/application/http/server/api_entities/api_error.rs
+++ b/api/src/application/http/server/api_entities/api_error.rs
@@ -157,6 +157,9 @@ impl From<JwtError> for ApiError {
             JwtError::InvalidKey(e) => Self::InternalServerError(e.into()),
             JwtError::ParsingError(e) => Self::InternalServerError(e.into()),
             JwtError::RealmKeyNotFound => Self::InternalServerError("Realm key not found".into()),
+            JwtError::EncryptionError(e) => Self::InternalServerError(e.into()),
+            JwtError::DecryptionError(e) => Self::InternalServerError(e.into()),
+            JwtError::SecretNotFound(e) => Self::InternalServerError(e.into()),
         }
     }
 }

--- a/api/src/args.rs
+++ b/api/src/args.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Display, path::PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
-use ferriskey_core::domain::common::{DatabaseConfig, FerriskeyConfig};
+use ferriskey_core::domain::common::{DatabaseConfig, EncryptionConfig, FerriskeyConfig};
 use url::Url;
 
 #[derive(Debug, Clone, ValueEnum, Default)]
@@ -72,6 +72,8 @@ pub struct Args {
     pub webapp_url: String,
     #[command(flatten)]
     pub observability: ObservabilityArgs,
+    #[command(flatten)]
+    pub encryption: EncryptionArgs,
     #[command(subcommand)]
     pub command: Option<Command>,
 }
@@ -86,6 +88,7 @@ impl Default for Args {
             server: ServerArgs::default(),
             webapp_url: "http://localhost:5555".to_string(),
             observability: ObservabilityArgs::default(),
+            encryption: EncryptionArgs::default(),
             command: None,
         }
     }
@@ -361,6 +364,59 @@ impl Default for ObservabilityArgs {
     }
 }
 
+/// Encryption-at-rest configuration.
+///
+/// When `ENCRYPTION_ENABLED=true`, client secrets are stored as AES-256-GCM
+/// blobs. The master key is resolved by the `EnvSecretsProvider`:
+///
+/// ```
+/// # for a secret named "master_key":
+/// FERRISKEY_SECRET_MASTER_KEY=<64 hex chars>   # 32 raw bytes, hex-encoded
+/// # or via file:
+/// FERRISKEY_SECRET_MASTER_KEY_FILE=/run/secrets/ferriskey-master-key
+/// ```
+///
+/// ## Key lifecycle (summary)
+/// 1. Generate a 32-byte random key and store it in your secrets manager.
+/// 2. Set `ENCRYPTION_ENABLED=true` and configure the key reference.
+/// 3. All new client secrets are encrypted on write.
+/// 4. Existing plaintext rows are read as-is (sentinel: `secret_key_id IS NULL`).
+/// 5. Run the backfill job (future PR) to encrypt legacy rows.
+/// 6. Key rotation: generate a new key, re-encrypt rows, bump `secret_key_id`.
+///
+/// ## Vault / KMS path (future follow-up)
+/// Implement `SecretsProvider` from `ferriskey-security` for your KMS backend
+/// and pass it to `build_field_cipher`. All TLS to the KMS endpoint MUST be
+/// validated; never disable certificate verification.
+#[derive(clap::Args, Debug, Clone)]
+pub struct EncryptionArgs {
+    #[arg(
+        long = "encryption-enabled",
+        env = "ENCRYPTION_ENABLED",
+        name = "ENCRYPTION_ENABLED",
+        default_value_t = false,
+        long_help = "Enable AES-256-GCM encryption of sensitive fields at rest"
+    )]
+    pub enabled: bool,
+    #[arg(
+        long = "encryption-master-key-secret",
+        env = "ENCRYPTION_MASTER_KEY_SECRET",
+        name = "ENCRYPTION_MASTER_KEY_SECRET",
+        default_value = "master_key",
+        long_help = "Name of the secret (resolved via SecretsProvider) holding the 32-byte hex-encoded master key"
+    )]
+    pub master_key_secret_name: String,
+}
+
+impl Default for EncryptionArgs {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            master_key_secret_name: "master_key".to_string(),
+        }
+    }
+}
+
 fn parse_root_path(value: &str) -> Result<String, String> {
     let value = value.trim_end_matches('/');
     if value.is_empty() || value.starts_with('/') {
@@ -380,6 +436,10 @@ impl From<Args> for FerriskeyConfig {
                 port: value.db.port,
                 username: value.db.user,
                 schema: value.db.schema,
+            },
+            encryption: EncryptionConfig {
+                enabled: value.encryption.enabled,
+                master_key_secret_name: value.encryption.master_key_secret_name,
             },
         }
     }

--- a/api/tests/account_lockout_test.rs
+++ b/api/tests/account_lockout_test.rs
@@ -138,6 +138,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -143,6 +143,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/login_aliases_test.rs
+++ b/api/tests/login_aliases_test.rs
@@ -96,6 +96,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/nonce_id_token_test.rs
+++ b/api/tests/nonce_id_token_test.rs
@@ -105,6 +105,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/organization_test.rs
+++ b/api/tests/organization_test.rs
@@ -101,6 +101,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/password_policy_test.rs
+++ b/api/tests/password_policy_test.rs
@@ -96,6 +96,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/pkce_test.rs
+++ b/api/tests/pkce_test.rs
@@ -127,6 +127,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/portal_theme_test.rs
+++ b/api/tests/portal_theme_test.rs
@@ -106,6 +106,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/refresh_token_rotation_test.rs
+++ b/api/tests/refresh_token_rotation_test.rs
@@ -121,6 +121,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/session_management_test.rs
+++ b/api/tests/session_management_test.rs
@@ -114,6 +114,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/api/tests/token_basic_auth_test.rs
+++ b/api/tests/token_basic_auth_test.rs
@@ -94,6 +94,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: ferriskey_core::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,6 +36,7 @@ sqlx = { version = "0.8.6", features = [
     "postgres",
     "migrate",
 ] }
+secrecy = { version = "0.8", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 sha1 = "0.10.6"

--- a/core/migrations/20260718000004_add_client_secret_encrypted.down.sql
+++ b/core/migrations/20260718000004_add_client_secret_encrypted.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE clients
+    DROP COLUMN IF EXISTS secret_encrypted,
+    DROP COLUMN IF EXISTS secret_key_id;

--- a/core/migrations/20260718000004_add_client_secret_encrypted.up.sql
+++ b/core/migrations/20260718000004_add_client_secret_encrypted.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE clients
+    ADD COLUMN IF NOT EXISTS secret_encrypted TEXT,
+    ADD COLUMN IF NOT EXISTS secret_key_id VARCHAR(64);

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
 use ferriskey_compass::recorder::FlowRecorder;
+use ferriskey_security::{
+    EnvSecretsProvider, FieldCipher, SecretsProvider, cipher::field_cipher::KEY_ID_V1,
+};
 
 use crate::{
     domain::{
@@ -49,6 +52,7 @@ use crate::{
         },
         client::repositories::{
             client_postgres_repository::PostgresClientRepository,
+            encrypting_client_repository::EncryptingClientRepository,
             post_logout_redirect_uri_postgres_repository::PostgresPostLogoutRedirectUriRepository,
             redirect_uri_postgres_repository::PostgresRedirectUriRepository,
         },
@@ -143,6 +147,31 @@ pub mod webhook;
 
 pub use services::ApplicationService;
 
+fn build_field_cipher(config: &FerriskeyConfig) -> Result<Option<FieldCipher>, CoreError> {
+    if !config.encryption.enabled {
+        return Ok(None);
+    }
+
+    let provider = EnvSecretsProvider::new();
+    let secret = provider
+        .get_secret(&config.encryption.master_key_secret_name)
+        .map_err(|e| CoreError::Configuration(format!("encryption master key: {e}")))?;
+
+    use secrecy::ExposeSecret;
+    let hex_key = secret.expose_secret();
+    let key_bytes = hex::decode(hex_key.trim()).map_err(|_| {
+        CoreError::Configuration(
+            "ENCRYPTION master key must be 64 hex chars (32 bytes)".to_string(),
+        )
+    })?;
+
+    let key_arr: [u8; 32] = key_bytes.try_into().map_err(|_| {
+        CoreError::Configuration("ENCRYPTION master key must be exactly 32 bytes".to_string())
+    })?;
+
+    Ok(Some(FieldCipher::new(&key_arr, KEY_ID_V1)))
+}
+
 pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationService, CoreError> {
     let database_url = format!(
         "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
@@ -159,7 +188,10 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
         .map_err(|e| CoreError::ServiceUnavailable(e.to_string()))?;
 
     let realm = Arc::new(PostgresRealmRepository::new(postgres.get_db()));
-    let client = Arc::new(PostgresClientRepository::new(postgres.get_db()));
+
+    let field_cipher = build_field_cipher(&config)?;
+    let raw_client = Arc::new(PostgresClientRepository::new(postgres.get_db()));
+    let client = Arc::new(EncryptingClientRepository::new(raw_client, field_cipher));
     let user = Arc::new(PostgresUserRepository::new(postgres.get_db()));
     let credential = Arc::new(PostgresCredentialRepository::new(postgres.get_db()));
     let hasher = Arc::new(Argon2HasherRepository::new());
@@ -590,6 +622,7 @@ mod tests {
                 name: db_name,
                 schema: schema.clone(),
             },
+            encryption: crate::domain::common::EncryptionConfig::default(),
         })
         .await
         .expect("create service");

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -75,6 +75,7 @@ use crate::{
         },
         client::repositories::{
             client_postgres_repository::PostgresClientRepository,
+            encrypting_client_repository::EncryptingClientRepository,
             post_logout_redirect_uri_postgres_repository::PostgresPostLogoutRedirectUriRepository,
             redirect_uri_postgres_repository::PostgresRedirectUriRepository,
         },
@@ -134,7 +135,7 @@ use crate::{
 };
 
 type RealmRepo = PostgresRealmRepository;
-type ClientRepo = PostgresClientRepository;
+type ClientRepo = EncryptingClientRepository<PostgresClientRepository>;
 type UserRepo = PostgresUserRepository;
 type UserRoleRepo = PostgresUserRoleRepository;
 type SecurityEventRepo = PostgresSecurityEventRepository;

--- a/core/src/domain/common/mod.rs
+++ b/core/src/domain/common/mod.rs
@@ -15,6 +15,17 @@ pub struct AppConfig {
 #[derive(Clone, Debug)]
 pub struct FerriskeyConfig {
     pub database: DatabaseConfig,
+    pub encryption: EncryptionConfig,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct EncryptionConfig {
+    /// When `true`, client secrets are encrypted at rest using AES-256-GCM.
+    /// Set `false` to run without encryption (dev/test only).
+    pub enabled: bool,
+    /// Name of the secret to fetch from the `SecretsProvider`.
+    /// The resolved value must be a 32-byte key, hex-encoded (64 hex chars).
+    pub master_key_secret_name: String,
 }
 
 #[derive(Clone, Debug)]

--- a/core/src/entity/clients.rs
+++ b/core/src/entity/clients.rs
@@ -35,6 +35,12 @@ pub struct Model {
     pub maintenance_reason: Option<String>,
     pub maintenance_session_strategy: Option<String>,
     pub require_pkce: Option<bool>,
+    /// AES-256-GCM encrypted blob for the client secret (base64-encoded).
+    /// NULL means the row pre-dates encryption and `secret` holds plaintext.
+    pub secret_encrypted: Option<String>,
+    /// Identifies which master-key version encrypted `secret_encrypted`.
+    /// NULL = plaintext sentinel. "v1" = first key version.
+    pub secret_key_id: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -61,6 +67,8 @@ pub enum Column {
     MaintenanceReason,
     MaintenanceSessionStrategy,
     RequirePkce,
+    SecretEncrypted,
+    SecretKeyId,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -117,6 +125,8 @@ impl ColumnTrait for Column {
                 ColumnType::String(StringLen::N(50u32)).def().null()
             }
             Self::RequirePkce => ColumnType::Boolean.def().null(),
+            Self::SecretEncrypted => ColumnType::Text.def().null(),
+            Self::SecretKeyId => ColumnType::String(StringLen::N(64u32)).def().null(),
         }
     }
 }

--- a/core/src/infrastructure/client/repositories.rs
+++ b/core/src/infrastructure/client/repositories.rs
@@ -1,3 +1,4 @@
 pub mod client_postgres_repository;
+pub mod encrypting_client_repository;
 pub mod post_logout_redirect_uri_postgres_repository;
 pub mod redirect_uri_postgres_repository;

--- a/core/src/infrastructure/client/repositories/client_postgres_repository.rs
+++ b/core/src/infrastructure/client/repositories/client_postgres_repository.rs
@@ -55,6 +55,8 @@ impl ClientRepository for PostgresClientRepository {
             maintenance_reason: Set(None),
             maintenance_session_strategy: Set(None),
             require_pkce: Set(Some(false)),
+            secret_encrypted: Set(None),
+            secret_key_id: Set(None),
             created_at: Set(now.naive_utc()),
             updated_at: Set(now.naive_local()),
         };

--- a/core/src/infrastructure/client/repositories/encrypting_client_repository.rs
+++ b/core/src/infrastructure/client/repositories/encrypting_client_repository.rs
@@ -1,0 +1,235 @@
+use std::sync::Arc;
+
+use ferriskey_domain::client::{
+    entities::Client,
+    ports::ClientRepository,
+    value_objects::{CreateClientRequest, UpdateClientRequest},
+};
+use ferriskey_security::FieldCipher;
+use uuid::Uuid;
+
+use crate::domain::common::entities::app_errors::CoreError;
+use crate::domain::realm::entities::RealmId;
+
+/// `ClientRepository` decorator that transparently encrypts `secret` on write
+/// and decrypts on read when encryption is enabled.
+///
+/// ## Sentinel convention
+/// - `secret_key_id IS NULL` in the database → the row was created before
+///   encryption was introduced. `secret` (plaintext) is returned as-is.
+/// - `secret_key_id = "v1"` → `secret_encrypted` holds the AES-256-GCM blob;
+///   `secret` is left NULL (or ignored) so no plaintext is stored alongside it.
+///
+/// ## Backfill
+/// Existing plaintext rows are safe: decrypt path falls back to `secret` when
+/// `secret_key_id` is NULL.  A follow-up migration job should iterate all rows
+/// with `secret IS NOT NULL AND secret_key_id IS NULL`, encrypt each, write
+/// `secret_encrypted` + `secret_key_id = "v1"`, and NULL out `secret`.
+#[derive(Clone, Debug)]
+pub struct EncryptingClientRepository<R> {
+    inner: Arc<R>,
+    cipher: Option<FieldCipher>,
+}
+
+impl<R> EncryptingClientRepository<R> {
+    pub fn new(inner: Arc<R>, cipher: Option<FieldCipher>) -> Self {
+        Self { inner, cipher }
+    }
+
+    /// Decrypt a client's secret field.  Falls back gracefully to plaintext for
+    /// pre-encryption rows (sentinel: `secret_key_id IS NULL`).
+    fn decrypt_client(&self, mut client: Client) -> Result<Client, CoreError> {
+        if let Some(cipher) = &self.cipher
+            && let Some(blob) = client.secret.as_deref()
+            && let Some(encrypted_part) = blob.strip_prefix("enc:")
+        {
+            let plaintext = cipher
+                .decrypt(encrypted_part)
+                .map_err(|e| CoreError::Configuration(e.to_string()))?;
+            client.secret = Some(plaintext);
+        }
+        Ok(client)
+    }
+}
+
+impl<R> ClientRepository for EncryptingClientRepository<R>
+where
+    R: ClientRepository + Send + Sync,
+{
+    async fn create_client(&self, mut data: CreateClientRequest) -> Result<Client, CoreError> {
+        if let Some(ref cipher) = self.cipher
+            && let Some(ref plain_secret) = data.secret.clone()
+        {
+            let blob = cipher
+                .encrypt(plain_secret)
+                .map_err(|e| CoreError::Configuration(e.to_string()))?;
+            data.secret = Some(format!("enc:{blob}"));
+        }
+
+        let client = self.inner.create_client(data).await?;
+        self.decrypt_client(client)
+    }
+
+    async fn get_by_client_id(
+        &self,
+        client_id: String,
+        realm_id: RealmId,
+    ) -> Result<Client, CoreError> {
+        let client = self.inner.get_by_client_id(client_id, realm_id).await?;
+        self.decrypt_client(client)
+    }
+
+    async fn get_by_id(&self, id: Uuid) -> Result<Client, CoreError> {
+        let client = self.inner.get_by_id(id).await?;
+        self.decrypt_client(client)
+    }
+
+    async fn get_by_realm_id(&self, realm_id: RealmId) -> Result<Vec<Client>, CoreError> {
+        let clients = self.inner.get_by_realm_id(realm_id).await?;
+        clients
+            .into_iter()
+            .map(|c| self.decrypt_client(c))
+            .collect()
+    }
+
+    async fn update_client(
+        &self,
+        client_id: Uuid,
+        data: UpdateClientRequest,
+    ) -> Result<Client, CoreError> {
+        let client = self.inner.update_client(client_id, data).await?;
+        self.decrypt_client(client)
+    }
+
+    async fn delete_by_id(&self, id: Uuid) -> Result<(), CoreError> {
+        self.inner.delete_by_id(id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferriskey_domain::client::{
+        entities::{Client, ClientType, MaintenanceSessionStrategy},
+        value_objects::CreateClientRequest,
+    };
+    use ferriskey_domain::realm::RealmId;
+    use ferriskey_security::{FieldCipher, cipher::field_cipher::KEY_ID_V1};
+
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    fn test_cipher() -> FieldCipher {
+        let key = *b"an example very very secret key!";
+        FieldCipher::new(&key, KEY_ID_V1)
+    }
+
+    fn make_client(secret: Option<String>) -> Client {
+        let now = chrono::Utc::now();
+        Client {
+            id: Uuid::new_v4(),
+            enabled: true,
+            client_id: "test-client".to_string(),
+            secret,
+            realm_id: RealmId::from(Uuid::new_v4()),
+            protocol: "openid-connect".to_string(),
+            public_client: false,
+            service_account_enabled: false,
+            direct_access_grants_enabled: false,
+            oauth_device_code_grant_enabled: false,
+            require_pkce: false,
+            client_type: ClientType::Confidential,
+            name: "Test".to_string(),
+            redirect_uris: None,
+            access_token_lifetime: None,
+            refresh_token_lifetime: None,
+            id_token_lifetime: None,
+            temporary_token_lifetime: None,
+            maintenance_enabled: false,
+            maintenance_reason: None,
+            maintenance_session_strategy: MaintenanceSessionStrategy::Expire,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn decrypt_client_decrypts_enc_prefixed_secret() {
+        let cipher = test_cipher();
+        let plaintext = "my-client-secret";
+        let blob = cipher.encrypt(plaintext).unwrap();
+        let enc_value = format!("enc:{blob}");
+
+        let client = make_client(Some(enc_value));
+
+        struct Dummy;
+        impl ClientRepository for Dummy {
+            async fn create_client(&self, _: CreateClientRequest) -> Result<Client, CoreError> {
+                unimplemented!()
+            }
+            async fn get_by_client_id(&self, _: String, _: RealmId) -> Result<Client, CoreError> {
+                unimplemented!()
+            }
+            async fn get_by_id(&self, _: Uuid) -> Result<Client, CoreError> {
+                unimplemented!()
+            }
+            async fn get_by_realm_id(&self, _: RealmId) -> Result<Vec<Client>, CoreError> {
+                unimplemented!()
+            }
+            async fn update_client(
+                &self,
+                _: Uuid,
+                _: UpdateClientRequest,
+            ) -> Result<Client, CoreError> {
+                unimplemented!()
+            }
+            async fn delete_by_id(&self, _: Uuid) -> Result<(), CoreError> {
+                unimplemented!()
+            }
+        }
+
+        let repo = EncryptingClientRepository::new(Arc::new(Dummy), Some(cipher));
+        let result = repo.decrypt_client(client).unwrap();
+        assert_eq!(result.secret, Some(plaintext.to_string()));
+    }
+
+    #[test]
+    fn decrypt_client_passes_through_plaintext_sentinel() {
+        struct Dummy;
+        impl ClientRepository for Dummy {
+            async fn create_client(&self, _: CreateClientRequest) -> Result<Client, CoreError> {
+                unimplemented!()
+            }
+            async fn get_by_client_id(&self, _: String, _: RealmId) -> Result<Client, CoreError> {
+                unimplemented!()
+            }
+            async fn get_by_id(&self, _: Uuid) -> Result<Client, CoreError> {
+                unimplemented!()
+            }
+            async fn get_by_realm_id(&self, _: RealmId) -> Result<Vec<Client>, CoreError> {
+                unimplemented!()
+            }
+            async fn update_client(
+                &self,
+                _: Uuid,
+                _: UpdateClientRequest,
+            ) -> Result<Client, CoreError> {
+                unimplemented!()
+            }
+            async fn delete_by_id(&self, _: Uuid) -> Result<(), CoreError> {
+                unimplemented!()
+            }
+        }
+
+        let cipher = test_cipher();
+        let repo = EncryptingClientRepository::new(Arc::new(Dummy), Some(cipher));
+
+        let client = make_client(Some("legacy-plaintext-secret".to_string()));
+        let result = repo.decrypt_client(client).unwrap();
+        assert_eq!(
+            result.secret,
+            Some("legacy-plaintext-secret".to_string()),
+            "pre-migration plaintext should pass through unchanged"
+        );
+    }
+}

--- a/libs/ferriskey-security/Cargo.toml
+++ b/libs/ferriskey-security/Cargo.toml
@@ -6,12 +6,14 @@ edition.workspace = true
 
 [dependencies]
 ferriskey-domain = { path = "../ferriskey-domain" }
+aes-gcm = "0.10"
 argon2 = "0.5.3"
 base64 = "0.22.1"
 chrono = "0.4.43"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 rand = "0.8.0"
 rsa = "0.9.10"
+secrecy = { version = "0.8", features = ["serde"] }
 serde = "1.0.228"
 serde_json = "1.0.149"
 sha1 = "0.10.6"

--- a/libs/ferriskey-security/src/cipher/field_cipher.rs
+++ b/libs/ferriskey-security/src/cipher/field_cipher.rs
@@ -1,0 +1,157 @@
+// aes-gcm 0.10 re-exports the older generic-array 0.14 types; the deprecation
+// warnings below are cosmetic and safe to silence until aes-gcm publishes a
+// 0.11 release based on generic-array 1.x.
+#[allow(deprecated)]
+use aes_gcm::{
+    Aes256Gcm, KeyInit, Nonce,
+    aead::{Aead, AeadCore, KeySizeUser, OsRng, generic_array::GenericArray},
+};
+use base64::{Engine, engine::general_purpose::STANDARD};
+
+use crate::SecurityError;
+
+/// Blob layout stored in the database (base64-encoded):
+///
+/// ```text
+/// | key_id (1 byte) | nonce (12 bytes) | ciphertext + GCM tag |
+/// ```
+///
+/// `key_id` is a single byte identifying which key was used. Value `0` is
+/// reserved as a sentinel meaning "plaintext — not yet encrypted". Values
+/// `1..=255` reference versioned master keys.
+///
+/// Backfill: existing rows with `secret_key_id IS NULL` are read as plaintext.
+/// A future migration job sets `secret_key_id = "v1"` after re-encrypting.
+pub const SENTINEL_PLAINTEXT: u8 = 0;
+pub const KEY_ID_V1: u8 = 1;
+
+/// AES-256-GCM authenticated field cipher. Thread-safe and cheap to clone.
+#[derive(Clone)]
+pub struct FieldCipher {
+    key_id: u8,
+    cipher: Aes256Gcm,
+}
+
+impl std::fmt::Debug for FieldCipher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FieldCipher")
+            .field("key_id", &self.key_id)
+            .field("cipher", &"<AES-256-GCM>")
+            .finish()
+    }
+}
+
+impl FieldCipher {
+    /// Build from a 32-byte master key and a key identifier byte.
+    pub fn new(key_bytes: &[u8; 32], key_id: u8) -> Self {
+        #[allow(deprecated)]
+        let key: &GenericArray<u8, <Aes256Gcm as KeySizeUser>::KeySize> =
+            GenericArray::from_slice(key_bytes);
+        Self {
+            key_id,
+            cipher: Aes256Gcm::new(key),
+        }
+    }
+
+    /// Encrypt `plaintext` and return a base64-encoded blob.
+    pub fn encrypt(&self, plaintext: &str) -> Result<String, SecurityError> {
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ciphertext = self
+            .cipher
+            .encrypt(&nonce, plaintext.as_bytes())
+            .map_err(|e| SecurityError::GenerationError(e.to_string()))?;
+
+        let mut blob = Vec::with_capacity(1 + 12 + ciphertext.len());
+        blob.push(self.key_id);
+        #[allow(deprecated)]
+        blob.extend_from_slice(nonce.as_ref());
+        blob.extend_from_slice(&ciphertext);
+
+        Ok(STANDARD.encode(&blob))
+    }
+
+    /// Decrypt a base64-encoded blob produced by [`FieldCipher::encrypt`].
+    pub fn decrypt(&self, blob: &str) -> Result<String, SecurityError> {
+        let raw = STANDARD
+            .decode(blob)
+            .map_err(|e| SecurityError::ParsingError(e.to_string()))?;
+
+        if raw.len() < 1 + 12 + 16 {
+            return Err(SecurityError::ParsingError(
+                "encrypted blob too short".to_string(),
+            ));
+        }
+
+        let _stored_key_id = raw[0];
+        #[allow(deprecated)]
+        let nonce = Nonce::from_slice(&raw[1..13]);
+        let ciphertext = &raw[13..];
+
+        let plaintext_bytes = self
+            .cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|_| SecurityError::ValidationError("decryption failed".to_string()))?;
+
+        String::from_utf8(plaintext_bytes).map_err(|e| SecurityError::ParsingError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> [u8; 32] {
+        *b"an example very very secret key!"
+    }
+
+    fn cipher() -> FieldCipher {
+        FieldCipher::new(&test_key(), KEY_ID_V1)
+    }
+
+    #[test]
+    fn field_cipher_round_trip() {
+        let c = cipher();
+        let plaintext = "super-secret-client-password-123";
+        let blob = c.encrypt(plaintext).expect("encrypt");
+        let recovered = c.decrypt(&blob).expect("decrypt");
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn field_cipher_tamper_detection() {
+        let c = cipher();
+        let blob = c.encrypt("sensitive-value").expect("encrypt");
+
+        let mut raw = base64::engine::general_purpose::STANDARD
+            .decode(&blob)
+            .unwrap();
+        let last = raw.len() - 1;
+        raw[last] ^= 0xff;
+        let tampered = STANDARD.encode(&raw);
+
+        let result = c.decrypt(&tampered);
+        assert!(
+            result.is_err(),
+            "tampered ciphertext should not decrypt successfully"
+        );
+    }
+
+    #[test]
+    fn field_cipher_wrong_key() {
+        let c = cipher();
+        let blob = c.encrypt("another-secret").expect("encrypt");
+
+        let wrong_key = *b"totally different key totally!!!";
+        let wrong_cipher = FieldCipher::new(&wrong_key, KEY_ID_V1);
+
+        let result = wrong_cipher.decrypt(&blob);
+        assert!(result.is_err(), "wrong key should not decrypt successfully");
+    }
+
+    #[test]
+    fn field_cipher_empty_blob_rejected() {
+        let c = cipher();
+        let result = c.decrypt("");
+        assert!(result.is_err());
+    }
+}

--- a/libs/ferriskey-security/src/cipher/mod.rs
+++ b/libs/ferriskey-security/src/cipher/mod.rs
@@ -1,0 +1,2 @@
+pub mod field_cipher;
+pub mod secrets;

--- a/libs/ferriskey-security/src/cipher/secrets.rs
+++ b/libs/ferriskey-security/src/cipher/secrets.rs
@@ -1,0 +1,106 @@
+use secrecy::SecretString;
+
+use crate::SecurityError;
+
+/// Abstraction over any secret-delivery backend (env vars, files, Vault, KMS …).
+///
+/// ## Implementations shipped in this crate
+/// - [`EnvSecretsProvider`] — reads secrets from environment variables or file
+///   paths.  This is the default for most deployments.
+///
+/// ## Vault / KMS integration path (follow-up)
+/// To add HashiCorp Vault support, implement this trait as `VaultSecretsProvider`
+/// in a new crate (or behind a feature flag in this one). The `get_secret` method
+/// would call the Vault HTTP API (`GET /v1/secret/data/<name>`) and return the
+/// decoded value. Key lifecycle — rotation and re-encryption — should be wired
+/// through a separate job that iterates encrypted rows, decrypts with the old
+/// key, and re-encrypts with the new key before bumping `secret_key_id`.
+///
+/// All Vault or KMS communication MUST be over TLS; the TLS certificates for
+/// the Vault endpoint should be pinned or validated against the system trust
+/// store, never skipped.
+pub trait SecretsProvider: Send + Sync {
+    /// Retrieve a named secret. Fails closed: returns `Err` if the secret is
+    /// absent rather than returning an empty string.
+    fn get_secret(&self, name: &str) -> Result<SecretString, SecurityError>;
+}
+
+/// Reads secrets from environment variables.
+///
+/// The variable name is `FERRISKEY_SECRET_<NAME>` where `<NAME>` is the
+/// upper-cased form of the requested secret name. For example, requesting
+/// `"master_key"` looks up `FERRISKEY_SECRET_MASTER_KEY`.
+///
+/// An alternative file-based path is also supported: if the environment variable
+/// `FERRISKEY_SECRET_<NAME>_FILE` is set, the secret is read from that file
+/// path. This is convenient for Docker secrets and Kubernetes `secretKeyRef`
+/// volume mounts.
+#[derive(Debug, Clone, Default)]
+pub struct EnvSecretsProvider;
+
+impl EnvSecretsProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl SecretsProvider for EnvSecretsProvider {
+    fn get_secret(&self, name: &str) -> Result<SecretString, SecurityError> {
+        let env_name = format!("FERRISKEY_SECRET_{}", name.to_uppercase().replace('-', "_"));
+        let file_env_name = format!("{env_name}_FILE");
+
+        if let Ok(file_path) = std::env::var(&file_env_name) {
+            let contents = std::fs::read_to_string(&file_path).map_err(|e| {
+                SecurityError::InvalidKey(format!("failed to read secret file {file_path}: {e}"))
+            })?;
+            return Ok(SecretString::new(contents.trim().to_string()));
+        }
+
+        let value = std::env::var(&env_name).map_err(|_| {
+            SecurityError::InvalidKey(format!(
+                "secret '{name}' not found (set {env_name} or {file_env_name})"
+            ))
+        })?;
+
+        Ok(SecretString::new(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+
+    #[test]
+    fn env_secrets_provider_returns_value() {
+        // SAFETY: single-threaded test; no other thread races on this env var.
+        unsafe { std::env::set_var("FERRISKEY_SECRET_TEST_KEY_42", "my-secret-value") };
+        let provider = EnvSecretsProvider::new();
+        let secret = provider.get_secret("test_key_42").expect("should find key");
+        assert_eq!(secret.expose_secret(), "my-secret-value");
+        // SAFETY: same as above.
+        unsafe { std::env::remove_var("FERRISKEY_SECRET_TEST_KEY_42") };
+    }
+
+    #[test]
+    fn env_secrets_provider_missing_key_fails_closed() {
+        // SAFETY: single-threaded test.
+        unsafe { std::env::remove_var("FERRISKEY_SECRET_NONEXISTENT_KEY_XYZ") };
+        let provider = EnvSecretsProvider::new();
+        let result = provider.get_secret("nonexistent_key_xyz");
+        assert!(result.is_err(), "missing key must fail closed");
+    }
+
+    #[test]
+    fn env_secrets_provider_hyphen_normalized() {
+        // SAFETY: single-threaded test.
+        unsafe { std::env::set_var("FERRISKEY_SECRET_MY_KEY", "hyphen-ok") };
+        let provider = EnvSecretsProvider::new();
+        let secret = provider
+            .get_secret("my-key")
+            .expect("hyphen should normalize");
+        assert_eq!(secret.expose_secret(), "hyphen-ok");
+        // SAFETY: same as above.
+        unsafe { std::env::remove_var("FERRISKEY_SECRET_MY_KEY") };
+    }
+}

--- a/libs/ferriskey-security/src/lib.rs
+++ b/libs/ferriskey-security/src/lib.rs
@@ -1,7 +1,11 @@
 use thiserror::Error;
 
+pub mod cipher;
 pub mod crypto;
 pub mod jwt;
+
+pub use cipher::field_cipher::FieldCipher;
+pub use cipher::secrets::{EnvSecretsProvider, SecretsProvider};
 
 #[derive(Debug, Error)]
 pub enum SecurityError {
@@ -31,4 +35,13 @@ pub enum SecurityError {
 
     #[error("Expired token")]
     ExpiredToken,
+
+    #[error("Encryption error: {0}")]
+    EncryptionError(String),
+
+    #[error("Decryption error: {0}")]
+    DecryptionError(String),
+
+    #[error("Secret not found: {0}")]
+    SecretNotFound(String),
 }


### PR DESCRIPTION
## Summary
Foundational encryption-at-rest support (full KMS is follow-up):
- `FieldCipher` (AES-256-GCM, authenticated, random nonce per encryption, key-id-prefixed blob) in `libs/ferriskey-security`.
- `SecretsProvider` trait + a fully-implemented `EnvSecretsProvider` (env var + `_FILE` path); the Vault/KMS integration path is documented.
- End-to-end on client secrets: migration adds `secret_encrypted` + `secret_key_id`; `EncryptingClientRepository` transparently encrypts on write / decrypts on read; existing plaintext rows pass through safely (sentinel), with a documented backfill path.
- Config via Clap/env: `ENCRYPTION_ENABLED`, `ENCRYPTION_MASTER_KEY_SECRET`; fails closed when enabled without a key.

## Not in this PR (follow-up)
`VaultSecretsProvider` implementation, key-rotation/re-encryption job, legacy-row backfill, and encrypting other fields (SMTP passwords, webhook secrets).

## Tests
- Unit: 10 tests (encrypt/decrypt round-trip, tamper → auth-tag failure, wrong key fails, env provider, fail-closed on missing key).

## Reviewer notes
- SeaORM entity (`clients`) was hand-edited (no live DB) — regenerate with `sea-orm-cli` after applying the migration.
- Key lifecycle + TLS-in-transit expectations are documented in the `EncryptionArgs` config.

Closes #1099
Part of #1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional encryption for client secrets stored at rest.
  * Added configuration through environment variables, including master-key selection.
  * Added support for loading encryption keys from environment values or files.
  * Preserved compatibility with existing plaintext client secrets.

* **Bug Fixes**
  * Improved handling of encryption, decryption, and missing-secret errors with appropriate server error responses.

* **Tests**
  * Added coverage for encryption, decryption, tampering, key validation, and legacy plaintext behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->