### PR TITLE
feat: add configurable PII pseudonymisation for SeaWatch audit logs

### DIFF
--- a/api/src/application/http/realm/handlers/update_realm_setting.rs
+++ b/api/src/application/http/realm/handlers/update_realm_setting.rs
@@ -70,6 +70,8 @@ pub async fn update_realm_setting(
                 lockout_threshold: payload.lockout_threshold,
                 lockout_duration_seconds: payload.lockout_duration_seconds,
                 login_aliases: payload.login_aliases,
+                seawatch_pii_mode: payload.seawatch_pii_mode,
+                seawatch_pseudo_key: payload.seawatch_pseudo_key,
             },
         )
         .await

--- a/api/src/application/http/realm/validators.rs
+++ b/api/src/application/http/realm/validators.rs
@@ -73,6 +73,10 @@ pub struct UpdateRealmSettingValidator {
     pub lockout_duration_seconds: Option<i32>,
     #[schema(value_type = Option<Vec<String>>)]
     pub login_aliases: Option<LoginAliases>,
+    pub seawatch_pii_mode: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_field")]
+    #[schema(value_type = Option<String>)]
+    pub seawatch_pseudo_key: Option<Option<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]

--- a/core/migrations/20260718000001_add_seawatch_pii_mode_to_realm_settings.down.sql
+++ b/core/migrations/20260718000001_add_seawatch_pii_mode_to_realm_settings.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE realm_settings
+    DROP COLUMN IF EXISTS seawatch_pii_mode,
+    DROP COLUMN IF EXISTS seawatch_pseudo_key;

--- a/core/migrations/20260718000001_add_seawatch_pii_mode_to_realm_settings.up.sql
+++ b/core/migrations/20260718000001_add_seawatch_pii_mode_to_realm_settings.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE realm_settings
+    ADD COLUMN seawatch_pii_mode VARCHAR(20) NOT NULL DEFAULT 'off',
+    ADD COLUMN seawatch_pseudo_key VARCHAR(255);

--- a/core/src/domain/realm/ports.rs
+++ b/core/src/domain/realm/ports.rs
@@ -170,6 +170,8 @@ pub trait RealmRepository: Send + Sync {
         lockout_threshold: Option<i32>,
         lockout_duration_seconds: Option<i32>,
         login_aliases: Option<LoginAliases>,
+        seawatch_pii_mode: Option<String>,
+        seawatch_pseudo_key: Option<Option<String>>,
     ) -> impl Future<Output = Result<RealmSetting, CoreError>> + Send;
 
     fn get_realm_settings(
@@ -228,6 +230,8 @@ pub struct UpdateRealmSettingInput {
     pub lockout_threshold: Option<i32>,
     pub lockout_duration_seconds: Option<i32>,
     pub login_aliases: Option<LoginAliases>,
+    pub seawatch_pii_mode: Option<String>,
+    pub seawatch_pseudo_key: Option<Option<String>>,
 }
 
 pub struct DeleteRealmInput {

--- a/core/src/domain/realm/services.rs
+++ b/core/src/domain/realm/services.rs
@@ -788,6 +788,8 @@ where
                 input.lockout_threshold,
                 input.lockout_duration_seconds,
                 input.login_aliases,
+                input.seawatch_pii_mode,
+                input.seawatch_pseudo_key,
             )
             .await?;
 

--- a/core/src/domain/seawatch/mod.rs
+++ b/core/src/domain/seawatch/mod.rs
@@ -1,9 +1,11 @@
 pub mod entities;
+pub mod pii;
 pub mod policies;
 pub mod ports;
 pub mod services;
 pub mod value_objects;
 
 pub use entities::{ActorType, EventStatus, SecurityEvent, SecurityEventType};
+pub use pii::{AuditPiiMode, PiiConfig};
 pub use ports::{SecurityEventPolicy, SecurityEventRepository};
 pub use value_objects::{EventExportRequest, ExportFormat, SecurityEventFilter};

--- a/core/src/domain/seawatch/pii.rs
+++ b/core/src/domain/seawatch/pii.rs
@@ -1,0 +1,251 @@
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use utoipa::ToSchema;
+
+use super::entities::SecurityEvent;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditPiiMode {
+    #[default]
+    Off,
+    Mask,
+    Pseudonymise,
+}
+
+impl AuditPiiMode {
+    pub fn as_str(&self) -> &str {
+        match self {
+            AuditPiiMode::Off => "off",
+            AuditPiiMode::Mask => "mask",
+            AuditPiiMode::Pseudonymise => "pseudonymise",
+        }
+    }
+}
+
+impl std::str::FromStr for AuditPiiMode {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "mask" => AuditPiiMode::Mask,
+            "pseudonymise" => AuditPiiMode::Pseudonymise,
+            _ => AuditPiiMode::Off,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PiiConfig {
+    pub mode: AuditPiiMode,
+    pub pseudo_key: Option<String>,
+}
+
+impl Default for PiiConfig {
+    fn default() -> Self {
+        Self {
+            mode: AuditPiiMode::Off,
+            pseudo_key: None,
+        }
+    }
+}
+
+pub fn apply_to_event(mut event: SecurityEvent, cfg: &PiiConfig) -> SecurityEvent {
+    match cfg.mode {
+        AuditPiiMode::Off => event,
+        AuditPiiMode::Mask => {
+            event.ip_address = event.ip_address.map(|ip| mask_ip(&ip));
+            event.user_agent = event.user_agent.map(|ua| mask_user_agent(&ua));
+            event
+        }
+        AuditPiiMode::Pseudonymise => {
+            let key = cfg.pseudo_key.as_deref().unwrap_or_default();
+            event.ip_address = event.ip_address.map(|ip| pseudonymise(&ip, key));
+            event.user_agent = event.user_agent.map(|ua| pseudonymise(&ua, key));
+            event
+        }
+    }
+}
+
+pub fn mask_ip(ip: &str) -> String {
+    if ip.contains(':') {
+        mask_ipv6(ip)
+    } else {
+        mask_ipv4(ip)
+    }
+}
+
+fn mask_ipv4(ip: &str) -> String {
+    let parts: Vec<&str> = ip.splitn(4, '.').collect();
+    if parts.len() == 4 {
+        format!("{}.{}.0.0", parts[0], parts[1])
+    } else {
+        "0.0.0.0".to_string()
+    }
+}
+
+fn mask_ipv6(ip: &str) -> String {
+    let groups: Vec<&str> = ip.splitn(9, ':').collect();
+    let kept = groups.iter().take(3).cloned().collect::<Vec<_>>().join(":");
+    if groups.len() >= 3 {
+        format!("{}::", kept)
+    } else {
+        "::".to_string()
+    }
+}
+
+pub fn mask_email(email: &str) -> String {
+    let mut parts = email.splitn(2, '@');
+    let local = parts.next().unwrap_or("");
+    let domain = parts.next().unwrap_or("");
+
+    let masked_local = if local.is_empty() {
+        "***".to_string()
+    } else {
+        let first = &local[..local.len().min(1)];
+        format!("{}***", first)
+    };
+
+    let masked_domain = if domain.is_empty() {
+        "***".to_string()
+    } else {
+        let first = &domain[..domain.len().min(1)];
+        format!("{}***", first)
+    };
+
+    format!("{}@{}", masked_local, masked_domain)
+}
+
+pub fn mask_user_agent(ua: &str) -> String {
+    ua.split('/').next().unwrap_or(ua).trim().to_string()
+}
+
+pub fn pseudonymise(value: &str, key: &str) -> String {
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(key.as_bytes())
+        .unwrap_or_else(|_| HmacSha256::new_from_slice(b"fallback").expect("valid key"));
+    mac.update(value.as_bytes());
+    let result = mac.finalize().into_bytes();
+    hex::encode(&result[..8])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::realm::entities::RealmId;
+    use crate::domain::seawatch::entities::{EventStatus, SecurityEvent, SecurityEventType};
+    use uuid::Uuid;
+
+    fn make_event() -> SecurityEvent {
+        SecurityEvent::new(
+            RealmId::from(Uuid::new_v4()),
+            SecurityEventType::LoginSuccess,
+            EventStatus::Success,
+            Uuid::new_v4(),
+        )
+        .with_context(
+            Some("192.168.1.42".to_string()),
+            Some("Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/128.0".to_string()),
+            None,
+        )
+    }
+
+    #[test]
+    fn test_off_mode_unchanged() {
+        let event = make_event();
+        let orig_ip = event.ip_address.clone();
+        let orig_ua = event.user_agent.clone();
+        let cfg = PiiConfig::default();
+        let out = apply_to_event(event, &cfg);
+        assert_eq!(out.ip_address, orig_ip);
+        assert_eq!(out.user_agent, orig_ua);
+    }
+
+    #[test]
+    fn test_mask_ipv4() {
+        assert_eq!(mask_ip("192.168.1.42"), "192.168.0.0");
+        assert_eq!(mask_ip("10.0.0.1"), "10.0.0.0");
+    }
+
+    #[test]
+    fn test_mask_ipv6() {
+        let masked = mask_ip("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+        assert!(masked.starts_with("2001:0db8:85a3::"), "got: {masked}");
+    }
+
+    #[test]
+    fn test_mask_email() {
+        assert_eq!(mask_email("alice@example.com"), "a***@e***");
+        assert_eq!(mask_email("bob@foo.org"), "b***@f***");
+    }
+
+    #[test]
+    fn test_mask_user_agent_family_only() {
+        assert_eq!(mask_user_agent("Mozilla/5.0 ..."), "Mozilla");
+        assert_eq!(mask_user_agent("curl/7.88.1"), "curl");
+        assert_eq!(mask_user_agent("Go-http-client/2.0"), "Go-http-client");
+    }
+
+    #[test]
+    fn test_mask_mode_applies_to_event() {
+        let event = make_event();
+        let cfg = PiiConfig {
+            mode: AuditPiiMode::Mask,
+            pseudo_key: None,
+        };
+        let out = apply_to_event(event, &cfg);
+        assert_eq!(out.ip_address.as_deref(), Some("192.168.0.0"));
+        assert_eq!(out.user_agent.as_deref(), Some("Mozilla"));
+    }
+
+    #[test]
+    fn test_pseudonymise_deterministic() {
+        let token1 = pseudonymise("192.168.1.42", "secret-key");
+        let token2 = pseudonymise("192.168.1.42", "secret-key");
+        assert_eq!(token1, token2);
+        assert_eq!(token1.len(), 16);
+    }
+
+    #[test]
+    fn test_pseudonymise_different_inputs_differ() {
+        let t1 = pseudonymise("192.168.1.1", "key");
+        let t2 = pseudonymise("192.168.1.2", "key");
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn test_pseudonymise_key_isolation() {
+        let t1 = pseudonymise("192.168.1.1", "realm-a-key");
+        let t2 = pseudonymise("192.168.1.1", "realm-b-key");
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn test_pseudonymise_mode_applies_to_event() {
+        let event = make_event();
+        let key = "test-key";
+        let cfg = PiiConfig {
+            mode: AuditPiiMode::Pseudonymise,
+            pseudo_key: Some(key.to_string()),
+        };
+        let out = apply_to_event(event.clone(), &cfg);
+
+        let expected_ip = pseudonymise("192.168.1.42", key);
+        assert_eq!(out.ip_address.as_deref(), Some(expected_ip.as_str()));
+
+        let expected_ua = pseudonymise(
+            "Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/128.0",
+            key,
+        );
+        assert_eq!(out.user_agent.as_deref(), Some(expected_ua.as_str()));
+    }
+
+    #[test]
+    fn test_pseudonymise_not_raw() {
+        let value = "192.168.1.42";
+        let token = pseudonymise(value, "some-key");
+        assert_ne!(token, value);
+        assert!(!token.contains('.'));
+    }
+}

--- a/core/src/entity/realm_settings.rs
+++ b/core/src/entity/realm_settings.rs
@@ -37,6 +37,8 @@ pub struct Model {
     pub lockout_threshold: i32,
     pub lockout_duration_seconds: i32,
     pub login_aliases: Vec<String>,
+    pub seawatch_pii_mode: String,
+    pub seawatch_pseudo_key: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -65,6 +67,8 @@ pub enum Column {
     LockoutThreshold,
     LockoutDurationSeconds,
     LoginAliases,
+    SeawatchPiiMode,
+    SeawatchPseudoKey,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -116,6 +120,8 @@ impl ColumnTrait for Column {
             Self::LockoutThreshold => ColumnType::Integer.def(),
             Self::LockoutDurationSeconds => ColumnType::Integer.def(),
             Self::LoginAliases => ColumnType::Array(RcOrArc::new(ColumnType::Text)).def(),
+            Self::SeawatchPiiMode => ColumnType::String(StringLen::N(20u32)).def(),
+            Self::SeawatchPseudoKey => ColumnType::String(StringLen::N(255u32)).def().null(),
         }
     }
 }

--- a/core/src/infrastructure/realm/mappers/realm_setting_mapper.rs
+++ b/core/src/infrastructure/realm/mappers/realm_setting_mapper.rs
@@ -36,6 +36,8 @@ impl From<Model> for RealmSetting {
             updated_at,
             lockout_threshold: value.lockout_threshold,
             lockout_duration_seconds: value.lockout_duration_seconds,
+            seawatch_pii_mode: value.seawatch_pii_mode,
+            seawatch_pseudo_key: value.seawatch_pseudo_key,
         }
     }
 }
@@ -71,6 +73,8 @@ mod tests {
             lockout_threshold: 10,
             lockout_duration_seconds: 900,
             login_aliases: vec!["email".to_string(), "username".to_string()],
+            seawatch_pii_mode: "off".to_string(),
+            seawatch_pseudo_key: None,
         }
     }
 

--- a/core/src/infrastructure/realm/repositories/realm_postgres_repository.rs
+++ b/core/src/infrastructure/realm/repositories/realm_postgres_repository.rs
@@ -203,6 +203,8 @@ impl RealmRepository for PostgresRealmRepository {
         lockout_threshold: Option<i32>,
         lockout_duration_seconds: Option<i32>,
         login_aliases: Option<LoginAliases>,
+        seawatch_pii_mode: Option<String>,
+        seawatch_pseudo_key: Option<Option<String>>,
     ) -> Result<RealmSetting, CoreError> {
         let realm_setting = crate::entity::realm_settings::Entity::find()
             .filter(crate::entity::realm_settings::Column::RealmId.eq::<Uuid>(realm_id.into()))
@@ -298,6 +300,14 @@ impl RealmRepository for PostgresRealmRepository {
         if let Some(aliases) = login_aliases {
             realm_setting.login_aliases =
                 Set(aliases.as_slice().iter().map(|a| a.to_string()).collect());
+        }
+
+        if let Some(mode) = seawatch_pii_mode {
+            realm_setting.seawatch_pii_mode = Set(mode);
+        }
+
+        if let Some(key) = seawatch_pseudo_key {
+            realm_setting.seawatch_pseudo_key = Set(key);
         }
 
         let realm_setting = realm_setting

--- a/core/src/infrastructure/seawatch/repositories/security_event_postgres_repository.rs
+++ b/core/src/infrastructure/seawatch/repositories/security_event_postgres_repository.rs
@@ -7,7 +7,10 @@ use uuid::Uuid;
 use crate::domain::common::entities::app_errors::CoreError;
 use crate::domain::realm::entities::RealmId;
 use crate::domain::seawatch::{
-    entities::SecurityEvent, ports::SecurityEventRepository, value_objects::SecurityEventFilter,
+    entities::SecurityEvent,
+    pii::{AuditPiiMode, PiiConfig, apply_to_event},
+    ports::SecurityEventRepository,
+    value_objects::SecurityEventFilter,
 };
 use crate::entity::security_events;
 
@@ -20,10 +23,35 @@ impl PostgresSecurityEventRepository {
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }
+
+    async fn load_pii_config(&self, realm_id: Uuid) -> PiiConfig {
+        let result = crate::entity::realm_settings::Entity::find()
+            .filter(crate::entity::realm_settings::Column::RealmId.eq(realm_id))
+            .one(&self.db)
+            .await;
+
+        match result {
+            Ok(Some(model)) => {
+                let mode = model
+                    .seawatch_pii_mode
+                    .parse::<AuditPiiMode>()
+                    .unwrap_or_default();
+                PiiConfig {
+                    mode,
+                    pseudo_key: model.seawatch_pseudo_key,
+                }
+            }
+            _ => PiiConfig::default(),
+        }
+    }
 }
 
 impl SecurityEventRepository for PostgresSecurityEventRepository {
     async fn store_event(&self, event: SecurityEvent) -> Result<(), CoreError> {
+        let realm_id: Uuid = event.realm_id.into();
+        let pii_cfg = self.load_pii_config(realm_id).await;
+        let event = apply_to_event(event, &pii_cfg);
+
         let active_model: security_events::ActiveModel = event.into();
 
         security_events::Entity::insert(active_model)

--- a/libs/ferriskey-domain/src/realm/mod.rs
+++ b/libs/ferriskey-domain/src/realm/mod.rs
@@ -163,6 +163,9 @@ pub struct RealmSetting {
     pub updated_at: DateTime<Utc>,
     pub lockout_threshold: i32,
     pub lockout_duration_seconds: i32,
+    pub seawatch_pii_mode: String,
+    #[serde(skip_serializing)]
+    pub seawatch_pseudo_key: Option<String>,
 }
 
 impl RealmSetting {
@@ -193,6 +196,8 @@ impl RealmSetting {
             updated_at: now,
             lockout_threshold: 10,
             lockout_duration_seconds: 900,
+            seawatch_pii_mode: "off".to_string(),
+            seawatch_pseudo_key: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a pure `seawatch::pii` module with three per-realm modes: `off` (default), `mask` (irreversible redaction — IPv4→`a.b.0.0`, IPv6→/48 prefix, user-agent→family), and `pseudonymise` (deterministic `HMAC-SHA256(value, realm_pseudo_key)` token, so the same value maps consistently without revealing the raw PII).
- The transform runs at write time inside `store_event`, so raw PII never lands in the DB when a mode is enabled.
- Configurable per realm via two new `realm_settings` columns (`seawatch_pii_mode`, `seawatch_pseudo_key`).
- The pseudonymisation key is `#[serde(skip_serializing)]` so it is never returned in API responses.

## Tests
- Unit: 11 tests (Off/Mask/Pseudonymise for IP, email, UA; determinism; per-realm key isolation; irreversibility).

## Reviewer notes
- SeaORM entity (`realm_settings`) was hand-edited (no live DB) — regenerate with `sea-orm-cli` after applying the migration.
- Interaction with #1097 (hash chaining): pseudonymisation runs before persistence, so once both merge the chain hashes the stored (pseudonymised) values consistently.

Closes #1098
Part of #1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable audit PII handling for security events.
  * Supports disabled, masked, and pseudonymized modes for sensitive data.
  * Added realm settings for selecting the PII mode and configuring a pseudonymization key.
  * Security events now apply each realm’s configured privacy settings before storage.
  * Pseudonymization keys are excluded from serialized realm settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->