### PR TITLE
fix: distinguish broker redirect URI failure modes

### DIFF
--- a/api/src/application/http/error.rs
+++ b/api/src/application/http/error.rs
@@ -29,8 +29,12 @@ impl From<CoreError> for ApiError {
             CoreError::InternalServerError => {
                         Self::InternalServerError("Internal server error".into())
                     }
-            CoreError::RedirectUriNotFound => Self::NotFound("Redirect URI not found".into()),
-            CoreError::InvalidRedirectUri => Self::BadRequest("Invalid redirect URI".into()),
+            CoreError::RedirectUriNotFound => {
+                Self::NotFound("No redirect URI is registered for this client".into())
+            }
+            CoreError::InvalidRedirectUri => {
+                Self::BadRequest("Redirect URI is not allowed for this client".into())
+            }
             CoreError::InvalidClient => Self::Unauthorized("Invalid client".into()),
             CoreError::InvalidRealm => Self::Unauthorized("Invalid realm".into()),
             CoreError::InvalidUser => Self::Unauthorized("Invalid user".into()),

--- a/core/src/domain/abyss/broker_services.rs
+++ b/core/src/domain/abyss/broker_services.rs
@@ -8,7 +8,7 @@ use ferriskey_compass::{
 };
 use rand::{RngCore, thread_rng};
 use sha2::{Digest, Sha256};
-use tracing::{error, instrument};
+use tracing::{error, instrument, warn};
 use uuid::Uuid;
 
 use crate::domain::abyss::identity_provider::broker::{
@@ -52,6 +52,30 @@ where
     auth_session_repository: Arc<ASR>,
     oauth_client: Arc<OC>,
     flow_recorder: FlowRecorder,
+}
+
+fn evaluate_redirect_uri(allowed: &[String], redirect_uri: &str) -> Result<(), CoreError> {
+    if allowed.is_empty() {
+        return Err(CoreError::RedirectUriNotFound);
+    }
+
+    let is_valid = allowed.iter().any(|uri| {
+        if uri == redirect_uri {
+            return true;
+        }
+
+        if let Ok(regex) = regex::Regex::new(uri) {
+            return regex.is_match(redirect_uri);
+        }
+
+        false
+    });
+
+    if is_valid {
+        Ok(())
+    } else {
+        Err(CoreError::InvalidRedirectUri)
+    }
 }
 
 impl<RR, IR, BR, LR, CR, RUR, UR, ASR, OC> BrokerServiceImpl<RR, IR, BR, LR, CR, RUR, UR, ASR, OC>
@@ -124,20 +148,19 @@ where
             .get_enabled_by_client_id(client_id)
             .await?;
 
-        let is_valid = redirect_uris.iter().any(|uri| {
-            if uri.value == redirect_uri {
-                return true;
-            }
+        let values = redirect_uris
+            .into_iter()
+            .map(|uri| uri.value)
+            .collect::<Vec<_>>();
 
-            if let Ok(regex) = regex::Regex::new(&uri.value) {
-                return regex.is_match(redirect_uri);
-            }
-
-            false
-        });
-
-        if !is_valid {
-            return Err(CoreError::InvalidRedirectUri);
+        if let Err(error) = evaluate_redirect_uri(&values, redirect_uri) {
+            warn!(
+                %client_id,
+                redirect_uri = %redirect_uri,
+                error = %error,
+                "Broker redirect URI validation failed"
+            );
+            return Err(error);
         }
 
         Ok(())
@@ -700,5 +723,44 @@ where
         Err(CoreError::IdpUserInfoFailed(
             "No ID token and no userinfo endpoint configured".to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evaluate_redirect_uri_returns_not_found_when_allowed_list_is_empty() {
+        let result = evaluate_redirect_uri(&[], "https://app.example/cb");
+
+        assert!(matches!(result, Err(CoreError::RedirectUriNotFound)));
+    }
+
+    #[test]
+    fn evaluate_redirect_uri_returns_invalid_when_no_entries_match() {
+        let allowed = vec!["https://other.example/cb".to_string()];
+
+        let result = evaluate_redirect_uri(&allowed, "https://app.example/cb");
+
+        assert!(matches!(result, Err(CoreError::InvalidRedirectUri)));
+    }
+
+    #[test]
+    fn evaluate_redirect_uri_accepts_exact_match() {
+        let allowed = vec!["https://app.example/cb".to_string()];
+
+        let result = evaluate_redirect_uri(&allowed, "https://app.example/cb");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn evaluate_redirect_uri_accepts_regex_match() {
+        let allowed = vec!["https://app\\.example/.*".to_string()];
+
+        let result = evaluate_redirect_uri(&allowed, "https://app.example/cb");
+
+        assert!(result.is_ok());
     }
 }

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -28,10 +28,10 @@ pub enum CoreError {
     #[error("Internal server error")]
     InternalServerError,
 
-    #[error("Redirect URI not found")]
+    #[error("No redirect URI is registered for this client")]
     RedirectUriNotFound,
 
-    #[error("Invalid redirect URI")]
+    #[error("Redirect URI is not allowed for this client")]
     InvalidRedirectUri,
 
     #[error("Invalid client")]


### PR DESCRIPTION
## Summary

The broker SSO login path returned the same `Invalid redirect URI` error for distinct redirect-URI validation failures, so operators configuring a federated IdP could not tell what was actually wrong. This splits the two failure modes apart and makes the messages actionable.

The matching logic is extracted into a small pure helper `evaluate_redirect_uri(allowed, redirect_uri)`:

- empty allowed list returns `RedirectUriNotFound` (the client has no redirect URI registered)
- a non-empty list with no exact-or-regex match returns `InvalidRedirectUri` (the supplied URI is not allowed for this client)
- a match returns `Ok(())`

`validate_redirect_uri` now also logs a `warn!` with the client id and supplied redirect URI on failure, so the cause is visible in server logs. No secrets are logged.

## Why this matters

In #1044 the reporter configured Keycloak as an identity provider and always got `{"code":"E_BAD_REQUEST","status":400,"message":"Invalid redirect URI"}`, even across unrelated misconfigurations. The actual cause was that the `redirect_uri` was not registered on the requesting OAuth client. The previous code in `core/src/domain/abyss/broker_services.rs:139` collapsed every validation failure into `CoreError::InvalidRedirectUri`, giving no signal about whether the client simply had no redirect URI configured versus the URI being disallowed. The two distinct `CoreError` variants already existed and were already mapped to distinct responses in `api/src/application/http/error.rs`; the broker login path just was not selecting between them.

This change only adjusts variant selection, the two user-facing messages, and adds logging. The public error envelope shape, status codes, and the `InvalidClient` / `InvalidClientSecret` / `ClientNotFound` handling are unchanged.

## Testing

- `cargo test -p ferriskey-core evaluate_redirect_uri` (4 new unit tests: empty list, non-matching list, exact match, regex match) pass.
- `cargo check -p ferriskey-api` passes.
- `cargo fmt --check` is clean.

Refs #1044


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for redirect URI validation, providing clearer distinction between unregistered and disallowed URIs.

* **New Features**
  * Added support for regex pattern matching when validating allowed redirect URIs.

* **Chores**
  * Improved logging for redirect URI validation failures to assist with troubleshooting configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->