### PR TITLE
feat: wire themes & email templates into the CIAM console branding

### DIFF
--- a/front/src/components/layout/product-layout.tsx
+++ b/front/src/components/layout/product-layout.tsx
@@ -65,7 +65,7 @@ export default function ProductLayout() {
   const activeSection = findActiveSection(pathname, activeRealm)
 
   return (
-    <div className='min-h-screen bg-background flex flex-col'>
+    <div className='h-screen bg-background flex flex-col overflow-hidden'>
       {/* Top Bar — breadcrumb + profile */}
       <header className='sticky top-0 z-20 flex h-12 items-center gap-2 sm:gap-3 border-b border-border bg-background px-3 sm:px-6'>
         <Link to={`/realms/${activeRealm}/overview`} className='flex items-center gap-2 shrink-0'>
@@ -194,7 +194,7 @@ export default function ProductLayout() {
       </header>
 
       {/* Horizontal section nav */}
-      <nav className='sticky top-12 z-10 flex h-12 items-stretch gap-1 border-b border-border bg-background px-3 sm:px-6 overflow-x-auto scrollbar-none'>
+      <nav className='sticky top-12 z-10 flex h-12 items-stretch gap-1 border-b border-border bg-background px-3 sm:px-6 overflow-x-hidden'>
         {productSections.map((s) => {
           const isActive = activeSection?.key === s.key
           return (
@@ -278,7 +278,7 @@ export default function ProductLayout() {
           </aside>
         )}
 
-        <main className='flex-1 min-w-0 overflow-x-hidden'>
+        <main className='flex flex-col flex-1 min-w-0 min-h-0 overflow-y-auto overflow-x-hidden'>
           <Outlet />
         </main>
       </div>

--- a/front/src/components/layout/product-nav-config.ts
+++ b/front/src/components/layout/product-nav-config.ts
@@ -166,6 +166,13 @@ export const productSections: ProductSection[] = [
         to: (r) => `${consolePath(r)}/branding/email-templates`,
         match: (p, r) => startsWith(p, `${consolePath(r)}/branding/email-templates`),
       },
+      {
+        label: 'Themes',
+        description: 'Portal appearance',
+        icon: Palette,
+        to: (r) => `${consolePath(r)}/branding/themes`,
+        match: (p, r) => startsWith(p, `${consolePath(r)}/branding/themes`),
+      },
     ],
   },
 ]

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,5 +1,13 @@
 @import "tailwindcss";
 
+@utility scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 @theme {
   --color-border: var(--border);
   --color-input: var(--input);

--- a/front/src/pages/authentication/components/portal-layout-wrapper.tsx
+++ b/front/src/pages/authentication/components/portal-layout-wrapper.tsx
@@ -234,7 +234,37 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
     (layoutId && isLayoutLoading) ||
     isRequirementsLoading
   ) {
-    return <div style={cssVars}>{children}</div>
+    // While the active theme / layout / requirements resolve, paint a themed
+    // (background-only) surface instead of the hardcoded React fallback —
+    // showing the fallback here flashes the default page structure + colours
+    // for a frame before the custom tree replaces it, which reads as the
+    // screen "jumping" and the base/custom themes blinking.
+    //
+    // BUT `children` (PageLoginFeature) owns the auth-flow bootstrap: when the
+    // session cookie isn't set yet, its effect redirects to the OIDC authorize
+    // endpoint to create it. Custom-theme realms render the custom tree (not
+    // `children`) once loaded, so this loading phase is the ONLY place that
+    // bootstrap runs for them — dropping it entirely left them with no session
+    // (passkey/login → 401 "Missing session cookie"). So we keep it MOUNTED
+    // but visually hidden: its effects (the redirect) still run, the user just
+    // never sees the fallback form flash.
+    return (
+      <div style={{ ...cssVars, minHeight: '100vh', background: 'var(--fk-color-page-bg)' }}>
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            width: 0,
+            height: 0,
+            overflow: 'hidden',
+            visibility: 'hidden',
+            pointerEvents: 'none',
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    )
   }
 
   // Page content: realm admin's custom tree when present, fall back to the

--- a/front/src/pages/console-branding/page-console-branding.tsx
+++ b/front/src/pages/console-branding/page-console-branding.tsx
@@ -1,6 +1,8 @@
 import { Navigate, Route, Routes } from 'react-router'
 import PageEmailTemplateListFeature from '@/pages/email-template/feature/page-email-template-list-feature'
 import PageEmailTemplateBuilderFeature from '@/pages/email-template/feature/page-email-template-builder-feature'
+import PageThemesListFeature from '@/pages/portal/themes/feature/page-themes-list-feature'
+import PageThemeBuilderFeature from '@/pages/portal/themes/feature/page-theme-builder-feature'
 
 export default function PageConsoleBranding() {
   return (
@@ -8,6 +10,12 @@ export default function PageConsoleBranding() {
       <Route index element={<Navigate to='email-templates' replace />} />
       <Route path='email-templates' element={<PageEmailTemplateListFeature />} />
       <Route path='email-templates/:template_id/builder' element={<PageEmailTemplateBuilderFeature />} />
+      {/* Portal themes, rendered inside the console chrome (shared with the
+          admin portal; navigation is path-aware so it stays in the console). */}
+      <Route path='themes' element={<PageThemesListFeature />} />
+      <Route path='themes/:theme_id' element={<PageThemeBuilderFeature />} />
+      <Route path='themes/:theme_id/:section' element={<PageThemeBuilderFeature />} />
+      <Route path='themes/:theme_id/pages/:page_type' element={<PageThemeBuilderFeature />} />
     </Routes>
   )
 }

--- a/front/src/pages/email-template/feature/page-email-template-builder-feature.tsx
+++ b/front/src/pages/email-template/feature/page-email-template-builder-feature.tsx
@@ -7,11 +7,11 @@ import {
 import type { BuilderNode } from '@/lib/builder-core'
 import { type EmailTemplatePreset, createMjmlAdapter } from '@/lib/builder-mjml'
 import {
-  EMAIL_TEMPLATES_URL,
+  emailTemplatesListUrl,
   type EmailTemplateRouterParams,
 } from '@/routes/sub-router/email-template.router'
 import { useCallback, useMemo, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import PageEmailTemplateBuilder from '../ui/page-email-template-builder'
 
 const EMAIL_TYPES = [
@@ -23,8 +23,10 @@ const EMAIL_TYPES = [
 export default function PageEmailTemplateBuilderFeature() {
   const { realm_name, template_id } = useParams<EmailTemplateRouterParams>()
   const navigate = useNavigate()
+  const { pathname } = useLocation()
   const realm = realm_name ?? 'master'
   const isNew = template_id === 'new'
+  const listUrl = emailTemplatesListUrl(pathname, realm)
 
   const { data: templateData, isLoading } = useGetEmailTemplate({
     realm,
@@ -42,7 +44,6 @@ export default function PageEmailTemplateBuilderFeature() {
   return (
     <BuilderFeatureInner
       key={templateData?.data?.id ?? 'new'}
-      realmName={realm_name}
       realm={realm}
       templateId={template_id ?? ''}
       isNew={isNew}
@@ -54,12 +55,12 @@ export default function PageEmailTemplateBuilderFeature() {
           : []
       }
       navigate={navigate}
+      listUrl={listUrl}
     />
   )
 }
 
 function BuilderFeatureInner({
-  realmName,
   realm,
   templateId,
   isNew,
@@ -67,8 +68,8 @@ function BuilderFeatureInner({
   initialEmailType,
   initialTree,
   navigate,
+  listUrl,
 }: {
-  realmName: string | undefined
   realm: string
   templateId: string
   isNew: boolean
@@ -76,6 +77,7 @@ function BuilderFeatureInner({
   initialEmailType: string
   initialTree: BuilderNode[]
   navigate: ReturnType<typeof useNavigate>
+  listUrl: string
 }) {
   const [name, setName] = useState(initialName)
   const [emailType, setEmailType] = useState(initialEmailType)
@@ -109,7 +111,7 @@ function BuilderFeatureInner({
         },
         {
           onSuccess: () => {
-            navigate(EMAIL_TEMPLATES_URL(realmName))
+            navigate(listUrl)
           },
         },
       )
@@ -127,7 +129,7 @@ function BuilderFeatureInner({
   }
 
   const handleBack = () => {
-    navigate(EMAIL_TEMPLATES_URL(realmName))
+    navigate(listUrl)
   }
 
   return (

--- a/front/src/pages/portal-layouts/components/sidebar-tabs.tsx
+++ b/front/src/pages/portal-layouts/components/sidebar-tabs.tsx
@@ -18,7 +18,7 @@ interface Props {
  */
 export function SidebarTabs({ current, onChange }: Props) {
   return (
-    <div className='flex items-center gap-1 border-b border-border bg-muted/30 p-1'>
+    <div className='flex items-center gap-1 overflow-x-auto scrollbar-none border-b border-border bg-muted/30 p-1'>
       <TabButton
         active={current === 'components'}
         onClick={() => onChange('components')}
@@ -60,7 +60,7 @@ function TabButton({
         active
           ? 'bg-background text-foreground shadow-sm'
           : 'text-muted-foreground hover:text-foreground'
-      }`}
+      } whitespace-nowrap`}
     >
       {icon}
       {label}

--- a/front/src/pages/portal/components/portal-overview-header.tsx
+++ b/front/src/pages/portal/components/portal-overview-header.tsx
@@ -1,8 +1,8 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { OverviewHeader } from '@/components/ui/overview-header'
 import type { RouterParams } from '@/routes/router'
 import { PORTAL_LAYOUTS_URL } from '@/routes/sub-router/portal-layouts.router'
-import { PORTAL_THEMES_URL } from '@/routes/sub-router/portal-theme.router'
+import { CONSOLE_THEMES_URL, PORTAL_THEMES_URL } from '@/routes/sub-router/portal-theme.router'
 
 type PortalTab = 'themes' | 'layouts'
 
@@ -17,22 +17,35 @@ interface Props {
 export function PortalOverviewHeader({ activeTab, primaryAction }: Props) {
   const { realm_name } = useParams<RouterParams>()
   const navigate = useNavigate()
+  const { pathname } = useLocation()
   const realm = realm_name ?? 'master'
+  // In the console (CIAM) only themes are exposed (layouts stay admin-only),
+  // so we drop the Layouts tab there. The admin portal keeps both tabs.
+  const isConsole = pathname.includes('/console/')
 
-  const tabs = [
-    {
-      key: 'themes',
-      label: 'Themes',
-      onClick: () => navigate(PORTAL_THEMES_URL(realm)),
-      active: activeTab === 'themes',
-    },
-    {
-      key: 'layouts',
-      label: 'Layouts',
-      onClick: () => navigate(PORTAL_LAYOUTS_URL(realm)),
-      active: activeTab === 'layouts',
-    },
-  ]
+  const tabs = isConsole
+    ? [
+        {
+          key: 'themes',
+          label: 'Themes',
+          onClick: () => navigate(CONSOLE_THEMES_URL(realm)),
+          active: activeTab === 'themes',
+        },
+      ]
+    : [
+        {
+          key: 'themes',
+          label: 'Themes',
+          onClick: () => navigate(PORTAL_THEMES_URL(realm)),
+          active: activeTab === 'themes',
+        },
+        {
+          key: 'layouts',
+          label: 'Layouts',
+          onClick: () => navigate(PORTAL_LAYOUTS_URL(realm)),
+          active: activeTab === 'layouts',
+        },
+      ]
 
   return (
     <OverviewHeader

--- a/front/src/pages/portal/themes/components/page-component-library.tsx
+++ b/front/src/pages/portal/themes/components/page-component-library.tsx
@@ -100,8 +100,14 @@ export function PageComponentLibrary({ requiredTypes, pageType }: Props) {
   const ungrouped = generic.filter((c) => !groupedTypes.has(c.type))
 
   return (
-    <div className='flex w-full min-w-0 flex-col'>
-      <SidebarTabs current={tab} onChange={setTab} />
+    <div className='flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden'>
+      {/* Tabs stay pinned: they live outside the scroll region so a wide
+          Tree / category list scrolls horizontally on its own without
+          dragging (and stretching) the Components/Presets/Tree row. */}
+      <div className='shrink-0'>
+        <SidebarTabs current={tab} onChange={setTab} />
+      </div>
+      <div className='min-h-0 min-w-0 flex-1 overflow-auto'>
       {tab === 'components' && (
         <div className='flex w-full min-w-0 flex-col gap-3 p-2'>
           {groupedItems.map((g) =>
@@ -131,6 +137,7 @@ export function PageComponentLibrary({ requiredTypes, pageType }: Props) {
       )}
       {tab === 'presets' && <PresetsTab />}
       {tab === 'tree' && <ComponentTree />}
+      </div>
     </div>
   )
 }

--- a/front/src/pages/portal/themes/components/page-tree-editor.tsx
+++ b/front/src/pages/portal/themes/components/page-tree-editor.tsx
@@ -181,10 +181,12 @@ export default function PageTreeEditor({
             <div className='min-h-0 min-w-0 overflow-hidden border-b border-border'>
               <ScrollArea className='h-full w-full'>{leftRailNav}</ScrollArea>
             </div>
-            <div className='min-h-0 min-w-0 overflow-hidden'>
-              <ScrollArea className='h-full w-full'>
-                <PageComponentLibrary requiredTypes={requirements} pageType={pageType} />
-              </ScrollArea>
+            {/* The library pins its own tabs row and scrolls only the panel
+                body (both axes), so a deep/wide tree scrolls within the rail
+                without dragging the tabs. `min-w-0` keeps the scroll inside
+                the 220px column rather than pushing the canvas. */}
+            <div className='flex min-h-0 min-w-0 flex-col overflow-hidden'>
+              <PageComponentLibrary requiredTypes={requirements} pageType={pageType} />
             </div>
           </aside>
 

--- a/front/src/pages/portal/themes/feature/page-theme-builder-feature.tsx
+++ b/front/src/pages/portal/themes/feature/page-theme-builder-feature.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { BasicSpinner } from '@/components/ui/spinner'
 import {
@@ -12,9 +12,9 @@ import {
 import { useGetPortalLayouts } from '@/api/portal-layouts.api'
 import type { RouterParams } from '@/routes/router'
 import {
-  PORTAL_THEMES_URL,
-  PORTAL_THEME_BUILDER_PAGE_URL,
-  PORTAL_THEME_BUILDER_SECTION_URL,
+  themeBuilderPageUrl,
+  themeBuilderSectionUrl,
+  themesListUrl,
   type PortalThemeBuilderSection,
 } from '@/routes/sub-router/portal-theme.router'
 import { PortalThemeProvider } from '@/pages/portal-theme/context/portal-theme-context'
@@ -62,15 +62,16 @@ export default function PageThemeBuilderFeature() {
     RouterParams & { theme_id: string; section?: string; page_type?: string }
   >()
   const navigate = useNavigate()
+  const { pathname } = useLocation()
   const realm = realm_name ?? 'master'
   const themeId = theme_id ?? ''
   const activeTab = resolveTab(section, page_type)
 
   const handleTabChange = (tab: BuilderTab) => {
     if (tab.kind === 'page') {
-      navigate(PORTAL_THEME_BUILDER_PAGE_URL(realm, themeId, tab.pageType))
+      navigate(themeBuilderPageUrl(pathname, realm, themeId, tab.pageType))
     } else {
-      navigate(PORTAL_THEME_BUILDER_SECTION_URL(realm, themeId, tab.section))
+      navigate(themeBuilderSectionUrl(pathname, realm, themeId, tab.section))
     }
   }
 
@@ -91,7 +92,7 @@ export default function PageThemeBuilderFeature() {
 
   const theme = themeData.data
 
-  const handleBack = () => navigate(PORTAL_THEMES_URL(realm))
+  const handleBack = () => navigate(themesListUrl(pathname, realm))
 
   // The save button fires metadata + N pages in parallel. We only want one
   // toast at the end: success if every call passed, error otherwise — so a
@@ -164,6 +165,10 @@ export default function PageThemeBuilderFeature() {
         onTabChange={handleTabChange}
         onSaveTheme={handleSaveTheme}
         onActivate={handleActivate}
+        // The console renders the builder inside ProductLayout's bounded,
+        // scrollable <main>, so it fills the parent; the admin portal has no
+        // such ancestor and falls back to the viewport-height calc.
+        fillParent={pathname.includes('/console/')}
       />
     </PortalThemeProvider>
   )

--- a/front/src/pages/portal/themes/feature/page-themes-list-feature.tsx
+++ b/front/src/pages/portal/themes/feature/page-themes-list-feature.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import type { RouterParams } from '@/routes/router'
 import {
   useActivatePortalTheme,
@@ -7,13 +7,14 @@ import {
   useGetActivePortalTheme,
   useListPortalThemes,
 } from '@/api/portal-theme.api'
-import { PORTAL_THEME_BUILDER_URL } from '@/routes/sub-router/portal-theme.router'
+import { themeBuilderUrl } from '@/routes/sub-router/portal-theme.router'
 import PageThemesList from '../ui/page-themes-list'
 import { defaultTheme } from '@/pages/portal-theme/lib/theme'
 
 export default function PageThemesListFeature() {
   const { realm_name } = useParams<RouterParams>()
   const navigate = useNavigate()
+  const { pathname } = useLocation()
   const realm = realm_name ?? 'master'
 
   const { data: listData, isLoading } = useListPortalThemes({ realm })
@@ -34,7 +35,7 @@ export default function PageThemesListFeature() {
         onSuccess: (res) => {
           const newId = res?.data?.id
           if (newId) {
-            navigate(PORTAL_THEME_BUILDER_URL(realm, newId))
+            navigate(themeBuilderUrl(pathname, realm, newId))
           }
         },
       },
@@ -42,7 +43,7 @@ export default function PageThemesListFeature() {
   }
 
   const handleEdit = (themeId: string) => {
-    navigate(PORTAL_THEME_BUILDER_URL(realm, themeId))
+    navigate(themeBuilderUrl(pathname, realm, themeId))
   }
 
   const handleActivate = (themeId: string) => {

--- a/front/src/pages/portal/themes/ui/page-theme-builder.tsx
+++ b/front/src/pages/portal/themes/ui/page-theme-builder.tsx
@@ -58,6 +58,14 @@ interface Props {
     pages: { pageType: PageType; tree: unknown }[]
   ) => void
   onActivate: () => void
+  /**
+   * When true the builder fills its parent (`h-full`) instead of computing its
+   * own viewport height. The console renders it inside ProductLayout's bounded,
+   * scrollable `<main>`, so filling the parent avoids fragile chrome-height
+   * math; the admin portal has no such bounded ancestor and keeps the viewport
+   * calc.
+   */
+  fillParent?: boolean
 }
 
 export default function PageThemeBuilder({
@@ -72,6 +80,7 @@ export default function PageThemeBuilder({
   onTabChange,
   onSaveTheme,
   onActivate,
+  fillParent = false,
 }: Props) {
   const [name, setName] = useState(theme.name)
   const [layoutId, setLayoutId] = useState<string | null>(theme.layout_id ?? null)
@@ -88,7 +97,18 @@ export default function PageThemeBuilder({
   }, [layoutId, layouts])
 
   return (
-    <div className='flex h-[calc(100vh-3rem)] w-full min-w-0 flex-col overflow-hidden'>
+    <div
+      className={cn(
+        'flex w-full min-w-0 flex-col overflow-hidden',
+        // In the console the parent <main> is a bounded flex column, so the
+        // builder fills it via flex (a flex-resolved height is definite, so
+        // the inner `h-full`/`flex-1` panels resolve — unlike `height:100%`,
+        // which collapses inside a flex item). The admin portal has no such
+        // ancestor and keeps the viewport-height calc.
+        fillParent && 'flex-1 min-h-0',
+      )}
+      style={fillParent ? undefined : { height: 'calc(100vh - 3rem)' }}
+    >
       <header className='flex items-center gap-3 border-b border-border px-4 py-2'>
         <Button variant='ghost' size='icon' onClick={onBack}>
           <ArrowLeft size={16} />

--- a/front/src/pages/realm/feature/page-realm-settings-email-feature.tsx
+++ b/front/src/pages/realm/feature/page-realm-settings-email-feature.tsx
@@ -2,7 +2,7 @@ import { useGetEmailTemplates, useDeleteEmailTemplate } from '@/api/email-templa
 import { useGetRealm, useUpdateRealmSettings } from '@/api/realm.api'
 import { RouterParams } from '@/routes/router'
 import { useNavigate, useParams } from 'react-router'
-import { EMAIL_TEMPLATE_BUILDER_URL } from '@/routes/sub-router/email-template.router'
+import { ADMIN_EMAIL_TEMPLATE_BUILDER_URL } from '@/routes/sub-router/email-template.router'
 import PageRealmSettingsEmail from '../ui/page-realm-settings-email'
 
 export default function PageRealmSettingsEmailFeature() {
@@ -15,11 +15,11 @@ export default function PageRealmSettingsEmailFeature() {
   const { mutate: updateSettings } = useUpdateRealmSettings()
 
   const handleEditTemplate = (templateId: string) => {
-    navigate(EMAIL_TEMPLATE_BUILDER_URL(realm_name, templateId))
+    navigate(ADMIN_EMAIL_TEMPLATE_BUILDER_URL(realm_name, templateId))
   }
 
   const handleCreateTemplate = () => {
-    navigate(EMAIL_TEMPLATE_BUILDER_URL(realm_name, 'new'))
+    navigate(ADMIN_EMAIL_TEMPLATE_BUILDER_URL(realm_name, 'new'))
   }
 
   const handleDeleteTemplate = (templateId: string) => {

--- a/front/src/routes/sub-router/email-template.router.ts
+++ b/front/src/routes/sub-router/email-template.router.ts
@@ -1,4 +1,4 @@
-import { REALM_URL } from '../router'
+import { REALM_SETTINGS_URL, REALM_URL } from '../router'
 
 const CONSOLE_BRANDING_URL = (realmName = ':realmName') =>
   `${REALM_URL(realmName)}/console/branding`
@@ -11,6 +11,26 @@ export const EMAIL_TEMPLATE_URL = (realmName = ':realmName', templateId = ':temp
 
 export const EMAIL_TEMPLATE_BUILDER_URL = (realmName = ':realmName', templateId = ':templateId') =>
   `${EMAIL_TEMPLATE_URL(realmName, templateId)}/builder`
+
+// Admin (IAM) — email templates also live under the realm root so the builder
+// renders inside the admin Layout instead of the console ProductLayout.
+export const ADMIN_EMAIL_TEMPLATES_URL = (realmName = ':realmName') =>
+  `${REALM_URL(realmName)}/email-templates`
+
+export const ADMIN_EMAIL_TEMPLATE_BUILDER_URL = (
+  realmName = ':realmName',
+  templateId = ':templateId',
+) => `${ADMIN_EMAIL_TEMPLATES_URL(realmName)}/${templateId}/builder`
+
+/**
+ * Where the email builder returns to (Back / after save), derived from the
+ * current path: the console branding list in CIAM mode, otherwise the admin
+ * Realm Settings → Email tab.
+ */
+export const emailTemplatesListUrl = (pathname: string, realmName = ':realmName') =>
+  pathname.includes('/console/')
+    ? EMAIL_TEMPLATES_URL(realmName)
+    : `${REALM_SETTINGS_URL(realmName)}/email`
 
 export type EmailTemplateRouterParams = {
   realm_name: string

--- a/front/src/routes/sub-router/portal-theme.router.ts
+++ b/front/src/routes/sub-router/portal-theme.router.ts
@@ -27,6 +27,52 @@ export const PORTAL_THEME_URL = (realmName = ':realmName') => `${PORTAL_URL(real
 export const PORTAL_BUILDER_DEMO_URL = (realmName = ':realmName') =>
   `${PORTAL_URL(realmName)}/builder-demo`
 
+// Console (CIAM) — themes are reachable from the Branding section and render
+// full-viewport (outside the console ProductLayout chrome).
+export const CONSOLE_THEMES_URL = (realmName = ':realmName') =>
+  `${REALM_URL(realmName)}/console/branding/themes`
+export const CONSOLE_THEME_BUILDER_URL = (realmName = ':realmName', themeId = ':themeId') =>
+  `${CONSOLE_THEMES_URL(realmName)}/${themeId}`
+
+/**
+ * Theme URLs scoped to the current context: the console branding section in
+ * CIAM mode, otherwise the admin portal. Lets the shared themes list/builder
+ * components keep navigation within the panel they were opened from.
+ */
+const inConsole = (pathname: string) => pathname.includes('/console/')
+
+export const themesListUrl = (pathname: string, realmName = ':realmName') =>
+  inConsole(pathname) ? CONSOLE_THEMES_URL(realmName) : PORTAL_THEMES_URL(realmName)
+
+export const themeBuilderUrl = (
+  pathname: string,
+  realmName = ':realmName',
+  themeId = ':themeId',
+) =>
+  inConsole(pathname)
+    ? CONSOLE_THEME_BUILDER_URL(realmName, themeId)
+    : PORTAL_THEME_BUILDER_URL(realmName, themeId)
+
+export const themeBuilderSectionUrl = (
+  pathname: string,
+  realmName = ':realmName',
+  themeId = ':themeId',
+  section: PortalThemeBuilderSection = 'theme',
+) =>
+  inConsole(pathname)
+    ? `${CONSOLE_THEME_BUILDER_URL(realmName, themeId)}/${section}`
+    : PORTAL_THEME_BUILDER_SECTION_URL(realmName, themeId, section)
+
+export const themeBuilderPageUrl = (
+  pathname: string,
+  realmName = ':realmName',
+  themeId = ':themeId',
+  pageType = ':page_type',
+) =>
+  inConsole(pathname)
+    ? `${CONSOLE_THEME_BUILDER_URL(realmName, themeId)}/pages/${pageType}`
+    : PORTAL_THEME_BUILDER_PAGE_URL(realmName, themeId, pageType)
+
 export type PortalThemeRouterParams = {
   realm_name: string
   theme_id: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Themes section in the portal/console navigation, including a theme list and builder views.
  * Theme and email template navigation now adapts to the current app area for smoother routing.

* **Bug Fixes**
  * Improved layout scrolling and sizing to prevent content and tabs from overflowing.
  * Reduced theme and loading-screen flicker during portal startup.
  * Kept template navigation returning users to the correct list view after saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->