### PR TITLE
feat: add human-readable display_name to realms

### DIFF
--- a/api/src/application/http/authentication/router.rs
+++ b/api/src/application/http/authentication/router.rs
@@ -26,28 +26,37 @@ use super::handlers::{
     userinfo::{__path_get_userinfo, get_userinfo},
     verify_email::{__path_verify_email_handler, verify_email_handler},
 };
+use ferriskey_core::domain::authentication::value_objects::CodeChallengeMethod;
+
 use crate::application::{auth::auth, http::server::app_state::AppState};
 
 #[derive(OpenApi)]
-#[openapi(paths(
-    exchange_token,
-    introspect_token,
-    authenticate,
-    device_authorization,
-    device_verification_page,
-    device_verify,
-    get_certs,
-    get_jwks_json,
-    auth_handler,
-    logout_get,
-    logout_post,
-    revoke_token,
-    get_openid_configuration,
-    registration_handler,
-    verify_email_handler,
-    resend_verification_email_handler,
-    get_userinfo,
-))]
+#[openapi(
+    paths(
+        exchange_token,
+        introspect_token,
+        authenticate,
+        device_authorization,
+        device_verification_page,
+        device_verify,
+        get_certs,
+        get_jwks_json,
+        auth_handler,
+        logout_get,
+        logout_post,
+        revoke_token,
+        get_openid_configuration,
+        registration_handler,
+        verify_email_handler,
+        resend_verification_email_handler,
+        get_userinfo,
+    ),
+    // `CodeChallengeMethod` is only reached through the `AuthRequest` query-params
+    // struct (`IntoParams`), which utoipa does not walk for component schemas — so the
+    // generated `$ref` would otherwise dangle and break OpenAPI clients. Register it
+    // explicitly here.
+    components(schemas(CodeChallengeMethod))
+)]
 pub struct AuthenticationApiDoc;
 
 pub fn authentication_routes(state: AppState, root_path: &str) -> Router<AppState> {

--- a/api/src/application/http/realm/handlers/create_realm.rs
+++ b/api/src/application/http/realm/handlers/create_realm.rs
@@ -33,6 +33,7 @@ pub async fn create_realm(
             identity,
             CreateRealmInput {
                 realm_name: payload.name,
+                display_name: payload.display_name,
             },
         )
         .await?;

--- a/api/src/application/http/realm/handlers/update_realm.rs
+++ b/api/src/application/http/realm/handlers/update_realm.rs
@@ -49,6 +49,7 @@ pub async fn update_realm(
             UpdateRealmInput {
                 realm_name: name,
                 name: payload.name,
+                display_name: payload.display_name,
             },
         )
         .await

--- a/api/src/application/http/realm/validators.rs
+++ b/api/src/application/http/realm/validators.rs
@@ -5,15 +5,27 @@ use validator::Validate;
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct CreateRealmValidator {
-    #[validate(length(min = 1, message = "name is required"))]
+    #[validate(
+        length(min = 1, message = "name is required"),
+        custom(function = "validate_realm_slug")
+    )]
     #[serde(default)]
     pub name: String,
+    #[validate(length(max = 255, message = "display_name must be at most 255 characters"))]
+    #[serde(default)]
+    pub display_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct UpdateRealmValidator {
-    #[validate(length(min = 1, message = "name is required"))]
+    #[validate(
+        length(min = 1, message = "name is required"),
+        custom(function = "validate_realm_slug")
+    )]
     pub name: String,
+    #[validate(length(max = 255, message = "display_name must be at most 255 characters"))]
+    #[serde(default)]
+    pub display_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
@@ -88,6 +100,25 @@ where
     D: serde::Deserializer<'de>,
 {
     Ok(Some(Option::deserialize(deserializer)?))
+}
+
+/// Ensures a realm `name` is safe to use as a URL slug.
+///
+/// The realm name is embedded in every realm URL (`/realms/{name}/...`), so it
+/// must not contain whitespace or characters that would need URL-encoding.
+/// Human-readable labels belong in `display_name`, which is free-form.
+fn validate_realm_slug(value: &str) -> Result<(), validator::ValidationError> {
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        Ok(())
+    } else {
+        Err(validator::ValidationError::new(
+            "name must contain only letters, digits, hyphens or underscores",
+        ))
+    }
 }
 
 fn validate_encryption(value: &str) -> Result<(), validator::ValidationError> {

--- a/core/migrations/20260705120000_add_display_name_to_realms.down.sql
+++ b/core/migrations/20260705120000_add_display_name_to_realms.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE realms DROP COLUMN display_name;

--- a/core/migrations/20260705120000_add_display_name_to_realms.up.sql
+++ b/core/migrations/20260705120000_add_display_name_to_realms.up.sql
@@ -1,0 +1,3 @@
+-- Add a human-readable display name to realms, separate from `name` (the URL slug).
+-- Nullable: existing realms keep their slug as the only label and fall back to it.
+ALTER TABLE realms ADD COLUMN display_name VARCHAR(255);

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -564,7 +564,7 @@ mod tests {
         let realm = app
             .realm_service
             .realm_repository
-            .create_realm(realm_name.clone())
+            .create_realm(realm_name.clone(), None)
             .await
             .expect("create realm");
 
@@ -611,6 +611,7 @@ mod tests {
             realm: Some(Realm {
                 id: realm.id,
                 name: realm.name.clone(),
+                display_name: realm.display_name.clone(),
                 settings: None,
                 created_at: realm.created_at,
                 updated_at: realm.updated_at,

--- a/core/src/domain/abyss/identity_provider_policies.rs
+++ b/core/src/domain/abyss/identity_provider_policies.rs
@@ -45,6 +45,7 @@ where
         let target_realm = Realm {
             id: realm_id,
             name: user_realm.name.clone(),
+            display_name: None,
             settings: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -87,6 +88,7 @@ where
         let target_realm = Realm {
             id: provider.realm_id,
             name: user_realm.name.clone(),
+            display_name: None,
             settings: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -131,6 +133,7 @@ where
         let target_realm = Realm {
             id: provider.realm_id,
             name: user_realm.name.clone(),
+            display_name: None,
             settings: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -179,6 +182,7 @@ mod tests {
         Realm {
             id: RealmId::default(),
             name: name.to_string(),
+            display_name: None,
             settings: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),

--- a/core/src/domain/abyss/policies.rs
+++ b/core/src/domain/abyss/policies.rs
@@ -45,6 +45,7 @@ where
         let target_realm = Realm {
             id: realm_id,
             name: user_realm.name.clone(), // Use same name for same-realm access
+            display_name: None,
             settings: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -87,6 +88,7 @@ where
         let target_realm = Realm {
             id: provider.realm_id,
             name: user_realm.name.clone(),
+            display_name: None,
             settings: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -131,6 +133,7 @@ where
         let target_realm = Realm {
             id: provider.realm_id,
             name: user_realm.name.clone(),
+            display_name: None,
             settings: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -182,6 +185,7 @@ mod tests {
         Realm {
             id: RealmId::default(),
             name: name.to_string(),
+            display_name: None,
             settings: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),

--- a/core/src/domain/common/services.rs
+++ b/core/src/domain/common/services.rs
@@ -117,7 +117,7 @@ where
 
                 let realm = self
                     .realm_repository
-                    .create_realm(config.master_realm_name.clone())
+                    .create_realm(config.master_realm_name.clone(), None)
                     .await?;
 
                 tracing::info!("{} realm created", config.master_realm_name);
@@ -127,7 +127,7 @@ where
                 tracing::info!("creating master realm");
                 let realm = self
                     .realm_repository
-                    .create_realm(config.master_realm_name.clone())
+                    .create_realm(config.master_realm_name.clone(), None)
                     .await?;
 
                 tracing::info!("{} realm created", config.master_realm_name);
@@ -612,6 +612,7 @@ pub mod tests {
         Realm {
             id: RealmId::default(),
             name: "test-realm".to_string(),
+            display_name: None,
             settings: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
@@ -622,6 +623,7 @@ pub mod tests {
         Realm {
             id: RealmId::default(),
             name: name.to_string(),
+            display_name: None,
             settings: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/core/src/domain/email_template/services.rs
+++ b/core/src/domain/email_template/services.rs
@@ -261,6 +261,7 @@ mod tests {
         Realm {
             id: uuid::Uuid::new_v4().into(),
             name: "test-realm".to_string(),
+            display_name: None,
             settings: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/core/src/domain/email_verification/services.rs
+++ b/core/src/domain/email_verification/services.rs
@@ -470,6 +470,7 @@ mod tests {
         Realm {
             id: RealmId::new(Uuid::new_v4()),
             name: "test-realm".to_string(),
+            display_name: None,
             settings: Some(RealmSetting::new(
                 RealmId::new(Uuid::new_v4()),
                 Some("RS256".to_string()),

--- a/core/src/domain/organization/services.rs
+++ b/core/src/domain/organization/services.rs
@@ -468,6 +468,7 @@ mod tests {
         Realm {
             id,
             name: name.to_string(),
+            display_name: None,
             settings: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/core/src/domain/portal_layouts/services.rs
+++ b/core/src/domain/portal_layouts/services.rs
@@ -258,6 +258,7 @@ mod tests {
         Realm {
             id: Uuid::new_v4().into(),
             name: "test-realm".to_string(),
+            display_name: None,
             settings: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/core/src/domain/portal_theme/services.rs
+++ b/core/src/domain/portal_theme/services.rs
@@ -357,6 +357,7 @@ mod tests {
         Realm {
             id: Uuid::new_v4().into(),
             name: "test-realm".to_string(),
+            display_name: None,
             settings: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/core/src/domain/realm/entities.rs
+++ b/core/src/domain/realm/entities.rs
@@ -54,6 +54,8 @@ impl std::str::FromStr for SmtpEncryption {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct RealmLoginSetting {
+    pub name: String,
+    pub display_name: Option<String>,
     pub user_registration_enabled: bool,
     pub forgot_password_enabled: bool,
     pub remember_me_enabled: bool,
@@ -68,6 +70,8 @@ pub struct RealmLoginSetting {
 impl From<RealmSetting> for RealmLoginSetting {
     fn from(value: RealmSetting) -> Self {
         Self {
+            name: String::new(),
+            display_name: None,
             forgot_password_enabled: value.forgot_password_enabled,
             remember_me_enabled: value.remember_me_enabled,
             user_registration_enabled: value.user_registration_enabled,

--- a/core/src/domain/realm/ports.rs
+++ b/core/src/domain/realm/ports.rs
@@ -125,12 +125,17 @@ pub trait RealmRepository: Send + Sync {
         realm_id: RealmId,
     ) -> impl Future<Output = Result<Option<Realm>, CoreError>> + Send;
 
-    fn create_realm(&self, name: String) -> impl Future<Output = Result<Realm, CoreError>> + Send;
+    fn create_realm(
+        &self,
+        name: String,
+        display_name: Option<String>,
+    ) -> impl Future<Output = Result<Realm, CoreError>> + Send;
 
     fn update_realm(
         &self,
         realm_name: String,
         name: String,
+        display_name: Option<String>,
     ) -> impl Future<Output = Result<Realm, CoreError>> + Send;
     fn delete_by_name(&self, name: &str) -> impl Future<Output = Result<(), CoreError>> + Send;
 
@@ -180,6 +185,7 @@ pub struct GetRealmSettingInput {
 
 pub struct CreateRealmInput {
     pub realm_name: String,
+    pub display_name: Option<String>,
 }
 
 pub struct CreateRealmWithUserInput {
@@ -190,6 +196,7 @@ pub struct CreateRealmWithUserInput {
 pub struct UpdateRealmInput {
     pub realm_name: String,
     pub name: String,
+    pub display_name: Option<String>,
 }
 
 pub struct UpdateRealmSettingInput {

--- a/core/src/domain/realm/services.rs
+++ b/core/src/domain/realm/services.rs
@@ -302,7 +302,10 @@ where
             "insufficient permissions",
         )?;
 
-        let realm = self.realm_repository.create_realm(input.realm_name).await?;
+        let realm = self
+            .realm_repository
+            .create_realm(input.realm_name, input.display_name)
+            .await?;
         self.realm_repository
             .create_realm_settings(realm.id, "RS256".to_string())
             .await?;
@@ -451,6 +454,7 @@ where
                 identity.clone(),
                 CreateRealmInput {
                     realm_name: input.realm_name.clone(),
+                    display_name: None,
                 },
             )
             .await?;
@@ -719,7 +723,7 @@ where
 
         let realm = self
             .realm_repository
-            .update_realm(input.realm_name, input.name)
+            .update_realm(input.realm_name, input.name, input.display_name)
             .await?;
 
         self.webhook_repository
@@ -828,6 +832,8 @@ where
             .map(|i| IdentityProviderPresentation::new(i, &realm.name))
             .collect();
 
+        settings.name = realm.name.clone();
+        settings.display_name = realm.display_name.clone();
         settings.identity_providers = idp;
 
         Ok(settings)
@@ -1071,9 +1077,12 @@ mod tests {
             Arc::get_mut(&mut self.realm_repo)
                 .unwrap()
                 .expect_create_realm()
-                .with(mockall::predicate::eq(realm_name))
+                .with(
+                    mockall::predicate::eq(realm_name),
+                    mockall::predicate::always(),
+                )
                 .times(1)
-                .return_once(move |_| Box::pin(async move { Ok(new_realm) }));
+                .return_once(move |_, _| Box::pin(async move { Ok(new_realm) }));
             self
         }
 
@@ -1456,6 +1465,7 @@ mod tests {
 
         let input = CreateRealmInput {
             realm_name: "realm_test".to_string(),
+            display_name: None,
         };
 
         // Create the new realm that will be returned

--- a/core/src/entity/realms.rs
+++ b/core/src/entity/realms.rs
@@ -15,6 +15,7 @@ impl EntityName for Entity {
 pub struct Model {
     pub id: Uuid,
     pub name: String,
+    pub display_name: Option<String>,
     pub created_at: DateTime,
     pub updated_at: DateTime,
 }
@@ -23,6 +24,7 @@ pub struct Model {
 pub enum Column {
     Id,
     Name,
+    DisplayName,
     CreatedAt,
     UpdatedAt,
 }
@@ -76,6 +78,7 @@ impl ColumnTrait for Column {
         match self {
             Self::Id => ColumnType::Uuid.def(),
             Self::Name => ColumnType::String(StringLen::N(255u32)).def().unique(),
+            Self::DisplayName => ColumnType::String(StringLen::N(255u32)).def().null(),
             Self::CreatedAt => ColumnType::DateTime.def(),
             Self::UpdatedAt => ColumnType::DateTime.def(),
         }

--- a/core/src/infrastructure/realm/mappers/realm_mapper.rs
+++ b/core/src/infrastructure/realm/mappers/realm_mapper.rs
@@ -10,6 +10,7 @@ impl From<Model> for Realm {
         Realm {
             id: value.id.into(),
             name: value.name,
+            display_name: value.display_name,
             settings: None,
             created_at,
             updated_at,
@@ -25,6 +26,7 @@ impl From<&Model> for Realm {
         Realm {
             id: model.id.into(),
             name: model.name.clone(),
+            display_name: model.display_name.clone(),
             settings: None,
             created_at,
             updated_at,

--- a/core/src/infrastructure/realm/repositories/realm_postgres_repository.rs
+++ b/core/src/infrastructure/realm/repositories/realm_postgres_repository.rs
@@ -80,12 +80,18 @@ impl RealmRepository for PostgresRealmRepository {
         Ok(realm)
     }
 
-    async fn create_realm(&self, name: String) -> Result<Realm, CoreError> {
-        let realm = Realm::new(name);
+    async fn create_realm(
+        &self,
+        name: String,
+        display_name: Option<String>,
+    ) -> Result<Realm, CoreError> {
+        let mut realm = Realm::new(name);
+        realm.display_name = display_name;
 
         let new_realm = ActiveModel {
             id: Set(realm.id.into()),
             name: Set(realm.name),
+            display_name: Set(realm.display_name),
             created_at: Set(realm.created_at.naive_utc()),
             updated_at: Set(realm.updated_at.naive_utc()),
         };
@@ -100,7 +106,12 @@ impl RealmRepository for PostgresRealmRepository {
         Ok(realm)
     }
 
-    async fn update_realm(&self, realm_name: String, name: String) -> Result<Realm, CoreError> {
+    async fn update_realm(
+        &self,
+        realm_name: String,
+        name: String,
+        display_name: Option<String>,
+    ) -> Result<Realm, CoreError> {
         let realm = RealmEntity::find()
             .filter(crate::entity::realms::Column::Name.eq(realm_name))
             .one(&self.db)
@@ -110,6 +121,7 @@ impl RealmRepository for PostgresRealmRepository {
 
         let mut realm: ActiveModel = realm.into();
         realm.name = Set(name.clone());
+        realm.display_name = Set(display_name);
         realm.updated_at = Set(Utc::now().naive_utc());
         realm
             .update(&self.db)

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -307,7 +307,7 @@ export namespace Schemas {
     sync_interval_minutes?: (number | null) | undefined
     sync_mode: string
   }
-  export type CreateRealmValidator = Partial<{ name: string }>
+  export type CreateRealmValidator = Partial<{ display_name: string | null; name: string }>
   export type CreateRedirectUriValidator = Partial<{ enabled: boolean; value: string }>
   export type Role = {
     client?: (null | Client) | undefined
@@ -380,6 +380,7 @@ export namespace Schemas {
   }
   export type Realm = {
     created_at: string
+    display_name?: (string | null) | undefined
     id: RealmId
     name: string
     settings?: (null | RealmSetting) | undefined
@@ -767,11 +768,13 @@ export namespace Schemas {
   export type PublicKeyCredentialCreationOptionsJSON = Record<string, unknown>
   export type PublicKeyCredentialRequestOptionsJSON = Record<string, unknown>
   export type RealmLoginSetting = {
+    display_name?: (string | null) | undefined
     email_verification_enabled: boolean
     forgot_password_enabled: boolean
     identity_providers: Array<IdentityProviderPresentation>
     magic_link_enabled: boolean
     magic_link_ttl: number
+    name: string
     passkey_enabled: boolean
     remember_me_enabled: boolean
     theme: PortalThemeConfig
@@ -977,7 +980,7 @@ export namespace Schemas {
     temporary_token_lifetime: number | null
     user_registration_enabled: boolean | null
   }>
-  export type UpdateRealmValidator = { name: string }
+  export type UpdateRealmValidator = { display_name?: (string | null) | undefined; name: string }
   export type UpdateRedirectUriResponse = { data: RedirectUri }
   export type UpdateRedirectUriValidator = Partial<{ enabled: boolean }>
   export type UpdateRolePermissionsResponse = { data: Role }

--- a/front/src/api/realm.api.ts
+++ b/front/src/api/realm.api.ts
@@ -73,6 +73,39 @@ export const useDeleteRealm = () => {
   })
 }
 
+export const useUpdateRealm = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...window.tanstackApi.mutation('put', '/realms/{name}').mutationOptions,
+    onSuccess: async (_, variables) => {
+      const userRealmsKeys = window.tanstackApi.get('/realms/{realm_name}/users/@me/realms', {
+        path: {
+          realm_name: variables.path.name,
+        },
+      }).queryKey
+
+      const realmKeys = window.tanstackApi.get('/realms/{name}', {
+        path: {
+          name: variables.path.name,
+        },
+      }).queryKey
+
+      const loginKeys = window.tanstackApi.get('/realms/{name}/login-settings', {
+        path: {
+          name: variables.path.name,
+        },
+      }).queryKey
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: userRealmsKeys }),
+        queryClient.invalidateQueries({ queryKey: realmKeys }),
+        queryClient.invalidateQueries({ queryKey: loginKeys }),
+      ])
+    },
+  })
+}
+
 export const useUpdateRealmSettings = () => {
   const queryClient = useQueryClient()
 

--- a/front/src/components/realm-switcher.tsx
+++ b/front/src/components/realm-switcher.tsx
@@ -61,7 +61,7 @@ export default function RealmSwitcher() {
               >
                 <div className='grid flex-1 text-left text-sm leading-tight'>
                   <span className='truncate text-xs font-medium text-sidebar-foreground/60 uppercase tracking-wider'>
-                    {activeRealm.name}
+                    {activeRealm.display_name || activeRealm.name}
                   </span>
                 </div>
                 <ChevronsUpDown className='ml-auto size-4 shrink-0 text-sidebar-foreground/50' />
@@ -85,7 +85,7 @@ export default function RealmSwitcher() {
                   <div className='flex size-6 items-center justify-center rounded-none border'>
                     <Globe className='size-3.5 shrink-0' />
                   </div>
-                  {realm.name}
+                  {realm.display_name || realm.name}
                   <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
                 </DropdownMenuItem>
               ))}
@@ -120,7 +120,18 @@ interface ModalCreateRealmProps {
 }
 
 const createRealmSchema = z.object({
-  name: z.string().trim().min(1, { message: 'Realm name is required' }),
+  name: z
+    .string()
+    .trim()
+    .min(1, { message: 'Realm name is required' })
+    .regex(/^[A-Za-z0-9_-]+$/, {
+      message: 'Only letters, digits, hyphens and underscores are allowed',
+    }),
+  display_name: z
+    .string()
+    .trim()
+    .max(255, { message: 'Display name must be at most 255 characters' })
+    .optional(),
 })
 
 type CreateRealmSchema = z.infer<typeof createRealmSchema>
@@ -132,12 +143,19 @@ function ModalCreateRealm({ open, setOpen, realm_name }: ModalCreateRealmProps) 
     resolver: zodResolver(createRealmSchema),
     defaultValues: {
       name: '',
+      display_name: '',
     },
   })
 
   const handleSubmit = () => {
+    const values = form.getValues()
+    const displayName = values.display_name?.trim()
+
     createRealm({
-      body: form.getValues(),
+      body: {
+        name: values.name,
+        display_name: displayName ? displayName : null,
+      },
     })
   }
   const isValid = form.formState.isValid
@@ -175,6 +193,19 @@ function ModalCreateRealm({ open, setOpen, realm_name }: ModalCreateRealmProps) 
                 name={'name'}
                 label='Realm Name'
                 value={field.value}
+                onChange={field.onChange}
+              />
+            )}
+          />
+
+          <FormField
+            name='display_name'
+            control={form.control}
+            render={({ field }) => (
+              <InputText
+                name={'display_name'}
+                label='Display Name (optional)'
+                value={field.value ?? ''}
                 onChange={field.onChange}
               />
             )}

--- a/front/src/pages/authentication/ui/page-login.tsx
+++ b/front/src/pages/authentication/ui/page-login.tsx
@@ -90,7 +90,9 @@ export default function PageLogin({
                             </p>
                           </div>
                           <h1 className='login-title text-3xl font-semibold tracking-tight text-foreground'>
-                            {realm_name?.toUpperCase() ?? 'Login'}
+                            {loginSettings.display_name?.trim()
+                              ? loginSettings.display_name
+                              : (realm_name?.toUpperCase() ?? 'Login')}
                           </h1>
                         </div>
                         {errorMessage && (

--- a/front/src/pages/realm/feature/page-realm-settings-general-feature.tsx
+++ b/front/src/pages/realm/feature/page-realm-settings-general-feature.tsx
@@ -7,7 +7,7 @@ import PageRealmSettingsGeneral from '../ui/page-realm-settings-general'
 import { useFormChanges } from '@/hooks/use-form-changes'
 import { useNavigate, useParams } from 'react-router'
 import { RouterParams } from '@/routes/router'
-import { useDeleteRealm, useGetRealm } from '@/api/realm.api'
+import { useDeleteRealm, useGetRealm, useUpdateRealm } from '@/api/realm.api'
 import { toast } from 'sonner'
 
 export default function PageRealmSettingsGeneralFeature() {
@@ -15,12 +15,14 @@ export default function PageRealmSettingsGeneralFeature() {
   const { data: realm } = useGetRealm({ realm: realm_name })
   const navigate = useNavigate()
   const deleteRealm = useDeleteRealm()
+  const updateRealm = useUpdateRealm()
 
   const form = useForm<UpdateRealmSchema>({
     resolver: zodResolver(updateRealmValidator),
     mode: 'all',
     values: {
       name: realm?.name ?? 'master',
+      display_name: realm?.display_name ?? '',
       default_signing_algorithm: SigningAlgorithm.RS256,
     }
   })
@@ -29,9 +31,29 @@ export default function PageRealmSettingsGeneralFeature() {
     form,
     realm && {
       name: realm.name ?? 'master',
+      display_name: realm.display_name ?? '',
       default_signing_algorithm: SigningAlgorithm.RS256,
     }
   )
+
+  const handleSaveRealm = form.handleSubmit((values) => {
+    if (!realm_name) return
+
+    const displayName = values.display_name?.trim()
+
+    updateRealm.mutate(
+      {
+        path: { name: realm_name },
+        body: {
+          name: values.name,
+          display_name: displayName ? displayName : null,
+        },
+      },
+      {
+        onSuccess: () => toast.success('Realm updated successfully.'),
+      }
+    )
+  })
 
   const handleDeleteRealm = () => {
     if (!realm_name) return
@@ -58,6 +80,7 @@ export default function PageRealmSettingsGeneralFeature() {
         realmName={realm_name ?? ''}
         isMaster={realm_name === 'master'}
         onDeleteRealm={handleDeleteRealm}
+        onSave={handleSaveRealm}
       />
     </Form>
   )

--- a/front/src/pages/realm/ui/page-realm-settings-general.tsx
+++ b/front/src/pages/realm/ui/page-realm-settings-general.tsx
@@ -13,9 +13,10 @@ export interface PageRealmSettingsGeneralProps {
   realmName: string
   isMaster: boolean
   onDeleteRealm: () => void
+  onSave: () => void
 }
 
-export default function PageRealmSettingsGeneral({ hasChanges, realmName, isMaster, onDeleteRealm }: PageRealmSettingsGeneralProps) {
+export default function PageRealmSettingsGeneral({ hasChanges, realmName, isMaster, onDeleteRealm, onSave }: PageRealmSettingsGeneralProps) {
   const form = useFormContext<UpdateRealmSchema>()
 
   return (
@@ -38,6 +39,24 @@ export default function PageRealmSettingsGeneral({ hasChanges, realmName, isMast
               </div>
               <div className='w-1/2'>
                 <InputText label='Realm Name' disabled {...field} />
+              </div>
+            </div>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='display_name'
+          render={({ field }) => (
+            <div className='flex items-start justify-between py-4 border-t'>
+              <div className='w-1/3'>
+                <p className='text-sm font-medium'>Display Name</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>
+                  Human-readable name shown in the login and admin UI. Leave empty to use the realm name.
+                </p>
+              </div>
+              <div className='w-1/2'>
+                <InputText label='Display Name' {...field} value={field.value ?? ''} />
               </div>
             </div>
           )}
@@ -84,7 +103,7 @@ export default function PageRealmSettingsGeneral({ hasChanges, realmName, isMast
       <FloatingActionBar
         show={hasChanges}
         title='Save Changes'
-        actions={[{ label: 'Save', variant: 'default', onClick: () => { } }]}
+        actions={[{ label: 'Save', variant: 'default', onClick: onSave }]}
         description="You have unsaved changes. Click 'Save' to apply them."
         onCancel={form.reset}
       />

--- a/front/src/pages/realm/validators.ts
+++ b/front/src/pages/realm/validators.ts
@@ -3,6 +3,10 @@ import { z } from 'zod'
 
 export const updateRealmValidator = z.object({
   name: z.string().min(1),
+  display_name: z
+    .string()
+    .max(255, { message: 'Display name must be at most 255 characters' })
+    .optional(),
   default_signing_algorithm: z.nativeEnum(SigningAlgorithm),
 })
 

--- a/libs/ferriskey-domain/src/realm/mod.rs
+++ b/libs/ferriskey-domain/src/realm/mod.rs
@@ -42,6 +42,12 @@ impl PartialEq<Uuid> for RealmId {
 pub struct Realm {
     pub id: RealmId,
     pub name: String,
+    /// Human-readable label shown in the login and admin UI.
+    ///
+    /// Unlike `name` (which is the URL slug and must stay URL-safe), this can
+    /// contain whitespace and be changed freely without breaking realm URLs.
+    /// Falls back to `name` when unset.
+    pub display_name: Option<String>,
     pub settings: Option<RealmSetting>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -107,6 +113,7 @@ impl Realm {
         Self {
             id: RealmId::default(),
             name,
+            display_name: None,
             settings: None,
             created_at: now,
             updated_at: now,


### PR DESCRIPTION
Closes #1134

## Problem

A realm's `name` served double duty: it's shown in the login/admin UI **and** used as the URL identifier (`/realms/{name}/...`). Giving a realm a human-readable name with whitespace broke URLs for some SSO clients.

## Solution

Keycloak-style separation: `name` stays the immutable **URL slug**, and a new nullable `display_name` is the **human-readable label**. `display_name` can contain whitespace and be changed anytime without touching realm URLs. UI falls back to `name` when `display_name` is unset.

## Changes

**Backend**
- Migration `20260705120000_add_display_name_to_realms` — nullable `VARCHAR(255)` column (+ SeaORM entity).
- `display_name` threaded through the domain `Realm`, ports/DTOs (`CreateRealmInput` / `UpdateRealmInput`), repository, services, mappers, and the master-realm seeders.
- Slug guard on `CreateRealmValidator` / `UpdateRealmValidator.name` (`^[A-Za-z0-9_-]+$`), so new realm slugs can no longer contain whitespace — this is what actually closes the reported bug. `display_name` is free-form (max 255). Existing realms and `master` are unaffected (validated on create/update only).
- `RealmLoginSetting` now carries `name` + `display_name` so the login page can render the friendly label.

**Frontend**
- Create-realm dialog and general-settings form gain a `display_name` field.
- The general-settings **Save** button (previously a no-op) is wired through a new `useUpdateRealm` mutation hook.
- Realm switcher and login heading display `display_name ?? name` (routing keeps using the slug).

## Verification

- `cargo check --workspace --tests` ✓
- Realm unit tests 25/25 ✓
- `cargo clippy` clean on all changed files ✓
- Frontend `tsc -b` ✓ and `eslint` ✓

## Notes

- `front/src/api/api.client.ts` was updated by targeted, generator-style hand-edits rather than a full `typed-openapi` regen: a full regen currently crashes on a pre-existing broken `$ref` (`#/components/schemas/CodeChallengeMethod`, missing from the utoipa registration added in #1102), and the committed `openapi.json` is gitignored/stale.
- The generated Rust `client/` crate was not regenerated (needs Docker + a valid spec); it still compiles and nothing depends on the new field there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Realms now support an optional **Display Name** alongside the existing **name** (URL slug).
  * Realm creation and settings pages let you view, enter, and save the display name.
  * Realm switchers and login headers now prefer the display name when available.
* **Bug Fixes**
  * Display names are now consistently carried through realm create/update and reflected in login settings.
  * Validation and length limits were tightened, while existing realms continue to work with display name left blank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->