### PR TITLE
docs: add OIDC conformance runbook, support matrix and self-certification path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 **/.DS_Store
 
 openapi.json
+
+# OIDF conformance suite result exports (large ZIPs — keep locally only)
+conformance/results/

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,33 @@
+# Conformance Configuration Templates
+
+This directory contains configuration templates for running the
+[OpenID Foundation conformance suite](https://www.certification.openid.net/)
+against a FerrisKey instance.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `basic-certification.json` | Test plan config for the Basic OP + Config OP profiles |
+| `results/` | Local only (gitignored) — store per-run ZIP exports here |
+
+## Quick start
+
+1. Copy `basic-certification.json` and replace the `<placeholder>` values:
+   - `<FERRISKEY_BASE_URL>` — your FerrisKey instance hostname (HTTPS)
+   - `<REALM_NAME>` — the realm to test against
+   - `<CLIENT_SECRET>` — the client secret for `oidf-conformance-client`
+   - `<YOUR_TEST_ALIAS>` — the alias you set when creating the plan on the OIDF server
+
+2. Follow the full runbook at [`docs/compliance/oidc-conformance-runbook.md`](../docs/compliance/oidc-conformance-runbook.md).
+
+3. After a passing run, consult [`docs/compliance/oidc-selfcert-path.md`](../docs/compliance/oidc-selfcert-path.md)
+   for submission instructions.
+
+## Current status
+
+See [`docs/compliance/oidc-support-matrix.md`](../docs/compliance/oidc-support-matrix.md)
+for the current PASS / PARTIAL / GAP assessment against the codebase.
+
+Blocking gaps before a passing Basic OP run: GAP-01 (PKCE inbound), GAP-02 (nonce
+in ID token), GAP-04 (discovery fields), GAP-05 (nonce capture at `/auth`).

--- a/conformance/basic-certification.json
+++ b/conformance/basic-certification.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "OIDF Conformance Suite — Basic OP test plan configuration for FerrisKey.",
+  "_comment2": "Replace every <placeholder> value before use. See docs/compliance/oidc-conformance-runbook.md.",
+  "alias": "<YOUR_TEST_ALIAS>",
+  "description": "FerrisKey Basic OP conformance run — realm: <REALM_NAME>",
+  "server": {
+    "discoveryUrl": "https://<FERRISKEY_BASE_URL>/realms/<REALM_NAME>/.well-known/openid-configuration"
+  },
+  "client": {
+    "client_id": "oidf-conformance-client",
+    "client_secret": "<CLIENT_SECRET>",
+    "redirect_uri": "https://www.certification.openid.net/test/a/<YOUR_TEST_ALIAS>/callback",
+    "post_logout_redirect_uri": "https://www.certification.openid.net/test/a/<YOUR_TEST_ALIAS>/post-logout-redirect"
+  },
+  "resource": {
+    "resourceUrl": "https://<FERRISKEY_BASE_URL>/realms/<REALM_NAME>/protocol/openid-connect/userinfo"
+  },
+  "override": {
+    "send_authentication_request_as_signed_request_object": false,
+    "request_object_signing_alg": "none",
+    "fapi_auth_request_method": "by_value"
+  }
+}

--- a/docs/compliance/oidc-conformance-runbook.md
+++ b/docs/compliance/oidc-conformance-runbook.md
@@ -1,0 +1,186 @@
+# OIDC Conformance Suite Runbook
+
+This runbook describes how to run the OpenID Foundation (OIDF) conformance suite
+against a FerrisKey instance and capture the results needed for self-certification.
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| FerrisKey instance reachable over HTTPS | Self-signed certs are accepted by the suite if you set the flag below |
+| Publicly reachable base URL (or local tunnel) | The OIDF server makes outbound calls to your instance |
+| A realm created and an OIDC client registered | See [Client registration](#2-register-a-conformance-client) |
+| A test user account in that realm | Used by the interactive authorization\_code flow tests |
+| Node.js ≥ 18 **or** Docker (for the local conformance server option) | See [Suite options](#suite-options) |
+
+---
+
+## Suite options
+
+**Option A — OIDF hosted server (recommended)**
+Use <https://www.certification.openid.net/>. No local install required. Results
+are stored on the OIDF server and can be used directly for self-certification
+evidence.
+
+**Option B — Self-hosted suite**
+
+```bash
+git clone https://gitlab.com/openid/conformance-suite.git
+cd conformance-suite
+# Requires Docker Compose
+docker-compose up
+# Server available at http://localhost:8080
+```
+
+The remaining steps are the same for both options.
+
+---
+
+## Step 1 — Configure the FerrisKey instance
+
+FerrisKey must serve its discovery document at the correct well-known URL.
+Verify it is reachable before starting:
+
+```bash
+# Replace <base_url> and <realm> with your values
+curl https://<base_url>/realms/<realm>/.well-known/openid-configuration | jq .
+```
+
+Expected fields at minimum: `issuer`, `authorization_endpoint`,
+`token_endpoint`, `jwks_uri`, `userinfo_endpoint`.
+
+**Environment variables for the API instance:**
+
+```bash
+PORT=3333
+ALLOWED_ORIGINS=https://<base_url>
+# Ensure the instance is exposed over TLS (use a reverse proxy if needed)
+```
+
+---
+
+## Step 2 — Register a conformance client
+
+Use the FerrisKey admin console or API to create an **OpenID Connect** client
+in your test realm with the following settings:
+
+| Field | Value |
+|---|---|
+| Client ID | `oidf-conformance-client` (or any name you choose) |
+| Client secret | generate a strong random secret |
+| Access type | Confidential |
+| Redirect URIs | `https://www.certification.openid.net/test/a/<YOUR_TEST_ALIAS>/callback` |
+| Post-logout redirect URIs | `https://www.certification.openid.net/test/a/<YOUR_TEST_ALIAS>/post-logout-redirect` |
+| Standard flow (authorization\_code) | Enabled |
+| Direct access grants (password) | Enabled (required for some test variants) |
+| Grant types | `authorization_code`, `refresh_token`, `client_credentials` |
+| Response types | `code` |
+| Scopes | `openid`, `profile`, `email` |
+
+> Replace `<YOUR_TEST_ALIAS>` with the alias you enter when you create the test
+> plan on the OIDF server.
+
+---
+
+## Step 3 — Create a test plan on the OIDF server
+
+1. Go to <https://www.certification.openid.net/> and sign in (or use the local
+   server at `http://localhost:8080`).
+2. Click **Create a new test plan**.
+3. Select the plan appropriate to the profiles you want to certify:
+   - **Basic OP** — the baseline profile (recommended first run).
+   - **Config OP** — tests the discovery / metadata endpoints.
+   - **Hybrid OP**, **Implicit OP** — only if those flows are needed.
+4. Set the **Alias** (used in redirect URI construction above).
+5. Fill in the **Server metadata** section:
+
+```json
+{
+  "server": {
+    "discoveryUrl": "https://<base_url>/realms/<realm>/.well-known/openid-configuration"
+  },
+  "client": {
+    "client_id": "oidf-conformance-client",
+    "client_secret": "<your_client_secret>"
+  },
+  "resource": {
+    "resourceUrl": "https://<base_url>/realms/<realm>/protocol/openid-connect/userinfo"
+  }
+}
+```
+
+6. Click **Create test plan**.
+
+---
+
+## Step 4 — Run the tests
+
+The suite presents individual test modules. Run them in order:
+
+1. **oidcc-server-rotate-keys** — JWKS rotation (can skip if key rotation not yet implemented).
+2. **oidcc-discovery-endpoint-test** — validates the `.well-known/openid-configuration` response.
+3. **oidcc-basic-*** — the authorization\_code flow tests.
+4. **oidcc-userinfo-*** — userinfo endpoint tests.
+5. **oidcc-logout-*** — RP-Initiated Logout tests.
+
+For tests that require user interaction (login page), the suite will pause and
+display a URL to open in a browser. Complete the login as the test user you
+created, then return to the suite.
+
+---
+
+## Step 5 — Capture and export results
+
+After all modules in a test plan have run:
+
+1. Click **Export** on the test plan summary page.
+2. Download the JSON export (`conformance-suite-results-<alias>.zip`).
+3. Store the export in `conformance/results/` in the repository (gitignored by
+   default — add only if you want to check in evidence).
+
+The JSON log contains the test plan ID, timestamp, and pass/fail per module.
+This is the artefact you upload when submitting for self-certification.
+
+---
+
+## Step 6 — Re-run after fixes
+
+After addressing the gaps listed in `oidc-gap-triage.md`, re-run the full
+test plan from Step 3. Each run produces a new plan ID. Keep the latest
+passing run as your certification evidence.
+
+---
+
+## Useful endpoints reference
+
+All endpoints are scoped under `/realms/<realm>/protocol/openid-connect/`.
+
+| Endpoint | URL suffix |
+|---|---|
+| Discovery | `/.well-known/openid-configuration` (realm-level path) |
+| Authorization | `/auth` |
+| Token | `/token` |
+| UserInfo | `/userinfo` |
+| JWKS | `/jwks.json` or `/certs` |
+| Introspection | `/token/introspect` |
+| Revocation | `/revoke` |
+| End Session | `/logout` |
+
+Full discovery URL pattern:
+```
+https://<base_url>/realms/<realm>/.well-known/openid-configuration
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Resolution |
+|---|---|
+| `issuer mismatch` | Verify the `host` and `x-forwarded-proto` headers reach the API correctly behind a reverse proxy |
+| `nonce` claim missing from ID token | See gap `GAP-04` in `oidc-gap-triage.md` |
+| `code_challenge` rejected | PKCE is not yet enforced on the inbound authorization flow; see `GAP-01` |
+| `discovery` test fails on missing fields | See `GAP-05` in the gap triage doc |
+| Redirect URI rejected | Ensure the URI registered in FerrisKey matches exactly; avoid relying on regex matching |

--- a/docs/compliance/oidc-gap-triage.md
+++ b/docs/compliance/oidc-gap-triage.md
@@ -1,0 +1,157 @@
+# OIDC Conformance Gap Triage
+
+Each item below is a self-contained follow-up issue ready to file against the
+`#1090` milestone. Items are ordered by conformance impact (blocking the OIDF
+Basic OP or Config OP suite first).
+
+---
+
+## GAP-01 — PKCE enforcement on the inbound authorization\_code flow
+
+**Title:** feat: enforce PKCE (RFC 7636) on the inbound authorization\_code flow
+
+**Scope:**
+Accept `code_challenge` and `code_challenge_method=S256` on the `/auth` endpoint
+(`AuthRequest`, `AuthInput`, `AuthSession`). Store the challenge. At token exchange
+(`/token` with `grant_type=authorization_code`), require the caller to supply
+`code_verifier` in `ExchangeTokenInput` and verify
+`BASE64URL(SHA256(verifier)) == stored_challenge`. Reject the exchange with
+`invalid_grant` if absent or mismatched.
+
+PKCE is currently only implemented on the outgoing federation leg
+(`abyss/broker_services.rs`), not on FerrisKey's own authorization server role.
+The OIDF Basic OP suite sends `code_challenge` and will reject responses that
+ignore it.
+
+---
+
+## GAP-02 — `nonce` injection into the ID token
+
+**Title:** fix: propagate `nonce` from auth session into ID token claims
+
+**Scope:**
+`AuthSession.nonce` is stored (`entities.rs:38`) but the `IdTokenClaims` struct
+(`libs/ferriskey-security/src/jwt/entities.rs:64`) has no `nonce` field.
+Add `nonce: Option<String>` to `IdTokenClaims`. Thread the nonce from the auth
+session through `GenerateTokenInput` and into `create_jwt`.
+OIDC Core §3.1.2.1 requires the `nonce` be included in the ID token when it was
+present in the authorization request. The conformance suite always sends a nonce
+and verifies its presence in the ID token.
+
+**Dependency:** Also requires that `AuthRequest` (`auth.rs`) expose `nonce` as a
+query parameter so it is captured when the authorization flow starts.
+
+---
+
+## GAP-03 — `auth_time` claim in ID token
+
+**Title:** feat: populate `auth_time` claim in the ID token (OIDC Core §2)
+
+**Scope:**
+`IdTokenClaims.auth_time` is declared but always set to `None`
+(`services.rs:698`). Record the timestamp of the user's last interactive
+authentication (at session creation in `AuthSession`) and include it in the
+ID token. Required when `max_age` is sent in the authorization request.
+
+---
+
+## GAP-04 — Discovery document missing required and recommended metadata fields
+
+**Title:** fix: extend `.well-known/openid-configuration` to satisfy OIDC Discovery 1.0
+
+**Scope:**
+`GetOpenIdConfigurationResponse` (`openid_configuration.rs:12–23`) is missing
+the following fields required by OIDC Discovery 1.0 / RFC 8414:
+
+- `response_types_supported` (REQUIRED) — add `["code"]`
+- `subject_types_supported` (REQUIRED) — add `["public"]`
+- `id_token_signing_alg_values_supported` (REQUIRED) — add `["RS256"]`
+- `scopes_supported` (RECOMMENDED) — `["openid","profile","email","address","phone","offline_access"]`
+- `claims_supported` (RECOMMENDED) — list of standard claims returned
+- `code_challenge_methods_supported` (RECOMMENDED) — add `["S256"]` once GAP-01 is resolved
+- `response_modes_supported` (OPTIONAL but tested) — `["query"]`
+- `grant_types_supported` — add `urn:ietf:params:oauth:grant-type:device_code`
+
+The OIDF `oidcc-discovery-endpoint-test` validates all REQUIRED fields and many
+RECOMMENDED ones. Missing REQUIRED fields cause immediate test failure.
+
+---
+
+## GAP-05 — `nonce` not captured at the authorization endpoint
+
+**Title:** fix: add `nonce` query parameter to the authorization endpoint
+
+**Scope:**
+`AuthRequest` in `auth.rs` only captures `response_type`, `client_id`,
+`redirect_uri`, `scope`, and `state`. The `nonce` query parameter is silently
+dropped. Add `nonce: Option<String>` to `AuthRequest` and pass it through
+`AuthInput` → `AuthSession`. This is a prerequisite for GAP-02 (ID token nonce).
+
+---
+
+## GAP-06 — Redirect URI regex matching is overly permissive
+
+**Title:** fix: restrict redirect\_uri validation to exact match; remove regex fallback
+
+**Scope:**
+`services.rs:1945–1956` falls back to `regex::Regex::new(&uri.value)` when an
+exact match fails. Any URI pattern stored for a client is compiled as a regex and
+matched against arbitrary incoming `redirect_uri` values. This allows open-redirect
+attacks if a client URI contains unescaped regex metacharacters, and does not
+satisfy RFC 6749 §3.1.2 / OIDC Core §3.1.2.1 which require exact URI matching.
+Limit matching to exact equality only (remove the regex branch). Provide a
+wildcard mechanism through an explicit prefix-match configuration field if needed.
+
+---
+
+## GAP-07 — Signed UserInfo response (OPTIONAL but tested in some profiles)
+
+**Title:** feat: support signed UserInfo responses (`application/jwt`)
+
+**Scope:**
+OIDC Core §5.3.2 allows the UserInfo endpoint to return a signed JWT when the
+client has registered `userinfo_signed_response_alg`. Currently `userinfo.rs`
+returns plain JSON. Add opt-in signing when the client configuration requests it.
+Advertise `userinfo_signing_alg_values_supported` in the discovery document when
+implemented.
+
+---
+
+## GAP-08 — `acr` and `amr` claims in the ID token
+
+**Title:** feat: populate `acr` and `amr` claims in the ID token
+
+**Scope:**
+OIDC Core §2 defines `acr` (Authentication Context Class Reference) and `amr`
+(Authentication Methods References) as OPTIONAL standard ID token claims.
+The OIDF suite sends `acr_values` in authorization requests and checks that
+`acr` is reflected in the ID token. Add `acr: Option<String>` and
+`amr: Option<Vec<String>>` to `IdTokenClaims`; populate them from the
+authentication flow context (password, webauthn, totp, etc.).
+
+---
+
+## GAP-09 — Backchannel logout (OIDC Back-Channel Logout 1.0)
+
+**Title:** feat: implement OIDC Back-Channel Logout
+
+**Scope:**
+When a user session ends (via `/logout`), send a signed logout token (JWT with
+`events` claim) to each client's registered `backchannel_logout_uri`. Required for
+the `oidcc-rp-initiated-logout` and related session management test plans. Advertise
+`backchannel_logout_supported: true` in the discovery document once implemented.
+This is a larger feature; file as a dedicated milestone item under `#1090`.
+
+---
+
+## GAP-10 — `kid` continuity between signing key and JWKS
+
+**Title:** fix: verify `kid` in signed token headers matches the JWKS entry
+
+**Scope:**
+Tokens are signed with RS256. The JWKS endpoint returns `JwkKey` entries. The OIDF
+suite fetches the JWKS and matches the `kid` in the token header to validate the
+signature. Confirm that the `kid` embedded in the JWT header (`Header.kid`)
+exactly matches the `kid` in the JWKS response for the same key. Add an integration
+test that decodes a freshly-issued access token, extracts `kid`, fetches
+`/jwks.json`, and asserts a matching entry exists.

--- a/docs/compliance/oidc-selfcert-path.md
+++ b/docs/compliance/oidc-selfcert-path.md
@@ -1,0 +1,135 @@
+# OIDC Self-Certification Path
+
+This document describes how to submit FerrisKey conformance results to the
+OpenID Foundation (OIDF) self-certification programme once the identified gaps
+have been resolved.
+
+---
+
+## What self-certification is
+
+OIDF self-certification is a self-attestation programme: you run the OIDF-hosted
+conformance suite, upload the results, and the OIDF lists your software on
+<https://openid.net/certification/>. It is distinct from third-party certification
+(which requires a formal evaluation). Self-certification is free and carries no
+compliance audit.
+
+---
+
+## Profiles available for an OP (OpenID Provider)
+
+| Profile | Description | Priority |
+|---|---|---|
+| **Basic OP** | authorization\_code flow + ID token + UserInfo | Start here |
+| **Config OP** | Discovery endpoint completeness | Required for most deployments |
+| **Hybrid OP** | `code token` / `code id_token` response types | Not yet applicable |
+| **Implicit OP** | `token` / `id_token` response types | Not applicable (deprecated) |
+| **RP-Initiated Logout OP** | RP-Initiated Logout 1.0 | After logout improvements |
+| **FAPI 1.0 Advanced OP** | Financial-grade API | Future / post-gap resolution |
+
+Start with **Basic OP** and **Config OP** together — the OIDF requires both to
+be passing for a base listing.
+
+---
+
+## Prerequisites for submission
+
+Before submitting:
+
+1. All gaps marked as blocking for Basic OP and Config OP in `oidc-gap-triage.md`
+   must be resolved: GAP-01 (PKCE), GAP-02 (nonce in ID token), GAP-04 (discovery
+   fields), GAP-05 (nonce capture), GAP-06 (redirect URI validation).
+2. The conformance suite must pass all test modules in the chosen plan(s) with
+   no FAILURE results. WARNING results may be accepted for optional features.
+3. A public HTTPS endpoint for FerrisKey must be available at the time of the
+   submission run (the OIDF server makes live outbound calls).
+
+---
+
+## Submission procedure
+
+### Step 1 — Run the suite on the OIDF server
+
+Follow `oidc-conformance-runbook.md`. Use the hosted server at
+<https://www.certification.openid.net/> (not the local Docker option) — only
+results generated on the OIDF-hosted server are accepted for self-certification.
+
+### Step 2 — Export the result log
+
+On the test plan summary page:
+
+1. Confirm every test module shows PASSED (green).
+2. Click **Export** → download the ZIP.
+3. Note the **plan ID** shown in the URL (e.g. `plan-a1b2c3d4`).
+
+### Step 3 — Prepare the submission package
+
+The OIDF requires:
+
+- The exported JSON result log (from the ZIP).
+- A completed **self-certification form** (available at
+  <https://openid.net/certification/op-certification/>).
+  Key fields:
+  - Software name: `FerrisKey`
+  - Software version: the release tag (e.g. `v0.8.0`)
+  - Conformance profile(s): `Basic OP`, `Config OP`
+  - Test plan IDs: the plan IDs from Step 2
+  - Contact email: `security@ferriskey.rs` (or maintainer address)
+  - Open-source URL: `https://github.com/ferriskey/ferriskey`
+
+### Step 4 — Submit
+
+Email the completed form and result logs to `certification@oidf.org` or use the
+web submission at <https://openid.net/certification/op-certification/>.
+
+The OIDF typically processes submissions within a few business days. Once
+approved, FerrisKey will appear on the certified implementations page.
+
+---
+
+## Where to keep evidence in the repository
+
+```
+conformance/
+  results/               # gitignored — store per-run ZIPs locally
+  basic-certification.json   # test plan config template (tracked)
+docs/compliance/
+  oidc-conformance-runbook.md
+  oidc-support-matrix.md
+  oidc-gap-triage.md
+  oidc-selfcert-path.md    # this file
+```
+
+Add `conformance/results/` to `.gitignore` to avoid committing large JSON logs.
+If you want a specific passing run as a permanent record, extract the summary
+section and commit it as `conformance/results/summary-<version>.json`.
+
+---
+
+## Renewal
+
+Self-certification listings on the OIDF site are version-specific. Each new
+major or minor release that changes the OAuth/OIDC behaviour should trigger a
+fresh conformance run and submission. Add a checklist item to the release process
+in `CONTRIBUTING.md`:
+
+```
+- [ ] Run OIDF conformance suite (Basic OP + Config OP)
+- [ ] All modules PASS
+- [ ] Update conformance/results/summary-<version>.json
+- [ ] Submit to OIDF if significant protocol changes were made
+```
+
+---
+
+## References
+
+- OIDF Certification Programme: <https://openid.net/certification/>
+- Self-Certification How-To: <https://openid.net/certification/op-certification/>
+- Conformance Suite Repository: <https://gitlab.com/openid/conformance-suite>
+- Conformance Suite Hosted: <https://www.certification.openid.net/>
+- OpenID Connect Core 1.0: <https://openid.net/specs/openid-connect-core-1_0.html>
+- RFC 8414 (OAuth 2.0 Authorization Server Metadata): <https://www.rfc-editor.org/rfc/rfc8414>
+- RFC 7636 (PKCE): <https://www.rfc-editor.org/rfc/rfc7636>
+- RFC 7009 (Token Revocation): <https://www.rfc-editor.org/rfc/rfc7009>
+- RFC 7662 (Token Introspection): <https://www.rfc-editor.org/rfc/rfc7662>

--- a/docs/compliance/oidc-support-matrix.md
+++ b/docs/compliance/oidc-support-matrix.md
@@ -1,0 +1,185 @@
+# OIDC Conformance Support Matrix
+
+Verification status of OpenID Connect Core 1.0 and related RFC requirements
+against the FerrisKey codebase. Every claim is grounded in a specific source
+file; the "Evidence" column links to the relevant handler or domain module.
+
+Legend: **PASS** = fully implemented / **PARTIAL** = partially implemented /
+**GAP** = not implemented or incorrectly implemented.
+
+---
+
+## 1. Discovery — OpenID Provider Metadata (OIDC Discovery 1.0)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| `issuer` present and matches token `iss` | PASS | `openid_configuration.rs:58–59`; services.rs builds issuer from host header |
+| `authorization_endpoint` | PASS | `openid_configuration.rs:66` |
+| `token_endpoint` | PASS | `openid_configuration.rs:67` |
+| `userinfo_endpoint` | PASS | `openid_configuration.rs:71` |
+| `jwks_uri` | PASS | `openid_configuration.rs:72` — points to `/jwks.json` |
+| `revocation_endpoint` | PASS | `openid_configuration.rs:68` |
+| `end_session_endpoint` | PASS | `openid_configuration.rs:69` |
+| `introspection_endpoint` | PASS | `openid_configuration.rs:70` |
+| `response_types_supported` | GAP | Field absent from `GetOpenIdConfigurationResponse` struct |
+| `response_modes_supported` | GAP | Not advertised |
+| `grant_types_supported` | PARTIAL | Present in struct (`authorization_code`, `refresh_token`, `client_credentials`, `password`); missing `urn:ietf:params:oauth:grant-type:device_code` |
+| `subject_types_supported` | GAP | Not advertised |
+| `id_token_signing_alg_values_supported` | GAP | Not advertised (RS256 is used — see `services.rs:449`) |
+| `scopes_supported` | GAP | Not advertised |
+| `token_endpoint_auth_methods_supported` | PASS | `openid_configuration.rs:79–82` (`client_secret_basic`, `client_secret_post`) |
+| `claims_supported` | GAP | Not advertised |
+| `code_challenge_methods_supported` | GAP | Not advertised; PKCE inbound not implemented |
+| `request_parameter_supported` | GAP | Not advertised; JAR not implemented |
+| `request_uri_parameter_supported` | GAP | Not advertised; PAR not implemented |
+| `backchannel_logout_supported` | GAP | Not implemented |
+| `frontchannel_logout_supported` | GAP | Not implemented |
+
+**Summary:** The discovery document is structurally valid but missing ~10 required or
+strongly-recommended metadata fields (RFC 8414 / OIDC Discovery §3). The conformance
+suite's `oidcc-discovery-endpoint-test` will fail on missing fields.
+
+---
+
+## 2. Authorization Endpoint (OIDC Core §3.1.2)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| `response_type=code` accepted | PASS | `auth.rs` — `AuthRequest` passes `response_type` to `AuthInput`; `services.rs` creates auth session |
+| `state` echoed back in redirect | PASS | `services.rs:83–91` (`format_authorization_redirect_url`) — state echoed when non-empty |
+| `nonce` stored and bound to auth session | PARTIAL | `AuthSession` has `nonce` field (`entities.rs:38`); `nonce` is accepted in `AuthInput` but `AuthRequest` struct in `auth.rs` does NOT include a `nonce` query parameter — it is dropped |
+| `scope=openid` triggers ID token | PASS | `services.rs:670–714` — ID token emitted when `openid` in scope |
+| Redirect URI strict validation | PARTIAL | Exact match + regex fallback (`services.rs:1945–1956`); regex is overly permissive (noted in 2026-06 audit) |
+| `prompt` parameter | GAP | Not handled |
+| `max_age` parameter | GAP | `auth_time` always `None` in IdTokenClaims |
+| `display` parameter | GAP | Not handled |
+| `ui_locales` parameter | GAP | Not handled |
+| **PKCE** `code_challenge` / `code_challenge_method` | GAP | `AuthRequest` and `AuthInput` have no `code_challenge` fields; PKCE is only implemented on the outgoing federation leg (`abyss/broker_services.rs:104–174`) |
+
+---
+
+## 3. Token Endpoint (OIDC Core §3.1.3 + RFC 6749)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| `authorization_code` grant | PASS | `services.rs:921` (`authorization_code`) |
+| `refresh_token` grant | PASS | `services.rs:1215` (`refresh_token`) |
+| `client_credentials` grant | PASS | `services.rs` (`client_credential`) |
+| `password` grant | PASS | `services.rs` (`password`) |
+| Device Code grant (RFC 8628) | PASS | `token.rs:92–98` — dispatched to `poll_device_token` |
+| `client_secret_basic` authentication | PASS | `basic_auth.rs` — parsed in token handler |
+| `client_secret_post` authentication | PASS | `validators.rs` — `client_id` / `client_secret` form fields |
+| Refresh token rotation (old token revoked on use) | PASS | `services.rs:1271–1274` — old jti deleted via `refresh_token_repository.delete` |
+| Refresh token reuse detection | PARTIAL | Old token is deleted; a replay attempt hits `get_by_jti` → not-found error (implicit rejection). No explicit family-based cascade revocation. |
+| `scope` downscoping on refresh | PASS | `services.rs:1264` — `claims.scope` carried forward |
+| PKCE `code_verifier` validation at token exchange | GAP | `ExchangeTokenInput` has no `code_verifier` field; `authorization_code()` does not check it |
+
+---
+
+## 4. ID Token (OIDC Core §2)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| `iss` | PASS | `IdTokenClaims.iss` set to issuer string |
+| `sub` | PASS | `IdTokenClaims.sub` = user UUID |
+| `aud` | PASS | `IdTokenClaims.aud` = `azp` (client\_id string) |
+| `exp` | PASS | `IdTokenClaims.exp` set |
+| `iat` | PASS | `IdTokenClaims.iat` set |
+| `nonce` (REQUIRED when nonce in auth request) | GAP | `IdTokenClaims` struct has no `nonce` field; even if auth session stores nonce, it is never injected |
+| `at_hash` (RECOMMENDED for code flow) | PASS | Computed at `services.rs:682–685` (SHA-256 left-half, base64url) |
+| `auth_time` | GAP | Field present in struct but always `None` |
+| `acr` | GAP | Not implemented |
+| `amr` | GAP | Not implemented |
+| `azp` | PASS | Present and set to `client_id` |
+| ID token signed with RS256 | PASS | `services.rs:449` — `Header::new(Algorithm::RS256)` |
+| Profile / email claims via mappers | PASS | Protocol mapper engine populates `additional_claims` in ID token |
+
+---
+
+## 5. UserInfo Endpoint (OIDC Core §5.3)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Bearer token accepted | PASS | `userinfo.rs` — `OptionalToken` extractor reads Bearer |
+| Returns `sub` | PASS | `UserInfoResponse` includes subject |
+| `profile` scope claims | PASS | Mapper engine (`user_property_mapper`, `user_attribute_mapper`) |
+| `email` scope claims | PASS | Mapper engine |
+| Returns JSON by default | PASS | Handler returns `Response<UserInfoResponse>` (JSON) |
+| Signed UserInfo response (JWT) | GAP | Not implemented |
+
+---
+
+## 6. Token Revocation (RFC 7009)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| `POST /revoke` endpoint present | PASS | `revoke.rs` |
+| Accepts `token` + `token_type_hint` | PASS | `RevokeTokenRequestValidator` |
+| Returns 200 even for unknown tokens | PASS | RFC 7009 §2.2 requires silent success |
+| Requires client authentication | PASS | `client_id` required in form |
+
+---
+
+## 7. Token Introspection (RFC 7662)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| `POST /token/introspect` present | PASS | `introspect.rs` |
+| Requires confidential client credentials | PASS | `basic_auth` or `client_secret_post` checked; unauthorized returns 401 |
+| Returns `active`, `sub`, `exp`, `iat`, `scope` | PASS | `TokenIntrospectionResponse` (from `ferriskey-domain` crate) |
+| Returns `active: false` for invalid tokens | PASS | Service returns `false` on lookup/validation failure |
+
+---
+
+## 8. RP-Initiated Logout (OIDC Session Management / RP-Initiated Logout 1.0)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| `GET /logout` | PASS | `logout.rs:120–127` (`logout_get`) |
+| `POST /logout` | PASS | `logout.rs:144–151` (`logout_post`) |
+| `id_token_hint` accepted | PASS | `LogoutRequestValidator.id_token_hint`; validated in `end_session` |
+| `post_logout_redirect_uri` accepted | PASS | Redirect returned when present |
+| `state` echoed in redirect | PASS | `EndSessionInput.state` forwarded |
+| `client_id` accepted | PASS | `LogoutRequestValidator.client_id` |
+| Session cookies cleared | PASS | `clear_session_cookies_headers` sets both cookies to removal |
+| Backchannel logout | GAP | Not implemented |
+| Frontchannel logout | GAP | Not implemented |
+
+---
+
+## 9. JWKS / Key Material (RFC 7517)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| JWKS endpoint (`/jwks.json`) | PASS | `get_certs.rs:66–71` |
+| `/certs` alias | PASS | `get_certs.rs:43–48` |
+| RS256 keys exposed | PASS | `JwkKey` type used; algorithm RS256 (`services.rs:449`) |
+| Key rotation support | PARTIAL | Keys fetched from keystore per realm; no automated rotation schedule documented |
+| `kid` header in signed tokens | PARTIAL | Present in `Header` via `ferriskey-security`; verify `kid` matches JWKS |
+
+---
+
+## 10. Scopes and Claims
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| `openid` scope required for ID token | PASS | `services.rs:670` |
+| `profile` scope | PASS | Defined in `scope.rs`; mappers in `user_property_mapper.rs` |
+| `email` scope | PASS | Defined in `scope.rs`; mapper in `user_property_mapper.rs` |
+| `address` scope | PARTIAL | Scope constant defined (`scope.rs:8`); no dedicated mapper verified |
+| `phone` scope | PARTIAL | Scope constant defined; no dedicated mapper verified |
+| `offline_access` scope | PARTIAL | Scope defined; no explicit offline token lifetime differentiation verified |
+
+---
+
+## Overall Readiness Summary
+
+| Profile | Expected OIDF Result | Blocking Gaps |
+|---|---|---|
+| Config OP | FAIL | Discovery missing 10+ fields (GAP-05) |
+| Basic OP | FAIL | PKCE inbound (GAP-01), nonce in ID token (GAP-04) |
+| Hybrid OP | Not applicable | `response_type=token` / implicit not implemented |
+| RP-Initiated Logout | PARTIAL FAIL | Backchannel/frontchannel logout absent |
+
+Addressing GAP-01, GAP-04, GAP-05 (and the sub-gaps under each) brings Basic OP
+and Config OP into reach. See `oidc-gap-triage.md` for scoped issue descriptions.


### PR DESCRIPTION
## Summary
- `docs/compliance/oidc-conformance-runbook.md` — step-by-step to run the OpenID Foundation conformance suite against a FerrisKey instance (prerequisites, client registration, hosted/local suite, result export).
- `docs/compliance/oidc-support-matrix.md` — PASS/PARTIAL/GAP matrix across OIDC Core / RFC areas, with per-claim code citations verified against the codebase.
- `docs/compliance/oidc-gap-triage.md` — 10 actionable follow-up issue descriptions.
- `docs/compliance/oidc-selfcert-path.md` — OIDF self-certification submission + renewal procedure.
- `conformance/` — a minimal test-plan config template + README; `.gitignore` excludes `conformance/results/`.

## Notes
- The support matrix was generated against `origin/main`. Some gaps it lists are already addressed by sibling EPIC #1090 PRs not yet merged — notably inbound PKCE (#1091) and refresh-token rotation (#1092); the matrix should be re-run once those land.
- The document explicitly does not claim a passing certification — it prepares for one.

Closes #1101
Part of #1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OIDC conformance testing runbook with step-by-step procedures
  * Added OIDC compliance support matrix documenting current feature status
  * Added OIDC self-certification submission guide
  * Added OIDC conformance gap triage roadmap

* **New Features**
  * Added Basic OP OIDC conformance configuration template

* **Chores**
  * Updated .gitignore to exclude conformance test result files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->