### PR TITLE
feat: enforce per-realm password policy on register, reset and password changes

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -69,3 +69,8 @@ jobs:
       # run as its own invocation without the shared-runtime harness.
       - name: run nonce id_token integration test
         run: cargo test -p ferriskey-api --test nonce_id_token_test -- --ignored
+
+      # Password policy enforcement: validates that the per-realm policy is
+      # applied to all password-set flows and is readable without auth.
+      - name: run password policy integration tests
+        run: cargo test -p ferriskey-api --test password_policy_test -- --ignored

--- a/api/src/application/http/authentication/handlers/registration.rs
+++ b/api/src/application/http/authentication/handlers/registration.rs
@@ -105,6 +105,11 @@ pub async fn registration_handler(
         .get("FERRISKEY_SESSION")
         .and_then(|c| Uuid::parse_str(c.value()).ok());
 
+    state
+        .service
+        .validate_password_policy(realm_name.clone(), &req.password)
+        .await?;
+
     let url_context = registration_url_context(
         &state.args.webapp_url,
         &base_url,

--- a/api/src/application/http/error.rs
+++ b/api/src/application/http/error.rs
@@ -1,6 +1,7 @@
 use ferriskey_core::domain::{
     authentication::device_flow::error::DeviceFlowError, common::entities::app_errors::CoreError,
-    portal_theme::validation::MissingBlocks, user::entities::RequiredAction,
+    password_policy::error::PasswordPolicyViolation, portal_theme::validation::MissingBlocks,
+    user::entities::RequiredAction,
 };
 use serde_json::{from_str, to_string};
 
@@ -272,6 +273,22 @@ impl From<CoreError> for ApiError {
             CoreError::PortalLayoutInUse => Self::BadRequest(
                 "Portal layout is referenced by one or more themes and cannot be deleted".into(),
             ),
+            CoreError::PasswordPolicyViolation(details) => {
+                match from_str::<Vec<PasswordPolicyViolation>>(&details) {
+                    Ok(violations) => Self::validation_errors(
+                        violations
+                            .into_iter()
+                            .map(|v| ValidationError {
+                                field: "password".into(),
+                                message: v.message.into(),
+                            })
+                            .collect(),
+                    ),
+                    Err(_) => {
+                        Self::BadRequest("Password does not meet the realm policy".into())
+                    }
+                }
+            }
         }
     }
 }

--- a/api/src/application/http/error.rs
+++ b/api/src/application/http/error.rs
@@ -284,9 +284,10 @@ impl From<CoreError> for ApiError {
                             })
                             .collect(),
                     ),
-                    Err(_) => {
-                        Self::BadRequest("Password does not meet the realm policy".into())
-                    }
+                    Err(_) => Self::validation_errors(vec![ValidationError {
+                        field: "password".into(),
+                        message: "Password does not meet the realm policy".into(),
+                    }]),
                 }
             }
         }

--- a/api/src/application/http/realm/handlers.rs
+++ b/api/src/application/http/realm/handlers.rs
@@ -3,6 +3,7 @@ pub mod delete_realm;
 pub mod delete_smtp_config;
 pub mod get_login_realm_settings;
 pub mod get_password_policy;
+pub mod get_public_password_policy;
 pub mod get_realm;
 pub mod get_smtp_config;
 pub mod get_user_realm_settings;

--- a/api/src/application/http/realm/handlers/get_public_password_policy.rs
+++ b/api/src/application/http/realm/handlers/get_public_password_policy.rs
@@ -1,0 +1,62 @@
+use axum::extract::{Path, State};
+use ferriskey_core::domain::password_policy::entity::PasswordPolicy;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::application::http::server::{
+    api_entities::{
+        api_error::{ApiError, ApiErrorResponse},
+        response::Response,
+    },
+    app_state::AppState,
+};
+
+/// A trimmed, anonymous-safe view of the realm password policy.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PublicPasswordPolicy {
+    pub min_length: i32,
+    pub require_uppercase: bool,
+    pub require_lowercase: bool,
+    pub require_number: bool,
+    pub require_special: bool,
+}
+
+impl From<PasswordPolicy> for PublicPasswordPolicy {
+    fn from(p: PasswordPolicy) -> Self {
+        Self {
+            min_length: p.min_length,
+            require_uppercase: p.require_uppercase,
+            require_lowercase: p.require_lowercase,
+            require_number: p.require_number,
+            require_special: p.require_special,
+        }
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/{realm_name}/password-policy/public",
+    tag = "realm",
+    summary = "Get public password policy for a realm",
+    description = "Returns the password policy rules for the specified realm. No authentication required.",
+    params(
+        ("realm_name" = String, Path, description = "Realm name"),
+    ),
+    responses(
+        (status = 200, description = "Password policy retrieved successfully", body = PublicPasswordPolicy),
+        (status = 401, description = "Realm not found", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn get_public_password_policy(
+    Path(realm_name): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Response<PublicPasswordPolicy>, ApiError> {
+    let policy = state
+        .service
+        .get_public_password_policy(realm_name)
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::OK(PublicPasswordPolicy::from(policy)))
+}

--- a/api/src/application/http/realm/handlers/get_public_password_policy.rs
+++ b/api/src/application/http/realm/handlers/get_public_password_policy.rs
@@ -44,7 +44,7 @@ impl From<PasswordPolicy> for PublicPasswordPolicy {
     ),
     responses(
         (status = 200, description = "Password policy retrieved successfully", body = PublicPasswordPolicy),
-        (status = 401, description = "Realm not found", body = ApiErrorResponse),
+        (status = 401, description = "Invalid realm", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     ),
 )]

--- a/api/src/application/http/realm/router.rs
+++ b/api/src/application/http/realm/router.rs
@@ -1,4 +1,7 @@
 use super::handlers::get_password_policy::{__path_get_password_policy, get_password_policy};
+use super::handlers::get_public_password_policy::{
+    __path_get_public_password_policy, get_public_password_policy,
+};
 use super::handlers::get_user_realms::{__path_get_user_realms, get_user_realms};
 use super::handlers::update_password_policy::{
     __path_update_password_policy, update_password_policy,
@@ -43,6 +46,7 @@ use utoipa::OpenApi;
     delete_smtp_config,
     get_password_policy,
     update_password_policy,
+    get_public_password_policy,
 ))]
 pub struct RealmApiDoc;
 
@@ -108,5 +112,12 @@ pub fn realm_routes(state: AppState) -> Router<AppState> {
                 state.args.server.root_path
             ),
             get(get_login_realm_settings_handler),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/password-policy/public",
+                state.args.server.root_path
+            ),
+            get(get_public_password_policy),
         )
 }

--- a/api/src/application/http/trident/handlers/reset_password.rs
+++ b/api/src/application/http/trident/handlers/reset_password.rs
@@ -32,7 +32,6 @@ const IDENTITY_COOKIE: &str = "FERRISKEY_IDENTITY";
 pub struct ResetPasswordRequest {
     pub token_id: Uuid,
     pub token: String,
-    #[validate(length(min = 8))]
     pub new_password: String,
 }
 
@@ -105,11 +104,16 @@ pub async fn verify_reset_token(
     )
 )]
 pub async fn reset_password_with_token(
-    Path(_realm_name): Path<String>,
+    Path(realm_name): Path<String>,
     State(state): State<AppState>,
     FullUrl(_, base_url): FullUrl,
     ValidateJson(payload): ValidateJson<ResetPasswordRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    state
+        .service
+        .validate_password_policy(realm_name, &payload.new_password)
+        .await?;
+
     let result = state
         .service
         .complete_password_reset(CompletePasswordResetInput {

--- a/api/src/application/http/trident/handlers/update_password.rs
+++ b/api/src/application/http/trident/handlers/update_password.rs
@@ -53,6 +53,11 @@ pub async fn update_password(
 ) -> Result<Response<UpdatePasswordResponse>, ApiError> {
     state
         .service
+        .validate_password_policy(realm_name.clone(), &payload.value)
+        .await?;
+
+    state
+        .service
         .update_password(
             identity,
             UpdatePasswordInput {

--- a/api/src/application/http/user/handlers/reset_password.rs
+++ b/api/src/application/http/user/handlers/reset_password.rs
@@ -58,6 +58,11 @@ pub async fn reset_password(
     );
     state
         .service
+        .validate_password_policy(realm_name.clone(), &payload.value)
+        .await?;
+
+    state
+        .service
         .reset_password(
             identity,
             ResetPasswordInput {

--- a/api/tests/password_policy_test.rs
+++ b/api/tests/password_policy_test.rs
@@ -229,14 +229,16 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(
-            user_response.status_code(),
-            201,
-            "user creation failed: {}",
+        let user_status = user_response.status_code();
+        assert!(
+            user_status == 200 || user_status == 201,
+            "user creation failed ({}): {}",
+            user_status,
             user_response.text()
         );
+        // The user-creation endpoint wraps its payload in a `data` envelope.
         let user_body: Value = user_response.json();
-        let user_id = user_body["id"]
+        let user_id = user_body["data"]["id"]
             .as_str()
             .expect("user id in response")
             .to_string();

--- a/api/tests/password_policy_test.rs
+++ b/api/tests/password_policy_test.rs
@@ -1,0 +1,280 @@
+/// Integration tests for per-realm password policy enforcement.
+///
+/// Requires a running Postgres instance. Run with:
+///   cargo test -p ferriskey-api --test password_policy_test -- --ignored
+///
+/// Environment variables (all optional, defaults shown):
+///   DATABASE_HOST=localhost  DATABASE_PORT=5432
+///   DATABASE_NAME=ferriskey  DATABASE_USER=ferriskey  DATABASE_PASSWORD=ferriskey
+#[cfg(test)]
+mod tests {
+    use std::{env, sync::Arc};
+
+    use axum::http::HeaderValue;
+    use axum_test::TestServer;
+    use ferriskey_api::{
+        application::http::server::{app_state::AppState, http_server::router},
+        args::Args,
+    };
+    use ferriskey_core::{
+        application::create_service,
+        domain::common::{
+            DatabaseConfig, FerriskeyConfig, entities::StartupConfig, ports::CoreService,
+        },
+    };
+    use serde_json::{Value, json};
+    use sqlx::Executor;
+    use uuid::Uuid;
+
+    fn env_or(key: &str, default: &str) -> String {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+
+    fn env_u16_or(key: &str, default: u16) -> u16 {
+        env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    struct TestContext {
+        server: TestServer,
+        realm_name: String,
+    }
+
+    async fn setup() -> TestContext {
+        let db_host = env_or("DATABASE_HOST", "localhost");
+        let db_port = env_u16_or("DATABASE_PORT", 5432);
+        let db_name = env_or("DATABASE_NAME", "ferriskey");
+        let db_user = env_or("DATABASE_USER", "ferriskey");
+        let db_password = env_or("DATABASE_PASSWORD", "ferriskey");
+
+        let schema = format!("pw_policy_test_{}", Uuid::new_v4().simple());
+
+        let admin_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+
+        let admin_pool = sqlx::PgPool::connect(&admin_url)
+            .await
+            .expect("connect admin pool");
+
+        admin_pool
+            .execute(sqlx::query(&format!(
+                "CREATE SCHEMA IF NOT EXISTS \"{}\"",
+                schema
+            )))
+            .await
+            .expect("create schema");
+
+        let schema_url = format!(
+            "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
+            db_user,
+            db_password,
+            db_host,
+            db_port,
+            db_name,
+            urlencoding::encode(&schema)
+        );
+
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+
+        sqlx::migrate!("../core/migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let service = create_service(FerriskeyConfig {
+            database: DatabaseConfig {
+                host: db_host,
+                port: db_port,
+                username: db_user,
+                password: db_password,
+                name: db_name,
+                schema: schema.clone(),
+            },
+        })
+        .await
+        .expect("create service");
+
+        let realm_name = format!("realm-{}", Uuid::new_v4().simple());
+
+        service
+            .initialize_application(StartupConfig {
+                master_realm_name: realm_name.clone(),
+                admin_username: "admin".to_string(),
+                admin_password: "admin".to_string(),
+                admin_email: "admin@test.local".to_string(),
+                // Use "ferriskey-admin" (not "admin-cli") to avoid the known
+                // harness bug (#1086) that breaks the admin password grant.
+                default_client_id: "ferriskey-admin".to_string(),
+            })
+            .await
+            .expect("initialize application");
+
+        let args = Arc::new(Args::default());
+        let state = AppState::new(args, service);
+        let app = router(state).expect("build router");
+        let server = TestServer::new(app).expect("create test server");
+
+        TestContext { server, realm_name }
+    }
+
+    fn auth_header(token: &str) -> HeaderValue {
+        format!("Bearer {}", token).parse().unwrap()
+    }
+
+    async fn get_admin_token(ctx: &TestContext) -> String {
+        let response = ctx
+            .server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/token",
+                ctx.realm_name
+            ))
+            .form(&[
+                ("grant_type", "password"),
+                ("client_id", "admin-cli"),
+                ("username", "admin"),
+                ("password", "admin"),
+            ])
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            200,
+            "admin token request failed: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        body["access_token"]
+            .as_str()
+            .expect("access_token in response")
+            .to_string()
+    }
+
+    /// Verifies:
+    ///  1. Admin can configure a strict password policy.
+    ///  2. The public endpoint returns the policy without auth.
+    ///  3. Resetting a user password with a weak value is rejected (422).
+    ///  4. Resetting with a strong value succeeds (200).
+    ///
+    /// Note: Registration enforcement shares the same `validate_password_policy`
+    /// seam as the other flows; it is not separately exercised here to avoid
+    /// the additional realm-setting setup required to enable self-registration.
+    #[tokio::test]
+    #[ignore]
+    async fn password_policy_is_enforced_and_public() {
+        let ctx = setup().await;
+        let admin_token = get_admin_token(&ctx).await;
+
+        // --- 1. Set a strict policy ---
+        let policy_response = ctx
+            .server
+            .put(&format!("/realms/{}/password-policy", ctx.realm_name))
+            .add_header("Authorization", auth_header(&admin_token))
+            .json(&json!({
+                "min_length": 10,
+                "require_uppercase": true,
+                "require_lowercase": true,
+                "require_number": true,
+                "require_special": true,
+            }))
+            .await;
+
+        assert_eq!(
+            policy_response.status_code(),
+            200,
+            "PUT password-policy failed: {}",
+            policy_response.text()
+        );
+
+        // --- 2. Public endpoint returns the policy without auth ---
+        let public_response = ctx
+            .server
+            .get(&format!(
+                "/realms/{}/password-policy/public",
+                ctx.realm_name
+            ))
+            .await;
+
+        assert_eq!(
+            public_response.status_code(),
+            200,
+            "GET password-policy/public failed: {}",
+            public_response.text()
+        );
+        let public_body: Value = public_response.json();
+        assert_eq!(
+            public_body["min_length"].as_i64(),
+            Some(10),
+            "expected min_length == 10"
+        );
+        assert_eq!(
+            public_body["require_uppercase"].as_bool(),
+            Some(true),
+            "expected require_uppercase == true"
+        );
+
+        // --- 3. Create a test user so we can reset their password ---
+        let user_response = ctx
+            .server
+            .post(&format!("/realms/{}/users", ctx.realm_name))
+            .add_header("Authorization", auth_header(&admin_token))
+            .json(&json!({
+                "username": format!("testuser-{}", Uuid::new_v4().simple()),
+                "email": format!("test-{}@example.com", Uuid::new_v4().simple()),
+            }))
+            .await;
+
+        assert_eq!(
+            user_response.status_code(),
+            201,
+            "user creation failed: {}",
+            user_response.text()
+        );
+        let user_body: Value = user_response.json();
+        let user_id = user_body["id"]
+            .as_str()
+            .expect("user id in response")
+            .to_string();
+
+        // --- 4. Weak password is rejected ---
+        let weak_reset = ctx
+            .server
+            .put(&format!(
+                "/realms/{}/users/{}/reset-password",
+                ctx.realm_name, user_id
+            ))
+            .add_header("Authorization", auth_header(&admin_token))
+            .json(&json!({ "value": "weak", "temporary": false }))
+            .await;
+
+        assert_eq!(
+            weak_reset.status_code(),
+            422,
+            "weak password should be rejected (422), got: {}",
+            weak_reset.text()
+        );
+
+        // --- 5. Strong password succeeds ---
+        let strong_reset = ctx
+            .server
+            .put(&format!(
+                "/realms/{}/users/{}/reset-password",
+                ctx.realm_name, user_id
+            ))
+            .add_header("Authorization", auth_header(&admin_token))
+            .json(&json!({ "value": "StrongPass1!", "temporary": false }))
+            .await;
+
+        assert_eq!(
+            strong_reset.status_code(),
+            200,
+            "strong password should succeed, got: {}",
+            strong_reset.text()
+        );
+    }
+}

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -457,6 +457,37 @@ impl ApplicationService {
             .await
     }
 
+    pub async fn validate_password_policy(
+        &self,
+        realm_name: String,
+        password: &str,
+    ) -> Result<(), CoreError> {
+        let realm = self
+            .realm_service
+            .realm_repository
+            .get_by_name(&realm_name)
+            .await?
+            .ok_or(CoreError::InvalidRealm)?;
+        self.password_policy_service
+            .enforce(realm.id.into(), password)
+            .await
+    }
+
+    pub async fn get_public_password_policy(
+        &self,
+        realm_name: String,
+    ) -> Result<PasswordPolicy, CoreError> {
+        let realm = self
+            .realm_service
+            .realm_repository
+            .get_by_name(&realm_name)
+            .await?
+            .ok_or(CoreError::InvalidRealm)?;
+        self.password_policy_service
+            .get_policy_public(realm.id.into())
+            .await
+    }
+
     /// Device authorization endpoint (RFC 8628 §3.1).
     ///
     /// Resolves the realm and client, builds the realm-scoped verification URI

--- a/core/src/domain/password_policy/entity.rs
+++ b/core/src/domain/password_policy/entity.rs
@@ -4,6 +4,8 @@ use sqlx::FromRow;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+use super::error::PasswordPolicyError;
+
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct PasswordPolicy {
     pub id: Uuid,
@@ -32,6 +34,136 @@ impl PasswordPolicy {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
+    }
+
+    pub fn validate(&self, password: &str) -> Result<(), Vec<PasswordPolicyError>> {
+        let mut errors = Vec::new();
+
+        if password.len() < self.min_length as usize {
+            errors.push(PasswordPolicyError::TooShort {
+                min: self.min_length,
+                actual: password.len(),
+            });
+        }
+
+        if self.require_uppercase && !password.chars().any(|c| c.is_uppercase()) {
+            errors.push(PasswordPolicyError::MissingUppercase);
+        }
+
+        if self.require_lowercase && !password.chars().any(|c| c.is_lowercase()) {
+            errors.push(PasswordPolicyError::MissingLowercase);
+        }
+
+        if self.require_number && !password.chars().any(|c| c.is_numeric()) {
+            errors.push(PasswordPolicyError::MissingNumber);
+        }
+
+        if self.require_special
+            && !password
+                .chars()
+                .any(|c| "!@#$%^&*()_+-=[]{}|;':\"\",./<>?".contains(c))
+        {
+            errors.push(PasswordPolicyError::MissingSpecialCharacter);
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_policy(
+        min_length: i32,
+        require_uppercase: bool,
+        require_lowercase: bool,
+        require_number: bool,
+        require_special: bool,
+    ) -> PasswordPolicy {
+        PasswordPolicy {
+            id: Uuid::new_v4(),
+            realm_id: Uuid::new_v4(),
+            min_length,
+            require_uppercase,
+            require_lowercase,
+            require_number,
+            require_special,
+            max_age_days: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_password_too_short() {
+        let policy = make_policy(8, false, false, false, false);
+        let result = policy.validate("abc");
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors[0],
+            PasswordPolicyError::TooShort { min: 8, actual: 3 }
+        ));
+    }
+
+    #[test]
+    fn test_password_missing_uppercase() {
+        let policy = make_policy(8, true, false, false, false);
+        let result = policy.validate("password");
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingUppercase))
+        );
+    }
+
+    #[test]
+    fn test_password_meets_all_requirements() {
+        let policy = make_policy(8, true, true, true, true);
+        let result = policy.validate("Password1!");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_password_multiple_violations() {
+        let policy = make_policy(8, true, true, true, true);
+        let result = policy.validate("PASS");
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 4);
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::TooShort { .. }))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingLowercase))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingNumber))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingSpecialCharacter))
+        );
     }
 }
 

--- a/core/src/domain/password_policy/entity.rs
+++ b/core/src/domain/password_policy/entity.rs
@@ -39,10 +39,11 @@ impl PasswordPolicy {
     pub fn validate(&self, password: &str) -> Result<(), Vec<PasswordPolicyError>> {
         let mut errors = Vec::new();
 
-        if password.len() < self.min_length as usize {
+        let length = password.chars().count();
+        if length < self.min_length as usize {
             errors.push(PasswordPolicyError::TooShort {
                 min: self.min_length,
-                actual: password.len(),
+                actual: length,
             });
         }
 

--- a/core/src/domain/password_policy/error.rs
+++ b/core/src/domain/password_policy/error.rs
@@ -1,5 +1,8 @@
 use std::fmt::Display;
 
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum PasswordPolicyError {
     TooShort { min: i32, actual: usize },
@@ -7,6 +10,18 @@ pub enum PasswordPolicyError {
     MissingLowercase,
     MissingNumber,
     MissingSpecialCharacter,
+}
+
+impl PasswordPolicyError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            PasswordPolicyError::TooShort { .. } => "too_short",
+            PasswordPolicyError::MissingUppercase => "missing_uppercase",
+            PasswordPolicyError::MissingLowercase => "missing_lowercase",
+            PasswordPolicyError::MissingNumber => "missing_number",
+            PasswordPolicyError::MissingSpecialCharacter => "missing_special",
+        }
+    }
 }
 
 impl Display for PasswordPolicyError {
@@ -36,3 +51,18 @@ impl Display for PasswordPolicyError {
 }
 
 impl std::error::Error for PasswordPolicyError {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PasswordPolicyViolation {
+    pub code: String,
+    pub message: String,
+}
+
+impl From<&PasswordPolicyError> for PasswordPolicyViolation {
+    fn from(e: &PasswordPolicyError) -> Self {
+        Self {
+            code: e.code().to_string(),
+            message: e.to_string(),
+        }
+    }
+}

--- a/core/src/domain/password_policy/service.rs
+++ b/core/src/domain/password_policy/service.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use uuid::Uuid;
+
 use crate::domain::{
     authentication::value_objects::Identity,
     client::ports::ClientRepository,
@@ -12,7 +14,7 @@ use crate::domain::{
 };
 
 use super::entity::{PasswordPolicy, UpdatePasswordPolicy};
-use super::error::PasswordPolicyError;
+use super::error::PasswordPolicyViolation;
 use super::ports::PasswordPolicyPolicy;
 use super::repository::PasswordPolicyRepository;
 
@@ -74,188 +76,25 @@ where
         self.repository.upsert(realm.id.into(), update).await
     }
 
-    pub fn validate_password(
-        password: &str,
-        policy: &PasswordPolicy,
-    ) -> Result<(), Vec<PasswordPolicyError>> {
-        let mut errors = Vec::new();
-
-        // Check minimum length
-        if password.len() < policy.min_length as usize {
-            errors.push(PasswordPolicyError::TooShort {
-                min: policy.min_length,
-                actual: password.len(),
-            });
-        }
-
-        // Check uppercase requirement
-        if policy.require_uppercase && !password.chars().any(|c| c.is_uppercase()) {
-            errors.push(PasswordPolicyError::MissingUppercase);
-        }
-
-        // Check lowercase requirement
-        if policy.require_lowercase && !password.chars().any(|c| c.is_lowercase()) {
-            errors.push(PasswordPolicyError::MissingLowercase);
-        }
-
-        // Check number requirement
-        if policy.require_number && !password.chars().any(|c| c.is_numeric()) {
-            errors.push(PasswordPolicyError::MissingNumber);
-        }
-
-        // Check special character requirement
-        if policy.require_special
-            && !password
-                .chars()
-                .any(|c| "!@#$%^&*()_+-=[]{}|;':\"\",./<>?".contains(c))
-        {
-            errors.push(PasswordPolicyError::MissingSpecialCharacter);
-        }
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::Utc;
-    use uuid::Uuid;
-
-    // Mock types for testing
-    use crate::domain::{
-        client::ports::MockClientRepository,
-        user::ports::{MockUserRepository, MockUserRoleRepository},
-    };
-
-    fn create_test_policy(
-        min_length: i32,
-        require_uppercase: bool,
-        require_lowercase: bool,
-        require_number: bool,
-        require_special: bool,
-    ) -> PasswordPolicy {
-        PasswordPolicy {
-            id: Uuid::new_v4(),
-            realm_id: Uuid::new_v4(),
-            min_length,
-            require_uppercase,
-            require_lowercase,
-            require_number,
-            require_special,
-            max_age_days: None,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        }
+    pub async fn enforce(&self, realm_id: Uuid, password: &str) -> Result<(), CoreError> {
+        let policy = self
+            .repository
+            .find_by_realm_id(realm_id)
+            .await?
+            .unwrap_or_else(|| PasswordPolicy::default(realm_id));
+        policy.validate(password).map_err(|errors| {
+            let violations: Vec<PasswordPolicyViolation> = errors.iter().map(Into::into).collect();
+            CoreError::PasswordPolicyViolation(
+                serde_json::to_string(&violations).unwrap_or_default(),
+            )
+        })
     }
 
-    #[test]
-    fn test_password_too_short() {
-        let policy = create_test_policy(8, false, false, false, false);
-        let result = PasswordPolicyService::<
-            MockRepository,
-            MockUserRepository,
-            MockClientRepository,
-            MockUserRoleRepository,
-        >::validate_password("abc", &policy);
-
-        assert!(result.is_err());
-        let errors = result.unwrap_err();
-        assert_eq!(errors.len(), 1);
-        assert!(matches!(
-            errors[0],
-            PasswordPolicyError::TooShort { min: 8, actual: 3 }
-        ));
-    }
-
-    #[test]
-    fn test_password_missing_uppercase() {
-        let policy = create_test_policy(8, true, false, false, false);
-        let result = PasswordPolicyService::<
-            MockRepository,
-            MockUserRepository,
-            MockClientRepository,
-            MockUserRoleRepository,
-        >::validate_password("password", &policy);
-
-        assert!(result.is_err());
-        let errors = result.unwrap_err();
-        assert_eq!(errors.len(), 1);
-        assert!(
-            errors
-                .iter()
-                .any(|e| matches!(e, PasswordPolicyError::MissingUppercase))
-        );
-    }
-
-    #[test]
-    fn test_password_meets_all_requirements() {
-        let policy = create_test_policy(8, true, true, true, true);
-        let result = PasswordPolicyService::<
-            MockRepository,
-            MockUserRepository,
-            MockClientRepository,
-            MockUserRoleRepository,
-        >::validate_password("Password1!", &policy);
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_password_multiple_violations() {
-        let policy = create_test_policy(8, true, true, true, true);
-        let result = PasswordPolicyService::<
-            MockRepository,
-            MockUserRepository,
-            MockClientRepository,
-            MockUserRoleRepository,
-        >::validate_password("PASS", &policy);
-
-        assert!(result.is_err());
-        let errors = result.unwrap_err();
-        assert_eq!(errors.len(), 4);
-        assert!(
-            errors
-                .iter()
-                .any(|e| matches!(e, PasswordPolicyError::TooShort { .. }))
-        );
-        assert!(
-            errors
-                .iter()
-                .any(|e| matches!(e, PasswordPolicyError::MissingLowercase))
-        );
-        assert!(
-            errors
-                .iter()
-                .any(|e| matches!(e, PasswordPolicyError::MissingNumber))
-        );
-        assert!(
-            errors
-                .iter()
-                .any(|e| matches!(e, PasswordPolicyError::MissingSpecialCharacter))
-        );
-    }
-
-    // Mock repository for tests
-    struct MockRepository;
-    impl PasswordPolicyRepository for MockRepository {
-        async fn find_by_realm_id(
-            &self,
-            _realm_id: Uuid,
-        ) -> Result<Option<PasswordPolicy>, CoreError> {
-            Ok(None)
-        }
-
-        async fn upsert(
-            &self,
-            _realm_id: Uuid,
-            _update: UpdatePasswordPolicy,
-        ) -> Result<PasswordPolicy, CoreError> {
-            Err(CoreError::NotFound)
-        }
+    pub async fn get_policy_public(&self, realm_id: Uuid) -> Result<PasswordPolicy, CoreError> {
+        Ok(self
+            .repository
+            .find_by_realm_id(realm_id)
+            .await?
+            .unwrap_or_else(|| PasswordPolicy::default(realm_id)))
     }
 }

--- a/front/src/api/password-policy.api.ts
+++ b/front/src/api/password-policy.api.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query'
+
+export interface PublicPasswordPolicy {
+  min_length: number
+  require_uppercase: boolean
+  require_lowercase: boolean
+  require_number: boolean
+  require_special: boolean
+}
+
+export const DEFAULT_PASSWORD_POLICY: PublicPasswordPolicy = {
+  min_length: 8,
+  require_uppercase: false,
+  require_lowercase: false,
+  require_number: false,
+  require_special: false,
+}
+
+async function fetchPublicPasswordPolicy(realmName: string): Promise<PublicPasswordPolicy> {
+  const base = (window.apiUrl ?? '').replace(/\/$/, '')
+  const url = `${base}/realms/${encodeURIComponent(realmName)}/password-policy/public`
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch password policy: HTTP ${response.status}`)
+  }
+
+  return response.json() as Promise<PublicPasswordPolicy>
+}
+
+export function usePublicPasswordPolicy(realmName: string | undefined) {
+  return useQuery<PublicPasswordPolicy>({
+    queryKey: ['public-password-policy', realmName],
+    queryFn: () => fetchPublicPasswordPolicy(realmName!),
+    enabled: !!realmName,
+    retry: false,
+    placeholderData: DEFAULT_PASSWORD_POLICY,
+  })
+}

--- a/front/src/pages/authentication/components/password-requirements.tsx
+++ b/front/src/pages/authentication/components/password-requirements.tsx
@@ -1,0 +1,72 @@
+import { cn } from '@/lib/utils'
+import { Check, X } from 'lucide-react'
+import type { PublicPasswordPolicy } from '@/api/password-policy.api'
+import { evaluatePassword, hasPolicyRules } from '../utils/password-policy'
+
+export interface PasswordRequirementsProps {
+  password: string
+  policy: PublicPasswordPolicy
+  className?: string
+}
+
+interface RuleRowProps {
+  label: string
+  met: boolean
+  show: boolean
+}
+
+function RuleRow({ label, met, show }: RuleRowProps) {
+  if (!show) return null
+  return (
+    <li className='flex items-center gap-2 text-sm'>
+      {met ? (
+        <Check className='h-3.5 w-3.5 shrink-0 text-green-500' />
+      ) : (
+        <X className='h-3.5 w-3.5 shrink-0 text-destructive' />
+      )}
+      <span className={cn(met ? 'text-muted-foreground line-through' : 'text-foreground')}>
+        {label}
+      </span>
+    </li>
+  )
+}
+
+export default function PasswordRequirements({
+  password,
+  policy,
+  className,
+}: PasswordRequirementsProps) {
+  if (!hasPolicyRules(policy)) return null
+
+  const eval_ = evaluatePassword(password, policy)
+
+  return (
+    <ul className={cn('space-y-1 rounded-md border border-border bg-muted/40 px-3 py-2', className)}>
+      <RuleRow
+        label={`At least ${policy.min_length} characters`}
+        met={eval_.minLength}
+        show={policy.min_length > 0}
+      />
+      <RuleRow
+        label='At least one uppercase letter'
+        met={eval_.uppercase}
+        show={policy.require_uppercase}
+      />
+      <RuleRow
+        label='At least one lowercase letter'
+        met={eval_.lowercase}
+        show={policy.require_lowercase}
+      />
+      <RuleRow
+        label='At least one number'
+        met={eval_.number}
+        show={policy.require_number}
+      />
+      <RuleRow
+        label='At least one special character (!@#$%^&*…)'
+        met={eval_.special}
+        show={policy.require_special}
+      />
+    </ul>
+  )
+}

--- a/front/src/pages/authentication/feature/page-register-feature.tsx
+++ b/front/src/pages/authentication/feature/page-register-feature.tsx
@@ -22,7 +22,7 @@ function buildRegisterSchema(policy: typeof DEFAULT_PASSWORD_POLICY) {
           const result = evaluatePassword(value, policy)
           if (!result.valid) {
             ctx.addIssue({
-              code: z.ZodIssueCode.custom,
+              code: 'custom',
               message: result.unmetMessages.join(', '),
             })
           }

--- a/front/src/pages/authentication/feature/page-register-feature.tsx
+++ b/front/src/pages/authentication/feature/page-register-feature.tsx
@@ -3,32 +3,52 @@ import PageRegister from '../ui/page-register'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useNavigate, useParams } from 'react-router'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useRegistrationMutation } from '@/api/auth.api'
 import { useAuth } from '@/hooks/use-auth'
 import { RouterParams } from '@/routes/router'
+import { usePublicPasswordPolicy, DEFAULT_PASSWORD_POLICY } from '@/api/password-policy.api'
+import { evaluatePassword } from '../utils/password-policy'
 
-const registerSchema = z
-  .object({
-    username: z.string().min(1, 'Username is required'),
-    email: z.string().email('Invalid email address'),
-    password: z.string().min(6, 'Password must be at least 6 characters long'),
-    confirmPassword: z.string().min(6, 'Confirm Password must be at least 6 characters long'),
-    firstName: z.string().optional(),
-    lastName: z.string().optional(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    path: ['confirmPassword'],
-    message: 'Passwords do not match',
-  })
+function buildRegisterSchema(policy: typeof DEFAULT_PASSWORD_POLICY) {
+  return z
+    .object({
+      username: z.string().min(1, 'Username is required'),
+      email: z.string().email('Invalid email address'),
+      password: z
+        .string()
+        .min(1, 'Password is required')
+        .superRefine((value, ctx) => {
+          const result = evaluatePassword(value, policy)
+          if (!result.valid) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: result.unmetMessages.join(', '),
+            })
+          }
+        }),
+      confirmPassword: z.string().min(1, 'Please confirm your password'),
+      firstName: z.string().optional(),
+      lastName: z.string().optional(),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      path: ['confirmPassword'],
+      message: 'Passwords do not match',
+    })
+}
 
-export type RegisterSchema = z.infer<typeof registerSchema>
+export type RegisterSchema = z.infer<ReturnType<typeof buildRegisterSchema>>
 
 export default function PageRegisterFeature() {
   const navigate = useNavigate()
   const { realm_name } = useParams<RouterParams>()
   const { mutate: registration, data } = useRegistrationMutation()
   const { setAuthTokens } = useAuth()
+
+  const { data: policy, isLoading: isPolicyLoading } = usePublicPasswordPolicy(realm_name)
+  const resolvedPolicy = policy ?? DEFAULT_PASSWORD_POLICY
+
+  const registerSchema = useMemo(() => buildRegisterSchema(resolvedPolicy), [resolvedPolicy])
 
   const backToLogin = () => {
     navigate('../login')
@@ -46,6 +66,17 @@ export default function PageRegisterFeature() {
       lastName: '',
     },
   })
+
+  // Re-validate password when policy finishes loading so the checklist is
+  // accurate even if the user typed before the policy arrived.
+  useEffect(() => {
+    if (!isPolicyLoading) {
+      const current = form.getValues('password')
+      if (current) {
+        void form.trigger('password')
+      }
+    }
+  }, [isPolicyLoading, resolvedPolicy, form])
 
   function onSubmit(data: RegisterSchema) {
     registration({
@@ -85,5 +116,12 @@ export default function PageRegisterFeature() {
     }
   }, [data, setAuthTokens, navigate, realm_name, form])
 
-  return <PageRegister form={form} onSubmit={onSubmit} backToLogin={backToLogin} />
+  return (
+    <PageRegister
+      form={form}
+      onSubmit={onSubmit}
+      backToLogin={backToLogin}
+      policy={resolvedPolicy}
+    />
+  )
 }

--- a/front/src/pages/authentication/feature/page-reset-password-feature.tsx
+++ b/front/src/pages/authentication/feature/page-reset-password-feature.tsx
@@ -5,8 +5,9 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useLocation, useNavigate, useParams } from 'react-router'
-import { resetPasswordSchema, type ResetPasswordSchema } from '../schemas/reset-password.schema'
+import { buildResetPasswordSchema, type ResetPasswordSchema } from '../schemas/reset-password.schema'
 import PageResetPassword from '../ui/page-reset-password'
+import { usePublicPasswordPolicy, DEFAULT_PASSWORD_POLICY } from '@/api/password-policy.api'
 
 type TokenStatus = 'loading' | 'valid' | 'invalid'
 
@@ -25,10 +26,28 @@ export default function PageResetPasswordFeature() {
   const { mutate: resetPassword, isPending, error } = useResetPassword()
   const { setAuthTokens } = useAuth()
 
+  const { data: policy, isLoading: isPolicyLoading } = usePublicPasswordPolicy(realm_name)
+  const resolvedPolicy = policy ?? DEFAULT_PASSWORD_POLICY
+
+  const resetPasswordSchema = useMemo(
+    () => buildResetPasswordSchema(resolvedPolicy),
+    [resolvedPolicy],
+  )
+
   const form = useForm<ResetPasswordSchema>({
     resolver: zodResolver(resetPasswordSchema),
     defaultValues: { password: '', confirmPassword: '' },
   })
+
+  // Re-validate when policy arrives after the user may have already typed
+  useEffect(() => {
+    if (!isPolicyLoading) {
+      const current = form.getValues('password')
+      if (current) {
+        void form.trigger('password')
+      }
+    }
+  }, [isPolicyLoading, resolvedPolicy, form])
 
   useEffect(() => {
     if (missingParams) return
@@ -80,6 +99,7 @@ export default function PageResetPasswordFeature() {
         isPending={isPending}
         tokenStatus={tokenStatus}
         errorMessage={error?.message ?? null}
+        policy={resolvedPolicy}
       />
     </Form>
   )

--- a/front/src/pages/authentication/schemas/reset-password.schema.ts
+++ b/front/src/pages/authentication/schemas/reset-password.schema.ts
@@ -1,13 +1,28 @@
 import { z } from 'zod'
+import type { PublicPasswordPolicy } from '@/api/password-policy.api'
+import { evaluatePassword } from '../utils/password-policy'
 
-export const resetPasswordSchema = z
-  .object({
-    password: z.string().min(8, { message: 'Password must be at least 8 characters' }),
-    confirmPassword: z.string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: 'Passwords do not match',
-    path: ['confirmPassword'],
-  })
+export function buildResetPasswordSchema(policy: PublicPasswordPolicy) {
+  return z
+    .object({
+      password: z
+        .string()
+        .min(1, 'Password is required')
+        .superRefine((value, ctx) => {
+          const result = evaluatePassword(value, policy)
+          if (!result.valid) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: result.unmetMessages.join(', '),
+            })
+          }
+        }),
+      confirmPassword: z.string(),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: 'Passwords do not match',
+      path: ['confirmPassword'],
+    })
+}
 
-export type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>
+export type ResetPasswordSchema = z.infer<ReturnType<typeof buildResetPasswordSchema>>

--- a/front/src/pages/authentication/schemas/reset-password.schema.ts
+++ b/front/src/pages/authentication/schemas/reset-password.schema.ts
@@ -12,7 +12,7 @@ export function buildResetPasswordSchema(policy: PublicPasswordPolicy) {
           const result = evaluatePassword(value, policy)
           if (!result.valid) {
             ctx.addIssue({
-              code: z.ZodIssueCode.custom,
+              code: 'custom',
               message: result.unmetMessages.join(', '),
             })
           }

--- a/front/src/pages/authentication/ui/page-register.tsx
+++ b/front/src/pages/authentication/ui/page-register.tsx
@@ -6,15 +6,22 @@ import { InputText } from '@/components/ui/input-text'
 import { Button } from '@/components/ui/button'
 import { useParams } from 'react-router'
 import './page-login.css'
+import type { PublicPasswordPolicy } from '@/api/password-policy.api'
+import PasswordRequirements from '../components/password-requirements'
 
 export interface PageRegisterProps {
   form: UseFormReturn<RegisterSchema>
   onSubmit: (data: RegisterSchema) => void
   backToLogin?: () => void
+  policy: PublicPasswordPolicy
 }
 
-export default function PageRegister({ form, onSubmit, backToLogin }: PageRegisterProps) {
+export default function PageRegister({ form, onSubmit, backToLogin, policy }: PageRegisterProps) {
   const { realm_name } = useParams()
+  const password = form.watch('password')
+  const isPasswordValid = !form.formState.errors.password && password.length > 0
+  const isFormSubmittable =
+    form.formState.isValid && !form.formState.isSubmitting
 
   return (
     <div className='login-shell flex min-h-svh flex-col items-center justify-center px-6 py-10'>
@@ -89,7 +96,7 @@ export default function PageRegister({ form, onSubmit, backToLogin }: PageRegist
                                   type='password'
                                   className='w-full'
                                 />
-                                {fieldState.error && (
+                                {fieldState.error && isPasswordValid === false && password.length > 0 && (
                                   <p className='text-sm text-destructive'>
                                     {fieldState.error.message}
                                   </p>
@@ -97,6 +104,7 @@ export default function PageRegister({ form, onSubmit, backToLogin }: PageRegist
                               </div>
                             )}
                           />
+                          <PasswordRequirements password={password} policy={policy} />
 
                           <FormField
                             control={form.control}
@@ -153,7 +161,9 @@ export default function PageRegister({ form, onSubmit, backToLogin }: PageRegist
                       </div>
 
                       <div className='flex flex-col gap-2'>
-                        <Button className='w-full'>Create Account</Button>
+                        <Button className='w-full' disabled={!isFormSubmittable}>
+                          Create Account
+                        </Button>
 
                         <Button type='button' variant='outline' onClick={backToLogin} className='w-full'>
                           Back to login

--- a/front/src/pages/authentication/ui/page-reset-password.tsx
+++ b/front/src/pages/authentication/ui/page-reset-password.tsx
@@ -7,6 +7,8 @@ import { Link, useParams } from 'react-router'
 import { type ResetPasswordSchema } from '../schemas/reset-password.schema'
 import { AlertTriangle, Loader2 } from 'lucide-react'
 import './page-login.css'
+import type { PublicPasswordPolicy } from '@/api/password-policy.api'
+import PasswordRequirements from '../components/password-requirements'
 
 export interface PageResetPasswordProps {
   form: UseFormReturn<ResetPasswordSchema>
@@ -14,6 +16,7 @@ export interface PageResetPasswordProps {
   isPending: boolean
   tokenStatus: 'loading' | 'valid' | 'invalid'
   errorMessage: string | null
+  policy: PublicPasswordPolicy
 }
 
 export default function PageResetPassword({
@@ -22,8 +25,11 @@ export default function PageResetPassword({
   isPending,
   tokenStatus,
   errorMessage,
+  policy,
 }: PageResetPasswordProps) {
   const { realm_name } = useParams()
+  const password = form.watch('password')
+  const isFormSubmittable = form.formState.isValid && !form.formState.isSubmitting && !isPending
 
   return (
     <div className='login-shell relative flex min-h-svh items-center justify-center px-6 py-10'>
@@ -73,10 +79,16 @@ export default function PageResetPassword({
                                   name='password'
                                   type='password'
                                   className='w-full'
-                                  error={form.formState.errors.password?.message}
+                                  error={
+                                    form.formState.errors.password?.message &&
+                                    password.length > 0
+                                      ? form.formState.errors.password.message
+                                      : undefined
+                                  }
                                 />
                               )}
                             />
+                            <PasswordRequirements password={password} policy={policy} />
                           </div>
                           <div className='grid gap-3'>
                             <FormField
@@ -94,7 +106,11 @@ export default function PageResetPassword({
                               )}
                             />
                           </div>
-                          <Button type='submit' className='w-full rounded-lg py-5 text-sm' disabled={isPending}>
+                          <Button
+                            type='submit'
+                            className='w-full rounded-lg py-5 text-sm'
+                            disabled={!isFormSubmittable}
+                          >
                             {isPending ? 'Resetting...' : 'Reset password'}
                           </Button>
                         </div>

--- a/front/src/pages/authentication/utils/password-policy.ts
+++ b/front/src/pages/authentication/utils/password-policy.ts
@@ -22,7 +22,8 @@ export function evaluatePassword(
   password: string,
   policy: PublicPasswordPolicy,
 ): PasswordEvaluation {
-  const minLength = password.length >= policy.min_length
+  // Count Unicode code points to match the backend's `chars().count()`.
+  const minLength = [...password].length >= policy.min_length
   const uppercase = !policy.require_uppercase || /[A-Z]/.test(password)
   const lowercase = !policy.require_lowercase || /[a-z]/.test(password)
   const number = !policy.require_number || /[0-9]/.test(password)

--- a/front/src/pages/authentication/utils/password-policy.ts
+++ b/front/src/pages/authentication/utils/password-policy.ts
@@ -1,0 +1,56 @@
+import type { PublicPasswordPolicy } from '@/api/password-policy.api'
+
+/**
+ * The special character set the backend validates against.
+ * Must stay in sync with the Rust backend's SPECIAL_CHARS constant.
+ */
+export const SPECIAL_CHARS = '!@#$%^&*()_+-=[]{}|;\':",./<>?'
+
+export interface PasswordEvaluation {
+  minLength: boolean
+  uppercase: boolean
+  lowercase: boolean
+  number: boolean
+  special: boolean
+  /** True only when every rule required by the policy passes */
+  valid: boolean
+  /** Human-readable messages for each unmet rule */
+  unmetMessages: string[]
+}
+
+export function evaluatePassword(
+  password: string,
+  policy: PublicPasswordPolicy,
+): PasswordEvaluation {
+  const minLength = password.length >= policy.min_length
+  const uppercase = !policy.require_uppercase || /[A-Z]/.test(password)
+  const lowercase = !policy.require_lowercase || /[a-z]/.test(password)
+  const number = !policy.require_number || /[0-9]/.test(password)
+  const special =
+    !policy.require_special || [...password].some((ch) => SPECIAL_CHARS.includes(ch))
+
+  const unmetMessages: string[] = []
+  if (!minLength) unmetMessages.push(`At least ${policy.min_length} characters`)
+  if (!uppercase) unmetMessages.push('At least one uppercase letter')
+  if (!lowercase) unmetMessages.push('At least one lowercase letter')
+  if (!number) unmetMessages.push('At least one number')
+  if (!special) unmetMessages.push('At least one special character')
+
+  const valid = minLength && uppercase && lowercase && number && special
+
+  return { minLength, uppercase, lowercase, number, special, valid, unmetMessages }
+}
+
+/**
+ * Returns true when the policy has at least one rule that should be displayed
+ * (i.e. it is stricter than the empty/default state).
+ */
+export function hasPolicyRules(policy: PublicPasswordPolicy): boolean {
+  return (
+    policy.min_length > 0 ||
+    policy.require_uppercase ||
+    policy.require_lowercase ||
+    policy.require_number ||
+    policy.require_special
+  )
+}

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -300,6 +300,9 @@ pub enum CoreError {
 
     #[error("Portal layout is referenced by one or more themes and cannot be deleted")]
     PortalLayoutInUse,
+
+    #[error("Password does not meet the realm policy")]
+    PasswordPolicyViolation(String),
 }
 
 impl From<AuthenticationError> for CoreError {


### PR DESCRIPTION
## Summary

The per-realm password policy (min length + character-class requirements) was fully configurable (admin UI + storage) but its validation logic had **zero production callers** — passwords were never checked against it anywhere. This wires enforcement end-to-end.

### Backend
- Moved the rule check onto the entity (`PasswordPolicy::validate`) and added stable error codes (`PasswordPolicyError::code`) + a serializable `PasswordPolicyViolation` DTO.
- New `CoreError::PasswordPolicyViolation`, mapped to a structured **422** (`field: "password"`, one message per unmet rule), following the existing portal-theme validation precedent.
- Single enforcement seam `ApplicationService::validate_password_policy(realm_name, password)`, called from **all four** password-set flows:
  - self-registration
  - reset-password (magic-link)
  - admin reset of a user's password
  - `UPDATE_PASSWORD` required action
- Removed the now-redundant hardcoded `min(8)` on the reset endpoint (the realm policy is authoritative).
- New **public** endpoint `GET /realms/{realm}/password-policy/public` (no auth) returning only the rule fields, so anonymous pages can validate live.

### Frontend
- `usePublicPasswordPolicy(realm)` hook + a shared `evaluatePassword` helper (special-char set kept in sync with the backend) + a reusable live `<PasswordRequirements>` checklist.
- Register and reset-password pages now build their Zod schema dynamically from the fetched policy, show the live checklist, and block submit until the password satisfies the policy (with a sensible default while the policy loads).

Out of scope (deliberately): `max_age_days` password expiry/rotation — tracked separately.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --all --exclude ferriskey-client -- -D warnings` — clean
- [x] `cargo build -p ferriskey-core -p ferriskey-api` — clean
- [x] Domain unit tests for `PasswordPolicy::validate` (4) pass
- [x] Frontend `tsc --noEmit` + `eslint` (touched files) — clean
- [x] New DB-backed integration test `api/tests/password_policy_test.rs` (`#[ignore]`, wired into the `integration-tests` CI job): sets a strict policy, reads it via the public endpoint unauthenticated, and asserts a weak admin password reset is rejected (422) while a strong one succeeds (200).

> Note: the `#[ignore]` integration test runs only in the Postgres-backed CI job (no local DB here); all other gates were run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public, unauthenticated “public password policy” endpoint per realm for viewing password requirements.
  * Frontend now loads the realm policy to drive registration and reset-password validation plus a live password requirements checklist.
* **Bug Fixes**
  * Password policy is now enforced consistently across registration, password update, and password reset.
  * Policy violations return consistent password field validation feedback when a password is too weak.
* **Tests**
  * Added an end-to-end integration test suite covering public policy access and per-realm enforcement (run as an ignored test).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->