### PR TITLE
feat(token-exchange): add GrantType::TokenExchange and domain value objects

### DIFF
--- a/core/src/domain/authentication/entities.rs
+++ b/core/src/domain/authentication/entities.rs
@@ -114,6 +114,9 @@ pub enum GrantType {
 
     #[serde(rename = "urn:ietf:params:oauth:grant-type:device_code")]
     DeviceCode,
+
+    #[serde(rename = "urn:ietf:params:oauth:grant-type:token-exchange")]
+    TokenExchange,
 }
 
 impl Display for GrantType {
@@ -124,6 +127,9 @@ impl Display for GrantType {
             GrantType::Credentials => write!(f, "credentials"),
             GrantType::RefreshToken => write!(f, "refresh_token"),
             GrantType::DeviceCode => write!(f, "urn:ietf:params:oauth:grant-type:device_code"),
+            GrantType::TokenExchange => {
+                write!(f, "urn:ietf:params:oauth:grant-type:token-exchange")
+            }
         }
     }
 }
@@ -302,4 +308,27 @@ pub enum AuthenticationStepStatus {
 pub enum AuthenticationMethod {
     UserCredentials { username: String, password: String },
     ExistingToken { token: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOKEN_EXCHANGE_URN: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+    #[test]
+    fn grant_type_token_exchange_serde_round_trips_to_exact_urn() {
+        let json = format!("\"{TOKEN_EXCHANGE_URN}\"");
+        let parsed: GrantType = serde_json::from_str(&json)
+            .expect("token-exchange URN should deserialize into GrantType");
+        assert_eq!(serde_json::to_string(&parsed).unwrap(), json);
+    }
+
+    #[test]
+    fn grant_type_token_exchange_displays_full_urn() {
+        let json = format!("\"{TOKEN_EXCHANGE_URN}\"");
+        let parsed: GrantType = serde_json::from_str(&json)
+            .expect("token-exchange URN should deserialize into GrantType");
+        assert_eq!(parsed.to_string(), TOKEN_EXCHANGE_URN);
+    }
 }

--- a/core/src/domain/authentication/mod.rs
+++ b/core/src/domain/authentication/mod.rs
@@ -5,6 +5,7 @@ pub mod mappers;
 pub mod ports;
 pub mod scope;
 pub mod services;
+pub mod token_exchange;
 pub mod value_objects;
 
 pub use scope::{OidcScope, SCOPE_EMAIL, SCOPE_OPENID, SCOPE_PROFILE, ScopeManager};

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -1372,6 +1372,9 @@ where
             GrantType::RefreshToken => self.refresh_token(params).await,
             // Device flow token exchange is not wired up yet (see #1020).
             GrantType::DeviceCode => Err(CoreError::InvalidRequest),
+            // RFC 8693 token exchange is handled in the token endpoint once
+            // the service lands (see #1053/#1054); not wired up yet.
+            GrantType::TokenExchange => Err(CoreError::InvalidRequest),
         }
     }
 

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -1372,8 +1372,8 @@ where
             GrantType::RefreshToken => self.refresh_token(params).await,
             // Device flow token exchange is not wired up yet (see #1020).
             GrantType::DeviceCode => Err(CoreError::InvalidRequest),
-            // RFC 8693 token exchange is handled in the token endpoint once
-            // the service lands (see #1053/#1054); not wired up yet.
+            // RFC 8693 token exchange is dispatched here once the exchange
+            // service lands (see #1053/#1054); not wired up yet.
             GrantType::TokenExchange => Err(CoreError::InvalidRequest),
         }
     }

--- a/core/src/domain/authentication/token_exchange/entities.rs
+++ b/core/src/domain/authentication/token_exchange/entities.rs
@@ -1,0 +1,130 @@
+//! Domain entities for OAuth 2.0 Token Exchange (RFC 8693).
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use utoipa::ToSchema;
+
+/// Token type identifiers defined by RFC 8693 §3, serialized as their URNs.
+///
+/// All three URNs parse, but only `access_token` is handled for now (see
+/// #1050): [`TokenType::ensure_supported`] rejects the others with
+/// `unsupported_token_type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum TokenType {
+    #[serde(rename = "urn:ietf:params:oauth:token-type:access_token")]
+    AccessToken,
+
+    #[serde(rename = "urn:ietf:params:oauth:token-type:id_token")]
+    IdToken,
+
+    #[serde(rename = "urn:ietf:params:oauth:token-type:jwt")]
+    Jwt,
+}
+
+impl TokenType {
+    /// Parses an RFC 8693 token-type URN.
+    ///
+    /// Unknown URNs map to `unsupported_token_type` (RFC 8693 §2.2.2), not to
+    /// a generic parse error, so the token endpoint can forward the code
+    /// verbatim.
+    pub fn from_urn(urn: &str) -> Result<Self, TokenExchangeError> {
+        match urn {
+            "urn:ietf:params:oauth:token-type:access_token" => Ok(Self::AccessToken),
+            "urn:ietf:params:oauth:token-type:id_token" => Ok(Self::IdToken),
+            "urn:ietf:params:oauth:token-type:jwt" => Ok(Self::Jwt),
+            _ => Err(TokenExchangeError::UnsupportedTokenType),
+        }
+    }
+
+    /// Returns the token type if the exchange supports it.
+    ///
+    /// Only `access_token` is handled for now; `id_token` and `jwt` parse but
+    /// are rejected with `unsupported_token_type`.
+    pub fn ensure_supported(self) -> Result<Self, TokenExchangeError> {
+        match self {
+            Self::AccessToken => Ok(self),
+            Self::IdToken | Self::Jwt => Err(TokenExchangeError::UnsupportedTokenType),
+        }
+    }
+}
+
+/// Errors surfaced by the token exchange grant (RFC 8693).
+///
+/// The `Display` strings intentionally match the `error` codes defined by
+/// RFC 8693 §2.2.2 so the HTTP layer can forward them verbatim in the token
+/// endpoint response (same convention as `DeviceFlowError`).
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TokenExchangeError {
+    /// The requested or supplied token type is valid but not supported by
+    /// this authorization server (RFC 8693 §2.2.2 `unsupported_token_type`).
+    #[error("unsupported_token_type")]
+    UnsupportedTokenType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACCESS_TOKEN_URN: &str = "urn:ietf:params:oauth:token-type:access_token";
+    const ID_TOKEN_URN: &str = "urn:ietf:params:oauth:token-type:id_token";
+    const JWT_URN: &str = "urn:ietf:params:oauth:token-type:jwt";
+
+    #[test]
+    fn token_type_serde_round_trips_rfc8693_urns() {
+        for (token_type, urn) in [
+            (TokenType::AccessToken, ACCESS_TOKEN_URN),
+            (TokenType::IdToken, ID_TOKEN_URN),
+            (TokenType::Jwt, JWT_URN),
+        ] {
+            let json = format!("\"{urn}\"");
+            let parsed: TokenType = serde_json::from_str(&json)
+                .expect("RFC 8693 URN should deserialize into TokenType");
+            assert_eq!(parsed, token_type);
+            let serialized =
+                serde_json::to_string(&token_type).expect("TokenType should serialize");
+            assert_eq!(serialized, json);
+        }
+    }
+
+    #[test]
+    fn from_urn_parses_known_urns() {
+        assert_eq!(
+            TokenType::from_urn(ACCESS_TOKEN_URN),
+            Ok(TokenType::AccessToken)
+        );
+        assert_eq!(TokenType::from_urn(ID_TOKEN_URN), Ok(TokenType::IdToken));
+        assert_eq!(TokenType::from_urn(JWT_URN), Ok(TokenType::Jwt));
+    }
+
+    #[test]
+    fn from_urn_unknown_maps_to_unsupported_token_type() {
+        assert_eq!(
+            TokenType::from_urn("urn:ietf:params:oauth:token-type:saml2"),
+            Err(TokenExchangeError::UnsupportedTokenType)
+        );
+    }
+
+    #[test]
+    fn ensure_supported_accepts_only_access_token() {
+        assert_eq!(
+            TokenType::AccessToken.ensure_supported(),
+            Ok(TokenType::AccessToken)
+        );
+        assert_eq!(
+            TokenType::IdToken.ensure_supported(),
+            Err(TokenExchangeError::UnsupportedTokenType)
+        );
+        assert_eq!(
+            TokenType::Jwt.ensure_supported(),
+            Err(TokenExchangeError::UnsupportedTokenType)
+        );
+    }
+
+    #[test]
+    fn unsupported_token_type_displays_rfc8693_error_code() {
+        assert_eq!(
+            TokenExchangeError::UnsupportedTokenType.to_string(),
+            "unsupported_token_type"
+        );
+    }
+}

--- a/core/src/domain/authentication/token_exchange/mod.rs
+++ b/core/src/domain/authentication/token_exchange/mod.rs
@@ -1,0 +1,7 @@
+//! Domain model for OAuth 2.0 Token Exchange (RFC 8693).
+
+pub mod entities;
+pub mod value_objects;
+
+pub use entities::{TokenExchangeError, TokenType};
+pub use value_objects::{TokenExchangeInput, TokenExchangeOutput};

--- a/core/src/domain/authentication/token_exchange/value_objects.rs
+++ b/core/src/domain/authentication/token_exchange/value_objects.rs
@@ -1,0 +1,75 @@
+//! DTOs for the token exchange grant use cases (RFC 8693).
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::domain::authentication::token_exchange::entities::TokenType;
+
+/// Input for the token endpoint with
+/// `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`
+/// (RFC 8693 §2.1).
+///
+/// The token-type fields carry the raw URNs as received; the service parses
+/// them with [`TokenType::from_urn`] so an unknown URN surfaces as
+/// `unsupported_token_type` rather than a deserialization error.
+pub struct TokenExchangeInput {
+    /// The token being exchanged.
+    pub subject_token: String,
+    /// Token-type URN of `subject_token`.
+    pub subject_token_type: String,
+    /// Requested type for the issued token. Defaults to `access_token` when
+    /// absent.
+    pub requested_token_type: Option<String>,
+    /// Target audience for the issued token.
+    pub audience: Option<String>,
+    /// Target resource URI for the issued token.
+    pub resource: Option<String>,
+    /// Requested scope; must be a subset of the subject token's scope.
+    pub scope: Option<String>,
+}
+
+/// Output of a successful token exchange (RFC 8693 §2.2.1).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TokenExchangeOutput {
+    pub access_token: String,
+    /// Token-type URN of the issued token.
+    pub issued_token_type: TokenType,
+    /// `Bearer`, per RFC 8693 §2.2.1 for access tokens.
+    pub token_type: String,
+    /// Issued token lifetime, in seconds.
+    #[schema(example = 300)]
+    pub expires_in: i64,
+    /// Scope of the issued token; omitted when identical to the subject
+    /// token's scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::authentication::token_exchange::entities::TokenType;
+
+    #[test]
+    fn output_serializes_issued_token_type_as_urn_and_omits_absent_scope() {
+        let output = TokenExchangeOutput {
+            access_token: "new-token".to_string(),
+            issued_token_type: TokenType::AccessToken,
+            token_type: "Bearer".to_string(),
+            expires_in: 300,
+            scope: None,
+        };
+
+        let json = serde_json::to_value(&output).expect("output should serialize");
+        assert_eq!(
+            json["issued_token_type"],
+            "urn:ietf:params:oauth:token-type:access_token"
+        );
+        assert_eq!(json["token_type"], "Bearer");
+        assert_eq!(json["expires_in"], 300);
+        assert!(
+            json.get("scope").is_none(),
+            "absent scope should be omitted from the RFC 8693 response"
+        );
+    }
+}

--- a/core/src/domain/authentication/token_exchange/value_objects.rs
+++ b/core/src/domain/authentication/token_exchange/value_objects.rs
@@ -12,6 +12,7 @@ use crate::domain::authentication::token_exchange::entities::TokenType;
 /// The token-type fields carry the raw URNs as received; the service parses
 /// them with [`TokenType::from_urn`] so an unknown URN surfaces as
 /// `unsupported_token_type` rather than a deserialization error.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TokenExchangeInput {
     /// The token being exchanged.
     pub subject_token: String,
@@ -84,5 +85,22 @@ mod tests {
 
         let json = serde_json::to_value(&output).expect("output should serialize");
         assert_eq!(json["scope"], "openid profile");
+    }
+
+    #[test]
+    fn input_deserializes_request_body_and_carries_raw_token_type_urn() {
+        let input: TokenExchangeInput = serde_json::from_str(
+            r#"{"subject_token":"subj","subject_token_type":"urn:example:custom-token-type"}"#,
+        )
+        .expect("input should deserialize from a token-exchange request body");
+
+        assert_eq!(input.subject_token, "subj");
+        // The raw URN is carried verbatim; parsing happens in the service so an
+        // unknown token type surfaces as `unsupported_token_type`, not a
+        // deserialization error.
+        assert_eq!(input.subject_token_type, "urn:example:custom-token-type");
+        // Absent optional fields deserialize to `None`.
+        assert!(input.requested_token_type.is_none());
+        assert!(input.audience.is_none());
     }
 }

--- a/core/src/domain/authentication/token_exchange/value_objects.rs
+++ b/core/src/domain/authentication/token_exchange/value_objects.rs
@@ -48,7 +48,6 @@ pub struct TokenExchangeOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::authentication::token_exchange::entities::TokenType;
 
     #[test]
     fn output_serializes_issued_token_type_as_urn_and_omits_absent_scope() {
@@ -71,5 +70,19 @@ mod tests {
             json.get("scope").is_none(),
             "absent scope should be omitted from the RFC 8693 response"
         );
+    }
+
+    #[test]
+    fn output_serializes_present_scope() {
+        let output = TokenExchangeOutput {
+            access_token: "new-token".to_string(),
+            issued_token_type: TokenType::AccessToken,
+            token_type: "Bearer".to_string(),
+            expires_in: 300,
+            scope: Some("openid profile".to_string()),
+        };
+
+        let json = serde_json::to_value(&output).expect("output should serialize");
+        assert_eq!(json["scope"], "openid profile");
     }
 }


### PR DESCRIPTION
Closes #1051 (part of #1050).

## Summary

Adds the RFC 8693 token-exchange domain model to `ferriskey-core`:

- `GrantType::TokenExchange`, serde-renamed to `urn:ietf:params:oauth:grant-type:token-exchange`, with a matching `Display` arm (full URN, same as `DeviceCode`).
- New `core/src/domain/authentication/token_exchange/` module:
  - `entities.rs`: `TokenType` (`access_token`, `id_token`, `jwt` URNs) plus `TokenExchangeError`, whose `Display` strings match the RFC 8693 §2.2.2 error codes so the HTTP layer can forward them verbatim (same convention as `DeviceFlowError`). `TokenType::from_urn` maps unknown URNs to `unsupported_token_type`; `ensure_supported` rejects everything but `access_token` for now.
  - `value_objects.rs`: `TokenExchangeInput` (token-type fields carry raw URN strings, parsed later by the service, so an unknown type surfaces as `unsupported_token_type` rather than a deserialization error) and `TokenExchangeOutput` (RFC 8693 §2.2.1 shape; `scope` omitted when absent).
  - `mod.rs`: re-exports.

## Two notes beyond the issue's task list

- `authenticate_with_grant_type` in `services.rs` matches `GrantType` exhaustively, so the new variant needs an arm to compile. It returns `CoreError::InvalidRequest` like the `DeviceCode` arm above it, with a comment pointing at #1053/#1054 where the grant gets wired up.
- `TokenExchangeError` lives in `entities.rs` to keep the module at the three files the issue names. Happy to lift it into an `error.rs` like `device_flow/` has if you'd prefer.

## Testing

- `cargo test -p ferriskey-core`: 8 new unit tests, including the two acceptance checks (grant type serde round-trips to the exact URN; unknown `subject_token_type` maps to `unsupported_token_type`).
- `cargo check --workspace`, `cargo clippy --all --exclude ferriskey-client -- -D warnings`, and `cargo fmt --all --check` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OAuth 2.0 Token Exchange (RFC 8693) payloads, including request/response fields for exchanged tokens.
  * Introduced token-type URN handling with validation and standardized JSON serialization.
* **Bug Fixes**
  * Token-exchange grant requests are now explicitly rejected with an invalid-request response until full support is wired in.
* **Tests**
  * Added unit tests covering token-type URN parsing/round-trips and request/response JSON serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->