### PR TITLE
fix(docker): make webapp web root writable by the unprivileged nginx user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,14 @@ RUN VITE_API_URL="" pnpm run build
 # ── Frontend runtime ──────────────────────────────────────────────────────────
 FROM nginxinc/nginx-unprivileged:1.31.1-alpine3.23-slim AS webapp
 
+# The unprivileged image ships root-owned index.html/50x.html in the web root and
+# runs as the non-root "nginx" user. The runtime entrypoint wipes and repopulates
+# that directory, so it must be owned by the runtime user — otherwise the rm fails
+# with "Permission denied" and (under `set -e`) nginx never starts.
+USER root
+RUN rm -rf /usr/share/nginx/html/* && chown -R nginx:nginx /usr/share/nginx/html
+USER nginx
+
 COPY --from=webapp-build /usr/local/src/ferriskey/dist /usr/local/src/ferriskey
 COPY front/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=0755 front/docker-entrypoint.sh /docker-entrypoint.d/docker-entrypoint.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend container startup reliability by ensuring the web content directory is writable at runtime.
  * Prevents permission-related failures that could stop the app from serving the site correctly in production-like environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->