### PR TITLE
feat: customizable device code pages in portal theme builder

### DIFF
--- a/core/migrations/20260627000000_portal_themes_add_device_verify_page.down.sql
+++ b/core/migrations/20260627000000_portal_themes_add_device_verify_page.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE portal_themes
+  DROP COLUMN page_device_verify,
+  DROP COLUMN page_device_verified;

--- a/core/migrations/20260627000000_portal_themes_add_device_verify_page.up.sql
+++ b/core/migrations/20260627000000_portal_themes_add_device_verify_page.up.sql
@@ -1,0 +1,12 @@
+-- Per-page JSONB trees for the RFC 8628 device flow pages. Mirrors the
+-- columns from 20260517120000_portal_themes_per_page_trees: default to an
+-- empty array so existing themes stay valid until an admin customises them.
+--
+-- - `page_device_verify`  : device-flow consent screen where the user enters
+--   the `user_code` shown on their device and approves / denies the request.
+-- - `page_device_verified`: success screen rendered once the device request
+--   has been approved ("you can return to your device").
+
+ALTER TABLE portal_themes
+  ADD COLUMN page_device_verify   JSONB NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN page_device_verified JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/core/src/domain/portal_theme/entities.rs
+++ b/core/src/domain/portal_theme/entities.rs
@@ -43,10 +43,22 @@ pub enum PortalPageType {
     /// device label to confirm the binding. Distinct from `Totp` (which
     /// only collects the code on subsequent logins).
     TotpSetup,
+    /// RFC 8628 device-flow consent screen. The user enters the `user_code`
+    /// displayed on the device that initiated the flow, then approves or
+    /// denies the authorisation. Requires a `user_code_input` plus the
+    /// `device_approve_button` / `device_deny_button` pair — the post-decision
+    /// "denied" result screen stays a hardcoded React fallback; the
+    /// "approved" success screen is `DeviceVerified`.
+    DeviceVerify,
+    /// Success screen rendered once a device-flow request has been approved
+    /// ("you can return to your device, it will sign in automatically").
+    /// Like `EmailVerified`, a fully-static heading + text composition is a
+    /// valid page — no required blocks.
+    DeviceVerified,
 }
 
 impl PortalPageType {
-    pub const ALL: [PortalPageType; 10] = [
+    pub const ALL: [PortalPageType; 12] = [
         PortalPageType::Login,
         PortalPageType::Register,
         PortalPageType::Totp,
@@ -57,6 +69,8 @@ impl PortalPageType {
         PortalPageType::VerifyEmail,
         PortalPageType::EmailVerified,
         PortalPageType::TotpSetup,
+        PortalPageType::DeviceVerify,
+        PortalPageType::DeviceVerified,
     ];
 }
 
@@ -73,6 +87,8 @@ pub struct PortalThemePages {
     pub verify_email: serde_json::Value,
     pub email_verified: serde_json::Value,
     pub totp_setup: serde_json::Value,
+    pub device_verify: serde_json::Value,
+    pub device_verified: serde_json::Value,
 }
 
 impl PortalThemePages {
@@ -88,6 +104,8 @@ impl PortalThemePages {
             PortalPageType::VerifyEmail => &self.verify_email,
             PortalPageType::EmailVerified => &self.email_verified,
             PortalPageType::TotpSetup => &self.totp_setup,
+            PortalPageType::DeviceVerify => &self.device_verify,
+            PortalPageType::DeviceVerified => &self.device_verified,
         }
     }
 }

--- a/core/src/domain/portal_theme/validation.rs
+++ b/core/src/domain/portal_theme/validation.rs
@@ -48,6 +48,20 @@ pub const REQUIRED_BLOCKS: &[(PortalPageType, &[&str])] = &[
         PortalPageType::TotpSetup,
         &["totp_qr_code", "totp_input", "submit_button"],
     ),
+    // RFC 8628 device verification. The user must be able to enter the
+    // `user_code` and act on it — without the code input plus both the
+    // approve and deny buttons the consent screen is un-completable.
+    (
+        PortalPageType::DeviceVerify,
+        &[
+            "user_code_input",
+            "device_approve_button",
+            "device_deny_button",
+        ],
+    ),
+    // Device approval success screen. Like `EmailVerified`, a static
+    // heading + text composition is a valid page, so no blocks are required.
+    (PortalPageType::DeviceVerified, &[]),
 ];
 
 pub fn required_blocks_for(page_type: PortalPageType) -> &'static [&'static str] {

--- a/core/src/entity/portal_themes.rs
+++ b/core/src/entity/portal_themes.rs
@@ -30,6 +30,8 @@ pub struct Model {
     pub page_magic_link_request: Json,
     pub page_email_verified: Json,
     pub page_totp_setup: Json,
+    pub page_device_verify: Json,
+    pub page_device_verified: Json,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -51,6 +53,8 @@ pub enum Column {
     PageMagicLinkRequest,
     PageEmailVerified,
     PageTotpSetup,
+    PageDeviceVerify,
+    PageDeviceVerified,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -93,6 +97,8 @@ impl ColumnTrait for Column {
             Self::PageMagicLinkRequest => ColumnType::JsonBinary.def(),
             Self::PageEmailVerified => ColumnType::JsonBinary.def(),
             Self::PageTotpSetup => ColumnType::JsonBinary.def(),
+            Self::PageDeviceVerify => ColumnType::JsonBinary.def(),
+            Self::PageDeviceVerified => ColumnType::JsonBinary.def(),
         }
     }
 }

--- a/core/src/infrastructure/repositories/portal_theme_repository.rs
+++ b/core/src/infrastructure/repositories/portal_theme_repository.rs
@@ -45,6 +45,8 @@ fn model_to_domain(model: Model) -> Result<PortalTheme, CoreError> {
         verify_email: model.page_verify_email,
         email_verified: model.page_email_verified,
         totp_setup: model.page_totp_setup,
+        device_verify: model.page_device_verify,
+        device_verified: model.page_device_verified,
     };
 
     Ok(PortalTheme {
@@ -71,6 +73,8 @@ fn page_column(page_type: PortalPageType) -> Column {
         PortalPageType::VerifyEmail => Column::PageVerifyEmail,
         PortalPageType::EmailVerified => Column::PageEmailVerified,
         PortalPageType::TotpSetup => Column::PageTotpSetup,
+        PortalPageType::DeviceVerify => Column::PageDeviceVerify,
+        PortalPageType::DeviceVerified => Column::PageDeviceVerified,
     }
 }
 

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -327,6 +327,8 @@ export namespace Schemas {
     permissions: Array<string>
   }
   export type PortalThemePages = Partial<{
+    deviceVerified: unknown
+    deviceVerify: unknown
     emailVerified: unknown
     forgotPassword: unknown
     login: unknown
@@ -704,6 +706,8 @@ export namespace Schemas {
     | 'verify_email'
     | 'email_verified'
     | 'totp_setup'
+    | 'device_verify'
+    | 'device_verified'
   export type PageRequirement = { page_type: PortalPageType; required_blocks: Array<string> }
   export type PageRequirementsResponse = { data: Array<PageRequirement> }
   export type PasskeyAuthenticateResponse = { login_url: string; status: string }
@@ -2630,6 +2634,8 @@ export namespace Endpoints {
           | 'verify_email'
           | 'email_verified'
           | 'totp_setup'
+          | 'device_verify'
+          | 'device_verified'
       }
       path: { realm_name: string }
     }
@@ -2793,6 +2799,8 @@ export namespace Endpoints {
           | 'verify_email'
           | 'email_verified'
           | 'totp_setup'
+          | 'device_verify'
+          | 'device_verified'
       }
 
       body: Schemas.UpdateThemePageValidator

--- a/front/src/api/portal-theme.api.tsx
+++ b/front/src/api/portal-theme.api.tsx
@@ -109,6 +109,9 @@ const BLOCK_TYPE_LABELS: Record<string, string> = {
   password_input: 'Password field',
   totp_input: 'OTP code field',
   submit_button: 'Submit button',
+  user_code_input: 'Device code field',
+  device_approve_button: 'Approve button',
+  device_deny_button: 'Deny button',
 }
 
 function labelForBlockType(type: string): string {
@@ -126,6 +129,8 @@ const PAGE_TYPE_LABELS: Partial<Record<Schemas.PortalPageType, string>> = {
   verify_email: 'verify email',
   email_verified: 'email verified',
   totp_setup: 'TOTP setup',
+  device_verify: 'device verification',
+  device_verified: 'device verified',
 }
 
 export function labelForPageType(pageType: Schemas.PortalPageType): string {
@@ -289,13 +294,14 @@ export const useDeletePortalTheme = () => {
 export const useGetActivePortalTheme = ({
   realm = 'master',
   pageType,
-}: BaseQuery & { pageType: Schemas.PortalPageType }) => {
+  enabled = true,
+}: BaseQuery & { pageType: Schemas.PortalPageType; enabled?: boolean }) => {
   return useQuery({
     ...window.tanstackApi.get('/realms/{realm_name}/portal/active', {
       path: { realm_name: realm },
       query: { page_type: pageType },
     }).queryOptions,
-    enabled: !!realm && !!pageType,
+    enabled: enabled && !!realm && !!pageType,
   })
 }
 

--- a/front/src/lib/builder-portal/components.tsx
+++ b/front/src/lib/builder-portal/components.tsx
@@ -16,9 +16,12 @@ import {
   LayoutTemplate,
   LockKeyhole,
   Mail,
+  Ban,
   Minus,
+  MonitorSmartphone,
   MousePointerClick,
   MoveVertical,
+  ScanLine,
   PanelBottom,
   PanelTop,
   QrCode,
@@ -49,7 +52,10 @@ const ALL_CHILDREN = [
   'password_input',
   'password_confirm_input',
   'totp_input',
+  'user_code_input',
   'submit_button',
+  'device_approve_button',
+  'device_deny_button',
   'magic_link_button',
   'passkey_button',
   'identity_providers',
@@ -355,6 +361,22 @@ export const portalComponents: ComponentDefinition[] = [
     },
     defaultStyles: {},
   },
+  // RFC 8628 device user-code input. Eight letters (charset
+  // BCDFGHJKLMNPQRSTVWXZ) split visually as XXXX-XXXX. Renders the same
+  // segmented control as `totp_input`; submitted as `name="user_code"` and
+  // prefilled from the `?user_code=` query at runtime.
+  {
+    type: 'user_code_input',
+    label: 'Device code input',
+    icon: <ScanLine size={14} />,
+    defaultProps: {
+      label: 'Enter the code shown on your device',
+      placeholder: 'XXXX-XXXX',
+      type: 'text',
+      name: 'user_code',
+    },
+    defaultStyles: {},
+  },
   {
     type: 'submit_button',
     label: 'Submit button',
@@ -364,6 +386,37 @@ export const portalComponents: ComponentDefinition[] = [
       variant: 'primary',
       fullWidth: 'true',
       submit: 'true',
+      align: 'center',
+    },
+    defaultStyles: {},
+  },
+  // Device-flow approve button — submits the form with action=approve. Same
+  // submit semantics as `submit_button` but page-exclusive to `device_verify`
+  // so the consent screen reads "Approve" rather than a generic "Continue".
+  {
+    type: 'device_approve_button',
+    label: 'Approve button',
+    icon: <MonitorSmartphone size={14} />,
+    hasContent: true,
+    defaultProps: {
+      variant: 'primary',
+      fullWidth: 'true',
+      submit: 'true',
+      align: 'center',
+    },
+    defaultStyles: {},
+  },
+  // Device-flow deny button — fires `data-fk-action="device-deny"`, handled by
+  // the portal wrapper (same declarative-action mechanism as the magic-link /
+  // passkey buttons). Outline by default since it's the non-primary choice.
+  {
+    type: 'device_deny_button',
+    label: 'Deny button',
+    icon: <Ban size={14} />,
+    hasContent: true,
+    defaultProps: {
+      variant: 'outline',
+      fullWidth: 'true',
       align: 'center',
     },
     defaultStyles: {},
@@ -508,6 +561,9 @@ export const REQUIRED_BLOCK_TYPES = new Set([
   'totp_input',
   'submit_button',
   'identity_providers',
+  'user_code_input',
+  'device_approve_button',
+  'device_deny_button',
 ])
 
 /**
@@ -656,6 +712,46 @@ export const HIDDEN_BLOCKS_BY_PAGE_TYPE: Record<string, ReadonlySet<string>> = {
     'username_input',
     'identity_providers',
   ]),
+  device_verify: new Set([
+    // Device-code consent screen: only the user-code input plus approve /
+    // deny buttons. Every other auth primitive (passwords, OTP, social,
+    // alt-auth, nav links) is irrelevant here — the user is already
+    // authenticated and is only authorising a separate device.
+    'magic_link_button',
+    'passkey_button',
+    'forgot_password_link',
+    'register_link',
+    'back_to_login_link',
+    'email_input',
+    'password_input',
+    'password_confirm_input',
+    'totp_input',
+    'first_name_input',
+    'last_name_input',
+    'username_input',
+    'identity_providers',
+    // The generic submit button is replaced by the dedicated approve button.
+    'submit_button',
+  ]),
+  device_verified: new Set([
+    // Pure confirmation screen ("your device is approved") — heading + text
+    // (+ optional logo). No form fields, no auth alternatives, no actions:
+    // the user just returns to their device, which signs in automatically.
+    'magic_link_button',
+    'passkey_button',
+    'forgot_password_link',
+    'register_link',
+    'back_to_login_link',
+    'submit_button',
+    'email_input',
+    'password_input',
+    'password_confirm_input',
+    'totp_input',
+    'first_name_input',
+    'last_name_input',
+    'username_input',
+    'identity_providers',
+  ]),
 }
 
 /**
@@ -670,6 +766,9 @@ export const HIDDEN_BLOCKS_BY_PAGE_TYPE: Record<string, ReadonlySet<string>> = {
 export const RESTRICTED_TO_PAGE_TYPE: Record<string, ReadonlySet<string>> = {
   totp_qr_code: new Set(['totp_setup']),
   totp_secret: new Set(['totp_setup']),
+  user_code_input: new Set(['device_verify']),
+  device_approve_button: new Set(['device_verify']),
+  device_deny_button: new Set(['device_verify']),
 }
 
 const DEFAULT_CONTENT: Partial<Record<string, string>> = {
@@ -677,6 +776,8 @@ const DEFAULT_CONTENT: Partial<Record<string, string>> = {
   text: 'Sign in to your account.',
   button: 'Continue',
   submit_button: 'Continue',
+  device_approve_button: 'Approve',
+  device_deny_button: 'Deny',
   magic_link_button: 'Sign in with a magic link',
   passkey_button: 'Sign in with a passkey',
   forgot_password_link: 'Forgot password?',

--- a/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
+++ b/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
@@ -758,12 +758,63 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
         </div>
       )
 
+    case 'device_approve_button':
+    case 'device_deny_button':
+      // Hard-wired action: approve submits the form (action=approve), deny
+      // fires the `device-deny` action handled by the portal wrapper. Only
+      // visual style is editable here — same pattern as submit_button.
+      return (
+        <div className='flex flex-col'>
+          {identity}
+          <div className='border-b border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground'>
+            {node.type === 'device_approve_button'
+              ? 'Approve action is locked — this button submits the device authorisation when clicked.'
+              : 'Deny action is locked — this button rejects the device authorisation when clicked.'}
+          </div>
+          <ConfigSection title='Style'>
+            <SelectField
+              label='Variant'
+              value={node.props.variant as string}
+              options={[
+                { label: 'Primary', value: 'primary' },
+                { label: 'Secondary', value: 'secondary' },
+                { label: 'Outline', value: 'outline' },
+              ]}
+              onChange={(v) => updateProp('variant', v)}
+              allowEmpty={false}
+            />
+            <SelectField
+              label='Alignment'
+              value={(node.props.align as string) || 'center'}
+              options={[
+                { label: 'Left', value: 'left' },
+                { label: 'Center', value: 'center' },
+                { label: 'Right', value: 'right' },
+              ]}
+              onChange={(v) => updateProp('align', v)}
+              allowEmpty={false}
+            />
+            <SelectField
+              label='Width'
+              value={node.props.fullWidth as string}
+              options={[
+                { label: 'Full', value: 'true' },
+                { label: 'Auto', value: 'false' },
+              ]}
+              onChange={(v) => updateProp('fullWidth', v)}
+              allowEmpty={false}
+            />
+          </ConfigSection>
+        </div>
+      )
+
     case 'username_input':
     case 'first_name_input':
     case 'last_name_input':
     case 'email_input':
     case 'password_input':
     case 'password_confirm_input':
+    case 'user_code_input':
     case 'totp_input': {
       const LOCKED_HINTS: Record<string, string> = {
         email_input: 'Email input — the HTML type and field name are locked to email.',
@@ -772,11 +823,14 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
           'Confirm-password input — submit handlers compare it against the password field; field name is locked to password_confirm.',
         totp_input:
           'TOTP input — rendered as a segmented digit-by-digit OTP field. The field name is locked to totp; the slot count is configurable below.',
+        user_code_input:
+          'Device code input — a segmented 8-slot field (XXXX-XXXX) restricted to the RFC 8628 charset. The field name is locked to user_code and it is prefilled from the device link.',
         username_input: 'Username input — the field name is locked to username.',
         first_name_input: 'First name input — the field name is locked to first_name.',
         last_name_input: 'Last name input — the field name is locked to last_name.',
       }
       const lockedHint = LOCKED_HINTS[node.type] ?? ''
+      const isSegmented = node.type === 'totp_input' || node.type === 'user_code_input'
       return (
         <div className='flex flex-col'>
           {identity}
@@ -785,7 +839,7 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
           </div>
           <ConfigSection title='Field'>
             <TextField label='Label' value={node.props.label as string} onChange={(v) => updateProp('label', v)} />
-            {node.type !== 'totp_input' && (
+            {!isSegmented && (
               <TextField
                 label='Placeholder'
                 value={node.props.placeholder as string}

--- a/front/src/lib/builder-portal/presets.ts
+++ b/front/src/lib/builder-portal/presets.ts
@@ -301,6 +301,94 @@ function totpSetupCard(): BuilderNode[] {
   ]
 }
 
+function deviceVerifyCard(): BuilderNode[] {
+  return [
+    node('card', {
+      props: { maxWidth: '440px', align: 'center' },
+      children: [
+        node('card-header', {
+          props: { textAlign: 'center', gap: '6px' },
+          children: [
+            node('heading', { content: 'Device verification' }),
+            node('text', {
+              content:
+                'Enter the code displayed on your device to authorise it.',
+            }),
+          ],
+        }),
+        node('card-content', {
+          props: { gap: '16px' },
+          children: [
+            // Surfaces unknown / expired / already-used code errors inline.
+            node('form_error_banner'),
+            node('user_code_input'),
+            node('device_approve_button', { content: 'Approve' }),
+            node('device_deny_button', { content: 'Deny' }),
+          ],
+        }),
+      ],
+    }),
+  ]
+}
+
+// Branded variant of the device-verify screen — logo + title + subtitle on
+// top of the code input and the approve / deny pair. Mirrors the look of the
+// hardcoded `PageDeviceVerify` fallback so an admin who just wants the default
+// design (but themed) can drop this in one click.
+function deviceVerifyBrandedCard(): BuilderNode[] {
+  return [
+    node('card', {
+      props: { maxWidth: '440px', align: 'center' },
+      children: [
+        node('card-header', {
+          props: { textAlign: 'center', gap: '8px' },
+          children: [
+            node('image', { props: { src: '/logo_ferriskey.png', alt: 'Logo', width: '48px', align: 'center' } }),
+            node('heading', { content: 'Device verification' }),
+            node('text', {
+              content:
+                'Enter the code displayed on your device to authorise it.',
+            }),
+          ],
+        }),
+        node('card-content', {
+          props: { gap: '16px' },
+          children: [
+            node('form_error_banner'),
+            node('user_code_input'),
+            node('device_approve_button', { content: 'Approve' }),
+            node('device_deny_button', { content: 'Deny' }),
+          ],
+        }),
+      ],
+    }),
+  ]
+}
+
+// Success screen shown once a device-flow request has been approved. Static
+// confirmation (logo + heading + text) — the user just returns to their
+// device, which signs in automatically. No actions needed.
+function deviceVerifiedCard(): BuilderNode[] {
+  return [
+    node('card', {
+      props: { maxWidth: '440px', align: 'center' },
+      children: [
+        node('card-header', {
+          props: { textAlign: 'center', gap: '8px' },
+          children: [
+            node('image', { props: { src: '/logo_ferriskey.png', alt: 'Logo', width: '48px', align: 'center' } }),
+            node('heading', { content: 'Device approved' }),
+            node('text', {
+              content:
+                'You can now return to the device that requested access. It should sign in automatically within a few seconds.',
+            }),
+          ],
+        }),
+      ],
+    }),
+  ]
+}
+
 function emailVerifiedCard(): BuilderNode[] {
   return [
     node('card', {
@@ -478,6 +566,27 @@ export const PORTAL_PRESETS: PortalPreset[] = [
     description:
       'Card with QR code + secret fallback + code confirmation + device label. For the TOTP setup page.',
     factory: totpSetupCard,
+  },
+  {
+    id: 'device-verify-card',
+    label: 'Device verify card',
+    description:
+      'Card with the device code input + approve / deny buttons. For the Device verify page (RFC 8628).',
+    factory: deviceVerifyCard,
+  },
+  {
+    id: 'device-verify-branded-card',
+    label: 'Device verify card (branded)',
+    description:
+      'Logo + title + subtitle above the device code input and approve / deny buttons. Mirrors the default device screen, themed.',
+    factory: deviceVerifyBrandedCard,
+  },
+  {
+    id: 'device-verified-card',
+    label: 'Device verified card',
+    description:
+      'Success card shown after a device request has been approved. For the Device verified page.',
+    factory: deviceVerifiedCard,
   },
   {
     id: 'passwordless-card',

--- a/front/src/lib/builder-portal/renderer.tsx
+++ b/front/src/lib/builder-portal/renderer.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from 'react'
 import { OTPInput, type SlotProps } from 'input-otp'
 import {
   AlertCircle,
+  Ban,
   Copy,
   KeyRound,
   Loader2,
@@ -248,6 +249,63 @@ function renderNode(node: BuilderNode, options: RenderOptions): ReactNode {
         </a>
       )
 
+    // Device-flow approve: same submit semantics as `submit_button` (drives
+    // the host <form>'s onSubmit, which the device_verify branch maps to the
+    // approve action). Kept as its own block so the consent screen reads
+    // "Approve" and is page-exclusive to device_verify.
+    case 'device_approve_button':
+      return options.runtime ? (
+        <button
+          key={node.id}
+          {...idAttr}
+          type='submit'
+          data-fk-portal-btn=''
+          data-fk-busy={options.isSubmitting ? 'true' : 'false'}
+          disabled={options.isSubmitting}
+          style={{ ...buttonStyle(node), gap: 8, border: 'none', cursor: 'pointer' }}
+        >
+          {options.isSubmitting && (
+            <Loader2 size={16} aria-hidden data-fk-portal-spinner='' />
+          )}
+          <span>{node.content ?? 'Approve'}</span>
+        </button>
+      ) : (
+        <a
+          key={node.id}
+          {...idAttr}
+          href='#'
+          data-fk-portal-btn=''
+          style={buttonStyle(node)}
+        >
+          {node.content ?? 'Approve'}
+        </a>
+      )
+
+    // Device-flow deny: declarative action button (same mechanism as the
+    // magic-link / passkey buttons). The portal wrapper listens for
+    // `data-fk-action="device-deny"` clicks and fires the deny mutation with
+    // the code already typed into the form. `type="button"` so it never
+    // submits the surrounding <form> (which would trigger an approve).
+    case 'device_deny_button':
+      return (
+        <button
+          key={node.id}
+          {...idAttr}
+          type='button'
+          data-fk-action='device-deny'
+          data-fk-portal-btn=''
+          style={{
+            ...buttonStyle(node),
+            gap: 8,
+            cursor: options.runtime ? 'pointer' : 'default',
+          }}
+          disabled={!options.runtime}
+        >
+          <Ban size={16} aria-hidden />
+          <span>{node.content ?? 'Deny'}</span>
+        </button>
+      )
+
     // Magic link / passkey: rendered as alternative auth actions. The host
     // portal page wires the click behavior by selecting on the
     // `data-fk-action` attribute (so the renderer stays declarative and the
@@ -437,6 +495,38 @@ function renderNode(node: BuilderNode, options: RenderOptions): ReactNode {
               const n = Number.parseInt(raw, 10)
               return Number.isFinite(n) && n > 0 && n <= 12 ? n : 6
             })()}
+          />
+          {node.props.helperText ? (
+            <span style={inputHelperStyle()}>{node.props.helperText as string}</span>
+          ) : null}
+        </div>
+      )
+
+    // RFC 8628 device user-code: an 8-slot segmented input (XXXX-XXXX),
+    // alpha charset, prefilled from the `?user_code=` query at runtime.
+    // Holds its value through a hidden `name="user_code"` input so the
+    // surrounding <form> picks it up; the device_verify submit branch
+    // re-inserts the dash before calling the verify endpoint.
+    case 'user_code_input':
+      return (
+        <div
+          key={node.id}
+          {...idAttr}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 6,
+            alignItems: 'center',
+            ...orderStyle(node),
+          }}
+        >
+          {node.props.label ? (
+            <label style={inputLabelStyle()}>{node.props.label as string}</label>
+          ) : null}
+          <UserCodeInputField
+            disabled={!options.runtime}
+            name={resolveInputName(node) ?? 'user_code'}
+            runtime={!!options.runtime}
           />
           {node.props.helperText ? (
             <span style={inputHelperStyle()}>{node.props.helperText as string}</span>
@@ -1125,6 +1215,85 @@ export function TotpInputField({
               ))}
             </div>
           )}
+        </>
+      )}
+    />
+  )
+}
+
+// RFC 8628 user-code charset (no vowels / easily-confused chars). Kept in
+// sync with the backend's `UserCode` generator and the device-verify schema.
+const USER_CODE_CHARSET = 'BCDFGHJKLMNPQRSTVWXZ'
+const USER_CODE_LENGTH = 8
+
+/**
+ * Read and normalise the `?user_code=` query param so the runtime
+ * `user_code_input` lands pre-filled (mirrors `normalisePrefill` in the
+ * hardcoded device-verify feature). Returns the dash-less, upper-cased
+ * 8-char value, or '' when absent / malformed. The hidden `<input>` keeps
+ * the concatenated value; the submit handler re-inserts the dash.
+ */
+function readUserCodePrefill(): string {
+  if (typeof window === 'undefined') return ''
+  const raw = new URLSearchParams(window.location.search).get('user_code')
+  if (!raw) return ''
+  const cleaned = raw.trim().toUpperCase().replace('-', '')
+  if (cleaned.length !== USER_CODE_LENGTH) return ''
+  for (const ch of cleaned) {
+    if (!USER_CODE_CHARSET.includes(ch)) return ''
+  }
+  return cleaned
+}
+
+/**
+ * Segmented device user-code input — same visual treatment as
+ * `TotpInputField` (two groups of four slots with a dash separator) but
+ * restricted to the RFC 8628 alpha charset and uppercased as the user
+ * types. Prefilled from `?user_code=` at runtime.
+ */
+export function UserCodeInputField({
+  disabled,
+  name,
+  runtime,
+}: {
+  disabled: boolean
+  name: string
+  runtime: boolean
+}) {
+  const [value, setValue] = useState(() => (runtime ? readUserCodePrefill() : ''))
+  const half = USER_CODE_LENGTH / 2
+  return (
+    <OTPInput
+      maxLength={USER_CODE_LENGTH}
+      value={value}
+      onChange={(next) =>
+        setValue(
+          next
+            .toUpperCase()
+            .split('')
+            .filter((ch) => USER_CODE_CHARSET.includes(ch))
+            .join(''),
+        )
+      }
+      disabled={disabled}
+      name={name}
+      autoFocus={!disabled}
+      inputMode='text'
+      autoComplete='one-time-code'
+      containerClassName='flex items-center justify-center gap-2'
+      render={({ slots }) => (
+        <>
+          <div className='flex items-center gap-1.5'>
+            {slots.slice(0, half).map((slot, i) => (
+              <TotpSlot key={i} {...slot} />
+            ))}
+          </div>
+          <TotpSlotSeparator />
+          <div className='flex items-center gap-1.5'>
+            {slots.slice(half).map((slot, i) => (
+              <TotpSlot key={half + i} {...slot} />
+            ))}
+          </div>
         </>
       )}
     />

--- a/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
+++ b/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from 'react'
-import { KeyRound, LayoutTemplate, Mail } from 'lucide-react'
+import { Ban, KeyRound, LayoutTemplate, Mail } from 'lucide-react'
 import type { BuilderNode, ComponentDefinition } from '../../builder-core'
 import { useBuilderContext } from '../../builder-core'
 import { PortalInput } from '../components/portal-input'
@@ -26,6 +26,7 @@ import {
   resolveInputType,
   textStyle,
   TotpInputField,
+  UserCodeInputField,
   TotpQrCodeBlock,
   TotpSecretBlock,
   FormErrorBannerBlock,
@@ -156,6 +157,8 @@ export function renderVisualBlock(
       return <DividerBlock node={node} isSelected={isSelected} />
     case 'button':
     case 'submit_button':
+    case 'device_approve_button':
+    case 'device_deny_button':
     case 'magic_link_button':
     case 'passkey_button':
       return <ButtonBlock node={node} isSelected={isSelected} />
@@ -169,6 +172,8 @@ export function renderVisualBlock(
       return <InputBlock node={node} isSelected={isSelected} />
     case 'totp_input':
       return <TotpInputBlock node={node} isSelected={isSelected} />
+    case 'user_code_input':
+      return <UserCodeInputBlock node={node} isSelected={isSelected} />
     case 'identity_providers':
       return <IdentityProvidersPreview node={node} isSelected={isSelected} />
     case 'forgot_password_link':
@@ -393,6 +398,8 @@ function ButtonBlock({ node, isSelected }: { node: BuilderNode; isSelected: bool
       <Mail size={16} aria-hidden />
     ) : node.type === 'passkey_button' ? (
       <KeyRound size={16} aria-hidden />
+    ) : node.type === 'device_deny_button' ? (
+      <Ban size={16} aria-hidden />
     ) : null
   const style = mergeStyles(
     {
@@ -491,6 +498,36 @@ function TotpInputBlock({ node, isSelected }: { node: BuilderNode; isSelected: b
     >
       {label ? <label style={inputLabelStyle()}>{label}</label> : null}
       <TotpInputField disabled name={resolveInputName(node) ?? 'totp'} length={length} />
+      {helperText ? <span style={inputHelperStyle()}>{helperText}</span> : null}
+    </div>
+  )
+}
+
+/**
+ * Canvas preview of the device user-code input. Mirrors `TotpInputBlock`
+ * but uses the runtime `UserCodeInputField` (8 alpha slots, XXXX-XXXX) so
+ * the admin sees exactly what end-users will. `runtime={false}` keeps it
+ * from reading any `?user_code=` prefill while editing.
+ */
+function UserCodeInputBlock({ node, isSelected }: { node: BuilderNode; isSelected: boolean }) {
+  const label = (node.props.label as string) ?? ''
+  const helperText = (node.props.helperText as string) ?? ''
+
+  return (
+    <div
+      data-fk-id={node.id}
+      style={{
+        ...chromeStyle(isSelected),
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        alignItems: 'center',
+        pointerEvents: 'none',
+        ...orderStyle(node),
+      }}
+    >
+      {label ? <label style={inputLabelStyle()}>{label}</label> : null}
+      <UserCodeInputField disabled name={resolveInputName(node) ?? 'user_code'} runtime={false} />
       {helperText ? <span style={inputHelperStyle()}>{helperText}</span> : null}
     </div>
   )

--- a/front/src/pages/authentication/components/portal-layout-wrapper.tsx
+++ b/front/src/pages/authentication/components/portal-layout-wrapper.tsx
@@ -15,6 +15,10 @@ import { mergeWithDefaults, themeToCssVars } from '@/pages/portal-theme/lib/them
 import type { Schemas } from '@/api/api.client'
 import { usePortalPageSubmit } from '../hooks/use-portal-page-submit'
 import { usePasskeyAuth } from '../hooks/use-passkey-auth'
+import {
+  DeviceVerifyResult,
+  DeviceVerifyShell,
+} from '../ui/page-device-verify'
 
 function parseTree(tree: unknown): BuilderNode[] {
   if (Array.isArray(tree)) {
@@ -61,6 +65,16 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
   const { data: activeData, isLoading: isThemeLoading } = useGetActivePortalTheme({
     realm,
     pageType,
+  })
+  // Device-verify only: the approved-state success screen is a separate
+  // themeable page (`device_verified`). Fetch its tree alongside so we can
+  // swap the hardcoded result for the admin's custom design once the user
+  // approves. Enabled only on the device-verify page to avoid an extra call
+  // everywhere else.
+  const { data: verifiedData } = useGetActivePortalTheme({
+    realm,
+    pageType: 'device_verified',
+    enabled: pageType === 'device_verify',
   })
   const layoutId = activeData?.layout_id
   const { data: layoutData, isLoading: isLayoutLoading } = useGetPublicPortalLayout({
@@ -153,9 +167,10 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
   // block reads this through the render options and shows or hides
   // itself accordingly.
   const [formError, setFormError] = useState<string | null>(null)
-  const { onSubmit, isSubmitting } = usePortalPageSubmit(pageType, {
-    onFormError: setFormError,
-  })
+  const { onSubmit, isSubmitting, onDeviceDeny, deviceResult, onDeviceReset } =
+    usePortalPageSubmit(pageType, {
+      onFormError: setFormError,
+    })
 
   // Passkey + magic-link buttons rendered inside the custom portal tree
   // expose themselves via `data-fk-action` (see renderer.tsx). The React
@@ -187,6 +202,16 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
         return
       }
 
+      if (action === 'device-deny') {
+        // Deny lives outside the form's submit path (that's reserved for
+        // approve). Read the typed user_code from the surrounding form and
+        // hand it to the device-verify hook with action=deny.
+        event.preventDefault()
+        const form = trigger.closest('form')
+        if (form && onDeviceDeny) onDeviceDeny(new FormData(form))
+        return
+      }
+
       if (action === 'magic-link') {
         event.preventDefault()
         // Carry over whatever the user already typed into the page's
@@ -201,7 +226,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
         navigate(`/realms/${realm}/authentication/magic-link-request${query}`)
       }
     },
-    [navigate, onPasskeyLogin, realm],
+    [navigate, onDeviceDeny, onPasskeyLogin, realm],
   )
 
   if (
@@ -277,6 +302,55 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
   // The layout is only renderable when it has a `page-content` slot.
   // Without one, applying it would hide the page entirely.
   const layoutIsValid = layoutTree.length > 0 && layoutHasPageContent(layoutTree)
+
+  // Device-verify terminal state: once the user has approved / denied, swap
+  // the code-entry tree for the result screen. The approved state renders the
+  // admin's custom `device_verified` tree when they've authored one — routed
+  // through the SAME layout slot as a normal page so it sits exactly where the
+  // code-entry screen does (centering comes from the active layout). Denied /
+  // no custom tree falls back to the hardcoded result, which centers itself
+  // via its own full-height shell.
+  if (pageType === 'device_verify' && deviceResult) {
+    const verifiedTree = parseTree(verifiedData?.page_tree)
+    if (deviceResult === 'approved' && verifiedTree.length > 0) {
+      const verifiedContent: ReactNode = treeToReactNode(verifiedTree, {
+        runtime: true,
+        identityProviders,
+      })
+      const verifiedStyleCss = [
+        generateBreakpointCss(verifiedTree),
+        generateBreakpointCss(layoutTree),
+      ]
+        .filter(Boolean)
+        .join('\n')
+      const verifiedStyle = verifiedStyleCss ? (
+        <style dangerouslySetInnerHTML={{ __html: verifiedStyleCss }} />
+      ) : null
+      return (
+        <div style={cssVars} onClick={handlePortalActionClick}>
+          {verifiedStyle}
+          {buttonInteractionStyle}
+          {layoutIsValid
+            ? treeToReactNode(layoutTree, {
+                runtime: true,
+                pageContent: verifiedContent,
+                identityProviders,
+              })
+            : verifiedContent}
+        </div>
+      )
+    }
+    return (
+      <div style={cssVars}>
+        <DeviceVerifyShell>
+          <DeviceVerifyResult
+            status={deviceResult}
+            onBackToStart={() => onDeviceReset?.()}
+          />
+        </DeviceVerifyShell>
+      </div>
+    )
+  }
 
   if (!pageIsValid || (layoutTree.length > 0 && !layoutIsValid)) {
     return (

--- a/front/src/pages/authentication/hooks/use-portal-page-submit.ts
+++ b/front/src/pages/authentication/hooks/use-portal-page-submit.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { AuthenticationStatus } from '@/api/api.interface'
@@ -9,9 +9,13 @@ import {
 } from '@/api/auth.api'
 import { useForgotPassword, useResetPassword } from '@/api/password-reset.api'
 import { useSendMagicLink, useSetupOtp, useVerifyOtp } from '@/api/trident.api'
+import { useDeviceVerify } from '@/api/device.api'
 import type { Schemas } from '@/api/api.client'
 import { useAuth } from '@/hooks/use-auth'
 import { useOAuthParams } from './use-oauth-params'
+import { POST_LOGIN_RETURN_KEY } from '../feature/page-device-verify-feature'
+
+export type DeviceVerifyResult = 'approved' | 'denied' | null
 
 /**
  * Returns an `onSubmit(FormData)` handler tailored to the portal page type.
@@ -38,6 +42,21 @@ export function usePortalPageSubmit(
    * something" hint instead of staring at a frozen form.
    */
   isSubmitting: boolean
+  /**
+   * Device-verify only: the deny action. Fired by the wrapper when a
+   * `device_deny_button` (`data-fk-action="device-deny"`) is clicked —
+   * reads the typed `user_code` from the form and POSTs with action=deny.
+   */
+  onDeviceDeny?: (data: FormData) => void
+  /**
+   * Device-verify only: `'approved'` / `'denied'` once the backend has
+   * recorded the decision. The wrapper swaps the custom tree for the
+   * hardcoded result screen when this is set; `null` while the form is
+   * still being filled in.
+   */
+  deviceResult?: DeviceVerifyResult
+  /** Device-verify only: clears the result so the user can verify another code. */
+  onDeviceReset?: () => void
 } {
   const onFormError = options?.onFormError
   const { realm_name, getAuthParamsFromUrl } = useOAuthParams()
@@ -305,6 +324,84 @@ export function usePortalPageSubmit(
     [realm_name, resendVerification],
   )
 
+  // Device verify (RFC 8628): approve is the form submit, deny is the
+  // `data-fk-action="device-deny"` button routed back here by the wrapper.
+  // Both read the typed `user_code` (the segmented input holds 8 flat chars,
+  // so we re-insert the dash to match the stored XXXX-XXXX code) and POST to
+  // the verify endpoint. A 401 means "not signed in yet" — stash the return
+  // URL and bounce to login, exactly like the hardcoded device feature.
+  const { mutateAsync: verifyDevice, isPending: isVerifyingDevice } = useDeviceVerify()
+  const [deviceResult, setDeviceResult] = useState<DeviceVerifyResult>(null)
+  const deviceRedirectingToLogin = useRef(false)
+  const runDeviceVerify = useCallback(
+    async (data: FormData, action: 'approve' | 'deny') => {
+      const raw = String(data.get('user_code') ?? '')
+        .trim()
+        .toUpperCase()
+        .replace('-', '')
+      if (raw.length !== 8) {
+        onFormError?.('Enter the 8-character code shown on your device.')
+        return
+      }
+      const userCode = `${raw.slice(0, 4)}-${raw.slice(4)}`
+      onFormError?.(null)
+      try {
+        const response = await verifyDevice({
+          realm: realm_name ?? 'master',
+          data: { user_code: userCode, action },
+        })
+        setDeviceResult(response.status === 'denied' ? 'denied' : 'approved')
+      } catch (err) {
+        const error = err as {
+          status?: number
+          data?: { error_description?: string; redirect_uri?: string }
+          message?: string
+        }
+        if (error.status === 401) {
+          if (deviceRedirectingToLogin.current) return
+          deviceRedirectingToLogin.current = true
+          try {
+            sessionStorage.setItem(
+              POST_LOGIN_RETURN_KEY,
+              error.data?.redirect_uri ??
+                `${window.location.pathname}${window.location.search}`,
+            )
+          } catch {
+            // sessionStorage disabled — the user lands on /overview after
+            // login instead of back here. Acceptable degradation.
+          }
+          navigate(`/realms/${realm_name ?? 'master'}/authentication/login`, {
+            replace: true,
+          })
+          return
+        }
+        const description =
+          error.data?.error_description ??
+          error.message ??
+          'Unable to verify this code. Please try again.'
+        onFormError?.(description)
+      }
+    },
+    [navigate, onFormError, realm_name, verifyDevice],
+  )
+  const deviceApproveSubmit = useCallback(
+    (data: FormData) => {
+      void runDeviceVerify(data, 'approve')
+    },
+    [runDeviceVerify],
+  )
+  const deviceDenySubmit = useCallback(
+    (data: FormData) => {
+      void runDeviceVerify(data, 'deny')
+    },
+    [runDeviceVerify],
+  )
+  const deviceReset = useCallback(() => {
+    deviceRedirectingToLogin.current = false
+    setDeviceResult(null)
+    onFormError?.(null)
+  }, [onFormError])
+
   // TOTP setup: submit reads the 6-digit code + optional device label from
   // the form, pulls the `secret` from the cached `useSetupOtp` query
   // (already prefetched by `PortalLayoutWrapper`), and posts to verify.
@@ -425,6 +522,15 @@ export function usePortalPageSubmit(
   }
   if (pageType === 'reset_password') {
     return { onSubmit: resetPasswordSubmit, isSubmitting: isResetPasswordPending }
+  }
+  if (pageType === 'device_verify') {
+    return {
+      onSubmit: deviceApproveSubmit,
+      onDeviceDeny: deviceDenySubmit,
+      deviceResult,
+      onDeviceReset: deviceReset,
+      isSubmitting: isVerifyingDevice,
+    }
   }
 
   return { isSubmitting: false }

--- a/front/src/pages/authentication/page-authentication.tsx
+++ b/front/src/pages/authentication/page-authentication.tsx
@@ -118,9 +118,19 @@ export default function PageAuthentication() {
       {/* Routes without a portal page type render bare. */}
       <Route path='/callback' element={<PageCallbackFeature />} />
       <Route path='/required-action' element={<PageRequiredActionFeature />} />
-      {/* RFC 8628 §3.3 device verification page. Rendered bare — no
-          PortalPageType variant yet, theme builder support is a follow-up. */}
-      <Route path='/device' element={<PageDeviceVerifyFeature />} />
+      {/* RFC 8628 §3.3 device verification page. Wrapped in <Portal> so realm
+          admins can customise the code-entry screen via the theme builder
+          (`device_verify` page type); `PageDeviceVerifyFeature` is the React
+          fallback when no valid custom tree exists. The post-decision
+          approved / denied result screen stays hardcoded either way. */}
+      <Route
+        path='/device'
+        element={
+          <Portal pageType='device_verify'>
+            <PageDeviceVerifyFeature />
+          </Portal>
+        }
+      />
       {/* "Check your inbox" screen reached right after registration — uses
           the `verify_email` portal pageType so the admin's customised
           design (heading, layout, link styling, theme tokens) applies

--- a/front/src/pages/authentication/ui/page-device-verify.tsx
+++ b/front/src/pages/authentication/ui/page-device-verify.tsx
@@ -185,7 +185,7 @@ export default function PageDeviceVerify({
   )
 }
 
-function DeviceVerifyShell({ children }: { children: React.ReactNode }) {
+export function DeviceVerifyShell({ children }: { children: React.ReactNode }) {
   return (
     <div className='login-shell relative flex min-h-svh items-center justify-center px-6 py-10'>
       <div className='relative z-10 w-full max-w-sm md:max-w-md lg:max-w-lg'>
@@ -199,7 +199,7 @@ function DeviceVerifyShell({ children }: { children: React.ReactNode }) {
   )
 }
 
-function DeviceVerifyResult({
+export function DeviceVerifyResult({
   status,
   onBackToStart,
 }: {

--- a/front/src/pages/portal/themes/feature/page-theme-builder-feature.tsx
+++ b/front/src/pages/portal/themes/feature/page-theme-builder-feature.tsx
@@ -34,6 +34,8 @@ const PAGE_TYPES = new Set<PageType>([
   'verify_email',
   'email_verified',
   'totp_setup',
+  'device_verify',
+  'device_verified',
 ])
 
 const SECTIONS = new Set<PortalThemeBuilderSection>(['theme', 'layout'])

--- a/front/src/pages/portal/themes/ui/page-theme-builder.tsx
+++ b/front/src/pages/portal/themes/ui/page-theme-builder.tsx
@@ -37,6 +37,8 @@ const PAGE_TYPES: { id: PageType; label: string }[] = [
   { id: 'verify_email', label: 'Verify email' },
   { id: 'email_verified', label: 'Email verified' },
   { id: 'totp_setup', label: 'TOTP setup' },
+  { id: 'device_verify', label: 'Device verify' },
+  { id: 'device_verified', label: 'Device verified' },
 ]
 
 interface Props {


### PR DESCRIPTION
Implement https://github.com/ferriskey/ferriskey/issues/1079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme support for two new device verification pages, including customizable content in the portal builder.
  * Introduced new device verification UI elements for entering a user code and choosing approve/deny actions.
  * Added a completed verification state for approved device flows.

* **Bug Fixes**
  * Updated authentication and theme loading so the new device pages render consistently within the portal layout.
  * Improved device-code handling to normalize and validate user input before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->