### PR TITLE
docs: add device authorization grant guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 **/.DS_Store
 
 openapi.json
+branch_structure.json
+temp_auto_push.bat
+temp_interactive_push.bat

--- a/api/src/application/http/error.rs
+++ b/api/src/application/http/error.rs
@@ -286,7 +286,7 @@ impl From<CoreError> for ApiError {
                     ),
                     Err(_) => Self::validation_errors(vec![ValidationError {
                         field: "password".into(),
-                        message: "Password does not meet the realm policy".into(),
+                        message: details.into(),
                     }]),
                 }
             }

--- a/api/src/application/http/realm/handlers/update_password_policy.rs
+++ b/api/src/application/http/realm/handlers/update_password_policy.rs
@@ -49,6 +49,9 @@ pub async fn update_password_policy(
         require_number: payload.require_number,
         require_special: payload.require_special,
         max_age_days: payload.max_age_days,
+        min_entropy_bits: payload.min_entropy_bits,
+        forbid_common: payload.forbid_common,
+        check_breached: payload.check_breached,
     };
 
     let policy = state

--- a/api/src/application/http/realm/validators.rs
+++ b/api/src/application/http/realm/validators.rs
@@ -92,6 +92,14 @@ pub struct UpdatePasswordPolicyValidator {
     pub require_special: Option<bool>,
     #[validate(range(min = 0, message = "max_age_days must be 0 or greater"))]
     pub max_age_days: Option<i32>,
+    #[validate(range(
+        min = 0,
+        max = 256,
+        message = "min_entropy_bits must be between 0 and 256"
+    ))]
+    pub min_entropy_bits: Option<i32>,
+    pub forbid_common: Option<bool>,
+    pub check_breached: Option<bool>,
 }
 
 fn deserialize_optional_field<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>

--- a/api/tests/password_policy_test.rs
+++ b/api/tests/password_policy_test.rs
@@ -181,6 +181,13 @@ mod tests {
                 "require_lowercase": true,
                 "require_number": true,
                 "require_special": true,
+                // This test exercises character-class + length enforcement only.
+                // Disable the entropy/common-password rules (which default to the
+                // strict CNIL values) so the configured policy matches what the
+                // assertions below expect.
+                "min_entropy_bits": 0,
+                "forbid_common": false,
+                "check_breached": false,
             }))
             .await;
 

--- a/core/migrations/20260705130000_add_password_policy_entropy_fields.down.sql
+++ b/core/migrations/20260705130000_add_password_policy_entropy_fields.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE password_policy
+    DROP COLUMN IF EXISTS min_entropy_bits,
+    DROP COLUMN IF EXISTS forbid_common,
+    DROP COLUMN IF EXISTS check_breached;

--- a/core/migrations/20260705130000_add_password_policy_entropy_fields.up.sql
+++ b/core/migrations/20260705130000_add_password_policy_entropy_fields.up.sql
@@ -1,0 +1,20 @@
+ALTER TABLE password_policy
+    ADD COLUMN IF NOT EXISTS min_entropy_bits INTEGER NOT NULL DEFAULT 80,
+    ADD COLUMN IF NOT EXISTS forbid_common    BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN IF NOT EXISTS check_breached   BOOLEAN NOT NULL DEFAULT false;
+
+-- Bring existing rows' min_length and require_* in line with CNIL 2022-100 defaults
+-- (only updates rows that still carry the original permissive defaults)
+UPDATE password_policy
+SET
+    min_length        = 12,
+    require_uppercase = true,
+    require_lowercase = true,
+    require_number    = true,
+    require_special   = true
+WHERE
+    min_length        = 8
+    AND require_uppercase = false
+    AND require_lowercase = false
+    AND require_number    = false
+    AND require_special   = false;

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -214,6 +214,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
     let realm_maintenance_whitelist = Arc::new(PostgresRealmMaintenanceWhitelistRepository::new(
         postgres.get_db(),
     ));
+    let password_policy = Arc::new(PostgresPasswordPolicyRepository::new(postgres.get_db()));
 
     let (compass_tx, compass_rx) = tokio::sync::mpsc::channel(1024);
     tokio::spawn(compass_writer_task(
@@ -355,6 +356,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             webhook.clone(),
             email_template.clone(),
             mjml_renderer.clone(),
+            password_policy.clone(),
         ),
         user_service: UserServiceImpl::new(
             realm.clone(),
@@ -367,6 +369,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             user_attribute.clone(),
             webhook.clone(),
             security_event.clone(),
+            password_policy.clone(),
             policy.clone(),
         ),
         webhook_service: WebhookServiceImpl::new(realm.clone(), webhook.clone(), policy.clone()),
@@ -446,7 +449,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             policy.clone(),
         ),
         password_policy_service: PasswordPolicyService::new(
-            Arc::new(PostgresPasswordPolicyRepository::new(postgres.get_db())),
+            password_policy.clone(),
             policy.clone(),
         ),
         organization_service: OrganizationServiceImpl::new(

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -186,6 +186,7 @@ type ApplicationTridentService = TridentServiceImpl<
     WebhookRepo,
     EmailTemplateRepo,
     MjmlRenderer,
+    PasswordPolicyRepo,
 >;
 
 type MaintenanceWhitelistRepo = crate::infrastructure::maintenance::repositories::maintenance_whitelist_repository::PostgresMaintenanceWhitelistRepository;
@@ -314,6 +315,7 @@ pub struct ApplicationService {
         WebhookRepo,
         SecurityEventRepo,
         UserAttributeRepo,
+        PasswordPolicyRepo,
     >,
     pub(crate) health_service: HealthServiceImpl<HealthCheckRepo>,
     pub(crate) webhook_service:

--- a/core/src/domain/password_policy/entity.rs
+++ b/core/src/domain/password_policy/entity.rs
@@ -16,21 +16,33 @@ pub struct PasswordPolicy {
     pub require_number: bool,
     pub require_special: bool,
     pub max_age_days: Option<i32>,
+    /// Minimum Shannon entropy in bits (charset-pool model). CNIL 2022-100 default: 80.
+    pub min_entropy_bits: i32,
+    /// Reject passwords found in the embedded common-password list or matching username/email.
+    pub forbid_common: bool,
+    /// Interface flag — reject passwords reported as breached (requires external check; no
+    /// network call is made when the provider is not wired up).
+    pub check_breached: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
 
 impl PasswordPolicy {
+    /// CNIL délibération 2022-100 compliant defaults (>= 80 bits entropy, all classes required,
+    /// min 12 characters).
     pub fn default(realm_id: Uuid) -> Self {
         Self {
             id: Uuid::now_v7(),
             realm_id,
-            min_length: 8,
-            require_uppercase: false,
-            require_lowercase: false,
-            require_number: false,
-            require_special: false,
+            min_length: 12,
+            require_uppercase: true,
+            require_lowercase: true,
+            require_number: true,
+            require_special: true,
             max_age_days: None,
+            min_entropy_bits: 80,
+            forbid_common: true,
+            check_breached: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
@@ -95,6 +107,9 @@ mod tests {
             require_number,
             require_special,
             max_age_days: None,
+            min_entropy_bits: 0,
+            forbid_common: false,
+            check_breached: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
@@ -176,4 +191,7 @@ pub struct UpdatePasswordPolicy {
     pub require_number: Option<bool>,
     pub require_special: Option<bool>,
     pub max_age_days: Option<i32>,
+    pub min_entropy_bits: Option<i32>,
+    pub forbid_common: Option<bool>,
+    pub check_breached: Option<bool>,
 }

--- a/core/src/domain/password_policy/error.rs
+++ b/core/src/domain/password_policy/error.rs
@@ -10,6 +10,9 @@ pub enum PasswordPolicyError {
     MissingLowercase,
     MissingNumber,
     MissingSpecialCharacter,
+    InsufficientEntropy { min_bits: f64, actual_bits: f64 },
+    CommonPassword,
+    BreachedPassword,
 }
 
 impl PasswordPolicyError {
@@ -20,6 +23,9 @@ impl PasswordPolicyError {
             PasswordPolicyError::MissingLowercase => "missing_lowercase",
             PasswordPolicyError::MissingNumber => "missing_number",
             PasswordPolicyError::MissingSpecialCharacter => "missing_special",
+            PasswordPolicyError::InsufficientEntropy { .. } => "insufficient_entropy",
+            PasswordPolicyError::CommonPassword => "common_password",
+            PasswordPolicyError::BreachedPassword => "breached_password",
         }
     }
 }
@@ -45,6 +51,28 @@ impl Display for PasswordPolicyError {
             }
             PasswordPolicyError::MissingSpecialCharacter => {
                 write!(f, "Password must contain at least one special character")
+            }
+            PasswordPolicyError::InsufficientEntropy {
+                min_bits,
+                actual_bits,
+            } => {
+                write!(
+                    f,
+                    "Password entropy is too low: {:.1} bits (minimum {:.1} bits required)",
+                    actual_bits, min_bits
+                )
+            }
+            PasswordPolicyError::CommonPassword => {
+                write!(
+                    f,
+                    "Password is too common or matches user credentials; please choose a stronger password"
+                )
+            }
+            PasswordPolicyError::BreachedPassword => {
+                write!(
+                    f,
+                    "Password has appeared in a data breach; please choose a different password"
+                )
             }
         }
     }

--- a/core/src/domain/password_policy/mod.rs
+++ b/core/src/domain/password_policy/mod.rs
@@ -4,3 +4,4 @@ pub mod policies;
 pub mod ports;
 pub mod repository;
 pub mod service;
+pub mod validator;

--- a/core/src/domain/password_policy/repository.rs
+++ b/core/src/domain/password_policy/repository.rs
@@ -6,6 +6,7 @@ use crate::domain::common::entities::app_errors::CoreError;
 
 use super::entity::{PasswordPolicy, UpdatePasswordPolicy};
 
+#[cfg_attr(test, mockall::automock)]
 pub trait PasswordPolicyRepository: Send + Sync {
     fn find_by_realm_id(
         &self,

--- a/core/src/domain/password_policy/service.rs
+++ b/core/src/domain/password_policy/service.rs
@@ -14,9 +14,10 @@ use crate::domain::{
 };
 
 use super::entity::{PasswordPolicy, UpdatePasswordPolicy};
-use super::error::PasswordPolicyViolation;
+use super::error::{PasswordPolicyError, PasswordPolicyViolation};
 use super::ports::PasswordPolicyPolicy;
 use super::repository::PasswordPolicyRepository;
+use super::validator;
 
 #[derive(Debug, Clone)]
 pub struct PasswordPolicyService<R, U, C, UR>
@@ -46,7 +47,6 @@ where
         identity: Identity,
         realm: &Realm,
     ) -> Result<PasswordPolicy, CoreError> {
-        // Check authorization
         ensure_policy(
             self.policy.can_view_password_policy(&identity, realm).await,
             "view realm password policy",
@@ -65,7 +65,6 @@ where
         realm: &Realm,
         update: UpdatePasswordPolicy,
     ) -> Result<PasswordPolicy, CoreError> {
-        // Check authorization
         ensure_policy(
             self.policy
                 .can_update_password_policy(&identity, realm)
@@ -96,5 +95,191 @@ where
             .find_by_realm_id(realm_id)
             .await?
             .unwrap_or_else(|| PasswordPolicy::default(realm_id)))
+    }
+
+    /// Validate a password against a policy (character class + entropy + common-password rules).
+    ///
+    /// Returns `Ok(())` on success, or an error whose message lists every violated rule.
+    pub fn validate_password(
+        password: &str,
+        policy: &PasswordPolicy,
+    ) -> Result<(), Vec<PasswordPolicyError>> {
+        validator::validate(password, policy, None, None)
+    }
+
+    /// Validate a password against a policy, providing user context for the
+    /// `forbid_common` username/email check.
+    pub fn validate_password_with_context(
+        password: &str,
+        policy: &PasswordPolicy,
+        username: Option<&str>,
+        email_local: Option<&str>,
+    ) -> Result<(), Vec<PasswordPolicyError>> {
+        validator::validate(password, policy, username, email_local)
+    }
+}
+
+/// Convert a list of policy violations into a single [`CoreError`] whose message
+/// enumerates all failed rules, separated by "; ".
+pub fn violations_to_core_error(violations: Vec<PasswordPolicyError>) -> CoreError {
+    let msg = violations
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join("; ");
+    CoreError::PasswordPolicyViolation(msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use crate::domain::{
+        client::ports::MockClientRepository,
+        user::ports::{MockUserRepository, MockUserRoleRepository},
+    };
+
+    fn make_policy(
+        min_length: i32,
+        require_uppercase: bool,
+        require_lowercase: bool,
+        require_number: bool,
+        require_special: bool,
+    ) -> PasswordPolicy {
+        PasswordPolicy {
+            id: Uuid::new_v4(),
+            realm_id: Uuid::new_v4(),
+            min_length,
+            require_uppercase,
+            require_lowercase,
+            require_number,
+            require_special,
+            max_age_days: None,
+            min_entropy_bits: 0,
+            forbid_common: false,
+            check_breached: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_password_too_short() {
+        let policy = make_policy(8, false, false, false, false);
+        let result = PasswordPolicyService::<
+            MockRepository,
+            MockUserRepository,
+            MockClientRepository,
+            MockUserRoleRepository,
+        >::validate_password("abc", &policy);
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors[0],
+            PasswordPolicyError::TooShort { min: 8, actual: 3 }
+        ));
+    }
+
+    #[test]
+    fn test_password_missing_uppercase() {
+        let policy = make_policy(8, true, false, false, false);
+        let result = PasswordPolicyService::<
+            MockRepository,
+            MockUserRepository,
+            MockClientRepository,
+            MockUserRoleRepository,
+        >::validate_password("password", &policy);
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingUppercase))
+        );
+    }
+
+    #[test]
+    fn test_password_meets_all_requirements() {
+        let policy = make_policy(8, true, true, true, true);
+        let result = PasswordPolicyService::<
+            MockRepository,
+            MockUserRepository,
+            MockClientRepository,
+            MockUserRoleRepository,
+        >::validate_password("Password1!", &policy);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_password_multiple_violations() {
+        let policy = make_policy(8, true, true, true, true);
+        let result = PasswordPolicyService::<
+            MockRepository,
+            MockUserRepository,
+            MockClientRepository,
+            MockUserRoleRepository,
+        >::validate_password("PASS", &policy);
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::TooShort { .. }))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingLowercase))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingNumber))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingSpecialCharacter))
+        );
+    }
+
+    #[test]
+    fn violations_to_core_error_formats_message() {
+        let violations = vec![
+            PasswordPolicyError::MissingUppercase,
+            PasswordPolicyError::MissingNumber,
+        ];
+        let err = violations_to_core_error(violations);
+        assert!(matches!(err, CoreError::PasswordPolicyViolation(_)));
+        if let CoreError::PasswordPolicyViolation(msg) = err {
+            assert!(msg.contains("uppercase"));
+            assert!(msg.contains("number"));
+        }
+    }
+
+    struct MockRepository;
+    impl PasswordPolicyRepository for MockRepository {
+        async fn find_by_realm_id(
+            &self,
+            _realm_id: Uuid,
+        ) -> Result<Option<PasswordPolicy>, CoreError> {
+            Ok(None)
+        }
+
+        async fn upsert(
+            &self,
+            _realm_id: Uuid,
+            _update: UpdatePasswordPolicy,
+        ) -> Result<PasswordPolicy, CoreError> {
+            Err(CoreError::NotFound)
+        }
     }
 }

--- a/core/src/domain/password_policy/validator.rs
+++ b/core/src/domain/password_policy/validator.rs
@@ -1,0 +1,458 @@
+use super::{entity::PasswordPolicy, error::PasswordPolicyError};
+
+/// Top-100 most common passwords (lowercase). Any password in this list is rejected when
+/// `forbid_common` is enabled, regardless of case.
+const COMMON_PASSWORDS: &[&str] = &[
+    "123456",
+    "password",
+    "123456789",
+    "12345678",
+    "12345",
+    "1234567",
+    "1234567890",
+    "qwerty",
+    "abc123",
+    "111111",
+    "123123",
+    "admin",
+    "letmein",
+    "welcome",
+    "monkey",
+    "login",
+    "princess",
+    "solo",
+    "master",
+    "dragon",
+    "passw0rd",
+    "pass@word1",
+    "iloveyou",
+    "sunshine",
+    "shadow",
+    "superman",
+    "michael",
+    "jessica",
+    "thomas",
+    "charlie",
+    "robert",
+    "football",
+    "baseball",
+    "soccer",
+    "hockey",
+    "basketball",
+    "batman",
+    "superman",
+    "trustno1",
+    "qwerty123",
+    "password1",
+    "password123",
+    "hunter2",
+    "hunter",
+    "696969",
+    "mustang",
+    "access",
+    "hello",
+    "secret",
+    "whatever",
+    "qazwsx",
+    "zxcvbnm",
+    "1q2w3e4r",
+    "1qaz2wsx",
+    "q1w2e3r4",
+    "asdfgh",
+    "asdfghjkl",
+    "zxcvbn",
+    "1234",
+    "12341234",
+    "1111",
+    "0000",
+    "7777777",
+    "666666",
+    "555555",
+    "444444",
+    "333333",
+    "222222",
+    "121212",
+    "654321",
+    "987654321",
+    "pass",
+    "test",
+    "root",
+    "toor",
+    "temp",
+    "changeme",
+    "qwert",
+    "asdf",
+    "zxcv",
+    "1password",
+    "2password",
+    "abc",
+    "abcd",
+    "abcdef",
+    "abcdefg",
+    "abcdefgh",
+    "abcdefghi",
+    "1234abcd",
+    "a1b2c3",
+    "aaa",
+    "aaaaaa",
+    "aaaa",
+    "bbb",
+    "111",
+    "000",
+    "qqqqqq",
+    "pppppp",
+    "iloveyou1",
+    "lovely",
+    "monkey123",
+];
+
+/// Pool sizes for character classes used in entropy estimation.
+const POOL_LOWERCASE: f64 = 26.0;
+const POOL_UPPERCASE: f64 = 26.0;
+const POOL_DIGIT: f64 = 10.0;
+/// Printable ASCII specials: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ plus space = 33 characters.
+const POOL_SPECIAL: f64 = 33.0;
+
+/// Estimate password entropy using the charset-pool model:
+/// entropy = length × log₂(pool_size)
+/// where pool_size = sum of sizes of each character class present in the password.
+pub fn estimate_entropy_bits(password: &str) -> f64 {
+    if password.is_empty() {
+        return 0.0;
+    }
+    let has_lower = password.chars().any(|c| c.is_ascii_lowercase());
+    let has_upper = password.chars().any(|c| c.is_ascii_uppercase());
+    let has_digit = password.chars().any(|c| c.is_ascii_digit());
+    let has_special = password
+        .chars()
+        .any(|c| c.is_ascii() && !c.is_alphanumeric());
+
+    let pool: f64 = (if has_lower { POOL_LOWERCASE } else { 0.0 })
+        + (if has_upper { POOL_UPPERCASE } else { 0.0 })
+        + (if has_digit { POOL_DIGIT } else { 0.0 })
+        + (if has_special { POOL_SPECIAL } else { 0.0 });
+
+    if pool == 0.0 {
+        return 0.0;
+    }
+    password.len() as f64 * pool.log2()
+}
+
+/// Validate a password against a policy.
+///
+/// `username` and `email_local` are used when `forbid_common` is enabled:
+/// a password equal (case-insensitively) to the username or the local part of the email
+/// is rejected.
+///
+/// Returns `Ok(())` if the password satisfies all enabled rules, or
+/// `Err(violations)` listing every rule that was violated.
+pub fn validate(
+    password: &str,
+    policy: &PasswordPolicy,
+    username: Option<&str>,
+    email_local: Option<&str>,
+) -> Result<(), Vec<PasswordPolicyError>> {
+    let mut errors = Vec::new();
+
+    if password.len() < policy.min_length as usize {
+        errors.push(PasswordPolicyError::TooShort {
+            min: policy.min_length,
+            actual: password.len(),
+        });
+    }
+
+    if policy.require_uppercase && !password.chars().any(|c| c.is_ascii_uppercase()) {
+        errors.push(PasswordPolicyError::MissingUppercase);
+    }
+
+    if policy.require_lowercase && !password.chars().any(|c| c.is_ascii_lowercase()) {
+        errors.push(PasswordPolicyError::MissingLowercase);
+    }
+
+    if policy.require_number && !password.chars().any(|c| c.is_ascii_digit()) {
+        errors.push(PasswordPolicyError::MissingNumber);
+    }
+
+    if policy.require_special
+        && !password
+            .chars()
+            .any(|c| c.is_ascii() && !c.is_alphanumeric())
+    {
+        errors.push(PasswordPolicyError::MissingSpecialCharacter);
+    }
+
+    let entropy = estimate_entropy_bits(password);
+    let min_entropy = policy.min_entropy_bits as f64;
+    if entropy < min_entropy {
+        errors.push(PasswordPolicyError::InsufficientEntropy {
+            min_bits: min_entropy,
+            actual_bits: entropy,
+        });
+    }
+
+    if policy.forbid_common {
+        let lower = password.to_ascii_lowercase();
+        let is_common = COMMON_PASSWORDS.contains(&lower.as_str());
+        let matches_username = username
+            .map(|u| lower == u.to_ascii_lowercase())
+            .unwrap_or(false);
+        let matches_email_local = email_local
+            .map(|e| lower == e.to_ascii_lowercase())
+            .unwrap_or(false);
+
+        if is_common || matches_username || matches_email_local {
+            errors.push(PasswordPolicyError::CommonPassword);
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::password_policy::entity::PasswordPolicy;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn cnil_policy() -> PasswordPolicy {
+        PasswordPolicy::default(Uuid::new_v4())
+    }
+
+    fn permissive_policy() -> PasswordPolicy {
+        PasswordPolicy {
+            id: Uuid::new_v4(),
+            realm_id: Uuid::new_v4(),
+            min_length: 1,
+            require_uppercase: false,
+            require_lowercase: false,
+            require_number: false,
+            require_special: false,
+            max_age_days: None,
+            min_entropy_bits: 0,
+            forbid_common: false,
+            check_breached: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn strong_password_passes_cnil_policy() {
+        // 14 chars: lower + upper + digit + special → pool=95, entropy ≈ 92 bits
+        let result = validate("Tr0ub4dor&3XY!", &cnil_policy(), None, None);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    #[test]
+    fn password_too_short_fails() {
+        let result = validate("Tr0ub!", &cnil_policy(), None, None);
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::TooShort { min: 12, actual: 6 }))
+        );
+    }
+
+    #[test]
+    fn missing_uppercase_fails() {
+        let mut p = cnil_policy();
+        p.min_entropy_bits = 0;
+        let result = validate("tr0ub4dor&3xy!", &p, None, None);
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingUppercase)),
+            "{:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn missing_lowercase_fails() {
+        let mut p = cnil_policy();
+        p.min_entropy_bits = 0;
+        let result = validate("TR0UB4DOR&3XY!", &p, None, None);
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingLowercase)),
+            "{:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn missing_digit_fails() {
+        let mut p = cnil_policy();
+        p.min_entropy_bits = 0;
+        let result = validate("TrOubAdOr&XYzA!", &p, None, None);
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingNumber)),
+            "{:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn missing_special_fails() {
+        let mut p = cnil_policy();
+        p.min_entropy_bits = 0;
+        let result = validate("Tr0ub4dor3XYzA", &p, None, None);
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::MissingSpecialCharacter)),
+            "{:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn entropy_boundary_79_bits_fails() {
+        // pool=62 (lower+upper+digit), entropy = len * log2(62) ≈ len * 5.954
+        // to reach exactly ≥80 bits we need len ≥ ceil(80/5.954) = 14 chars
+        // 13 chars with only alphanum → ~77.4 bits < 80
+        let mut p = permissive_policy();
+        p.min_length = 13;
+        p.min_entropy_bits = 80;
+        // 13-char alphanumeric: pool=62
+        let result = validate("Abcdefg1234567", &p, None, None);
+        // 14 chars → pool=62, entropy≈83.4 → should pass
+        // but let's test 13 chars → should fail
+        let result13 = validate("Abcdefg123456", &p, None, None);
+        let errors13 = result13.unwrap_err();
+        assert!(
+            errors13
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::InsufficientEntropy { .. })),
+            "expected InsufficientEntropy, got {:?}",
+            errors13
+        );
+        // 14 chars → passes entropy
+        assert!(
+            result.is_ok(),
+            "expected 14-char password to pass, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn entropy_boundary_80_bits_passes() {
+        // 14 lower+upper+digit chars → pool=62, entropy ≈ 83.4 bits ≥ 80
+        let mut p = permissive_policy();
+        p.min_entropy_bits = 80;
+        let result = validate("Abcdefg12345678", &p, None, None);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    #[test]
+    fn common_password_rejected() {
+        let mut p = permissive_policy();
+        p.forbid_common = true;
+        let result = validate("password", &p, None, None);
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::CommonPassword)),
+            "{:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn common_password_case_insensitive() {
+        let mut p = permissive_policy();
+        p.forbid_common = true;
+        let result = validate("PASSWORD", &p, None, None);
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::CommonPassword)),
+            "{:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn password_equal_to_username_rejected() {
+        let mut p = permissive_policy();
+        p.forbid_common = true;
+        let result = validate("johndoe", &p, Some("johndoe"), None);
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::CommonPassword)),
+            "{:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn password_equal_to_email_local_rejected() {
+        let mut p = permissive_policy();
+        p.forbid_common = true;
+        let result = validate("alice", &p, None, Some("alice"));
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, PasswordPolicyError::CommonPassword)),
+            "{:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn unique_password_not_in_common_list_accepted() {
+        let mut p = permissive_policy();
+        p.forbid_common = true;
+        let result = validate("xK9#mR2$pL7@nQ5", &p, Some("alice"), Some("alice"));
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    #[test]
+    fn multiple_violations_reported_together() {
+        let result = validate("abc", &cnil_policy(), None, None);
+        let errors = result.unwrap_err();
+        // TooShort, MissingUppercase, MissingNumber, MissingSpecialCharacter, InsufficientEntropy
+        assert!(
+            errors.len() >= 3,
+            "expected multiple errors, got {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn estimate_entropy_empty_password() {
+        assert_eq!(estimate_entropy_bits(""), 0.0);
+    }
+
+    #[test]
+    fn estimate_entropy_digits_only() {
+        // pool=10, len=6 → 6 * log2(10) ≈ 19.9
+        let e = estimate_entropy_bits("123456");
+        assert!(e > 19.0 && e < 21.0, "got {}", e);
+    }
+
+    #[test]
+    fn estimate_entropy_all_classes() {
+        // pool=95, len=14 → 14 * log2(95) ≈ 91.9
+        let e = estimate_entropy_bits("Abc1!Def2@Gh3#");
+        assert!(e > 90.0 && e < 95.0, "got {}", e);
+    }
+}

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -33,6 +33,10 @@ use crate::{
             entities::interpolate_variables,
             ports::{EmailTemplateRepository, TemplateRenderer},
         },
+        password_policy::{
+            entity::PasswordPolicy, repository::PasswordPolicyRepository,
+            service::violations_to_core_error, validator,
+        },
         realm::{
             entities::RealmId,
             ports::{RealmRepository, SmtpConfigRepository},
@@ -206,7 +210,7 @@ async fn store_auth_code_and_generate_login_url<AS: AuthSessionRepository>(
 }
 
 #[derive(Clone, Debug)]
-pub struct TridentServiceImpl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR>
+pub struct TridentServiceImpl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR>
 where
     CR: CredentialRepository,
     RC: RecoveryCodeRepository,
@@ -223,6 +227,7 @@ where
     WH: WebhookRepository,
     ETR: EmailTemplateRepository,
     TR: TemplateRenderer,
+    PPR: PasswordPolicyRepository,
 {
     pub(crate) credential_repository: Arc<CR>,
     pub(crate) recovery_code_repository: Arc<RC>,
@@ -239,10 +244,11 @@ where
     pub(crate) webhook_repository: Arc<WH>,
     pub(crate) email_template_repository: Arc<ETR>,
     pub(crate) template_renderer: Arc<TR>,
+    pub(crate) password_policy_repository: Arc<PPR>,
 }
 
-impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR>
-    TridentServiceImpl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR>
+impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR>
+    TridentServiceImpl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR>
 where
     CR: CredentialRepository,
     RC: RecoveryCodeRepository,
@@ -259,6 +265,7 @@ where
     WH: WebhookRepository,
     ETR: EmailTemplateRepository,
     TR: TemplateRenderer,
+    PPR: PasswordPolicyRepository,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -277,6 +284,7 @@ where
         webhook_repository: Arc<WH>,
         email_template_repository: Arc<ETR>,
         template_renderer: Arc<TR>,
+        password_policy_repository: Arc<PPR>,
     ) -> Self {
         Self {
             credential_repository,
@@ -294,6 +302,7 @@ where
             webhook_repository,
             email_template_repository,
             template_renderer,
+            password_policy_repository,
         }
     }
 
@@ -332,8 +341,8 @@ where
     }
 }
 
-impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR> TridentService
-    for TridentServiceImpl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR>
+impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR> TridentService
+    for TridentServiceImpl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR>
 where
     CR: CredentialRepository,
     RC: RecoveryCodeRepository,
@@ -350,6 +359,7 @@ where
     WH: WebhookRepository,
     ETR: EmailTemplateRepository,
     TR: TemplateRenderer,
+    PPR: PasswordPolicyRepository,
 {
     async fn generate_recovery_code(
         &self,
@@ -1030,6 +1040,26 @@ where
             Identity::User(user) => user,
             _ => return Err(CoreError::Forbidden("is not user".to_string())),
         };
+
+        let policy = self
+            .password_policy_repository
+            .find_by_realm_id(user.realm_id.into())
+            .await?
+            .unwrap_or_else(|| PasswordPolicy::default(user.realm_id.into()));
+
+        let email_local_buf = user
+            .email
+            .as_deref()
+            .and_then(|e| e.split('@').next())
+            .map(str::to_string);
+
+        validator::validate(
+            &input.value,
+            &policy,
+            Some(user.username.as_str()),
+            email_local_buf.as_deref(),
+        )
+        .map_err(violations_to_core_error)?;
 
         let password_credential = self
             .credential_repository
@@ -1713,13 +1743,39 @@ where
             return Err(CoreError::InvalidToken);
         }
 
-        // 3. Delete old password credential
+        // 3. Enforce password policy before applying the new credential.
+        let policy = self
+            .password_policy_repository
+            .find_by_realm_id(prt.realm_id)
+            .await?
+            .unwrap_or_else(|| PasswordPolicy::default(prt.realm_id));
+
+        // Look up user context for the common-password check (username/email match).
+        let target_user = self.user_repository.get_by_id(prt.user_id).await.ok();
+
+        let (username_buf, email_local_buf);
+        let (username_ref, email_local_ref) = if let Some(ref u) = target_user {
+            username_buf = u.username.clone();
+            email_local_buf = u
+                .email
+                .as_deref()
+                .and_then(|e| e.split('@').next())
+                .map(str::to_string);
+            (Some(username_buf.as_str()), email_local_buf.as_deref())
+        } else {
+            (None, None)
+        };
+
+        validator::validate(&input.new_password, &policy, username_ref, email_local_ref)
+            .map_err(violations_to_core_error)?;
+
+        // 4. Delete old password credential
         let _ = self
             .credential_repository
             .delete_password_credential(prt.user_id)
             .await;
 
-        // 4. Create new hashed credential
+        // 5. Create new hashed credential
         let hash_result = self
             .hasher_repository
             .hash_password(&input.new_password)
@@ -1855,6 +1911,7 @@ mod tests {
         common::{email::MockEmailPort, services::tests::create_test_realm_with_name},
         credential::ports::MockCredentialRepository,
         email_template::ports::MockEmailTemplateRepository,
+        password_policy::repository::MockPasswordPolicyRepository,
         realm::ports::{MockRealmRepository, MockSmtpConfigRepository},
         seawatch::ports::MockSecurityEventRepository,
         trident::ports::{
@@ -1898,6 +1955,7 @@ mod tests {
         webhook_repo: Arc<MockWebhookRepository>,
         email_template_repo: Arc<MockEmailTemplateRepository>,
         template_renderer: Arc<NoopTemplateRenderer>,
+        password_policy_repo: Arc<MockPasswordPolicyRepository>,
     }
 
     impl TridentTestBuilder {
@@ -1918,6 +1976,7 @@ mod tests {
                 webhook_repo: Arc::new(MockWebhookRepository::new()),
                 email_template_repo: Arc::new(MockEmailTemplateRepository::new()),
                 template_renderer: Arc::new(NoopTemplateRenderer),
+                password_policy_repo: Arc::new(MockPasswordPolicyRepository::new()),
             }
         }
 
@@ -1939,6 +1998,7 @@ mod tests {
             MockWebhookRepository,
             MockEmailTemplateRepository,
             NoopTemplateRenderer,
+            MockPasswordPolicyRepository,
         > {
             TridentServiceImpl::new(
                 self.credential_repo,
@@ -1956,6 +2016,7 @@ mod tests {
                 self.webhook_repo,
                 self.email_template_repo,
                 self.template_renderer,
+                self.password_policy_repo,
             )
         }
     }
@@ -2241,6 +2302,18 @@ mod tests {
             .expect_verify_magic_token()
             .returning(|_, _| Box::pin(async { Ok(true) }));
 
+        // Policy lookup: no stored policy → use CNIL defaults
+        Arc::get_mut(&mut builder.password_policy_repo)
+            .unwrap()
+            .expect_find_by_realm_id()
+            .returning(|_| Box::pin(async { Ok(None) }));
+
+        // User lookup for username/email context
+        Arc::get_mut(&mut builder.user_repo)
+            .unwrap()
+            .expect_get_by_id()
+            .returning(move |_| Box::pin(async { Err(CoreError::NotFound) }));
+
         Arc::get_mut(&mut builder.credential_repo)
             .unwrap()
             .expect_delete_password_credential()
@@ -2301,15 +2374,16 @@ mod tests {
             .returning(|_, _: WebhookPayload<()>| Box::pin(async { Ok(()) }));
 
         let service = builder.build();
+        // Strong password satisfying CNIL defaults (≥12 chars, all classes, ≥80 bits entropy)
         let result = service
             .complete_password_reset(CompletePasswordResetInput {
                 token_id,
                 token: "raw_token".to_string(),
-                new_password: "newpassword123".to_string(),
+                new_password: "Str0ng!P@ssword#2024".to_string(),
             })
             .await;
 
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "expected Ok, got Err");
     }
 
     #[tokio::test]

--- a/core/src/domain/user/services.rs
+++ b/core/src/domain/user/services.rs
@@ -12,6 +12,10 @@ use crate::domain::{
     },
     credential::ports::CredentialRepository,
     crypto::HasherRepository,
+    password_policy::{
+        entity::PasswordPolicy, repository::PasswordPolicyRepository,
+        service::violations_to_core_error, validator,
+    },
     realm::ports::RealmRepository,
     role::{entities::permission::Permissions, ports::RoleRepository},
     seawatch::{EventStatus, SecurityEvent, SecurityEventRepository, SecurityEventType},
@@ -48,7 +52,7 @@ fn normalize_optional_email(email: Option<String>) -> Option<String> {
 }
 
 #[derive(Clone, Debug)]
-pub struct UserServiceImpl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR>
+pub struct UserServiceImpl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR, PPR>
 where
     R: RealmRepository,
     U: UserRepository,
@@ -61,6 +65,7 @@ where
     W: WebhookRepository,
     SE: SecurityEventRepository,
     UAR: UserAttributeRepository,
+    PPR: PasswordPolicyRepository,
 {
     pub(crate) realm_repository: Arc<R>,
     pub(crate) user_repository: Arc<U>,
@@ -72,12 +77,13 @@ where
     pub(crate) user_attribute_repository: Arc<UAR>,
     pub(crate) webhook_repository: Arc<W>,
     pub(crate) security_event_repository: Arc<SE>,
+    pub(crate) password_policy_repository: Arc<PPR>,
 
     pub(crate) policy: Arc<FerriskeyPolicy<U, C, UR>>,
 }
 
-impl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR>
-    UserServiceImpl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR>
+impl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR, PPR>
+    UserServiceImpl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR, PPR>
 where
     R: RealmRepository,
     U: UserRepository,
@@ -90,6 +96,7 @@ where
     W: WebhookRepository,
     SE: SecurityEventRepository,
     UAR: UserAttributeRepository,
+    PPR: PasswordPolicyRepository,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -103,6 +110,7 @@ where
         user_attribute_repository: Arc<UAR>,
         webhook_repository: Arc<W>,
         security_event_repository: Arc<SE>,
+        password_policy_repository: Arc<PPR>,
         policy: Arc<FerriskeyPolicy<U, C, UR>>,
     ) -> Self {
         Self {
@@ -116,13 +124,14 @@ where
             user_attribute_repository,
             webhook_repository,
             security_event_repository,
+            password_policy_repository,
             policy,
         }
     }
 }
 
-impl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR> UserService
-    for UserServiceImpl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR>
+impl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR, PPR> UserService
+    for UserServiceImpl<R, U, C, UR, CR, H, RO, URA, W, SE, UAR, PPR>
 where
     R: RealmRepository,
     U: UserRepository,
@@ -135,6 +144,7 @@ where
     W: WebhookRepository,
     SE: SecurityEventRepository,
     UAR: UserAttributeRepository,
+    PPR: PasswordPolicyRepository,
 {
     async fn delete_user(
         &self,
@@ -201,6 +211,30 @@ where
             self.policy.can_update_user(&identity, &realm).await,
             "insufficient permissions",
         )?;
+
+        let policy = self
+            .password_policy_repository
+            .find_by_realm_id(realm.id.into())
+            .await?
+            .unwrap_or_else(|| PasswordPolicy::default(realm.id.into()));
+
+        let target_user = self.user_repository.get_by_id(input.user_id).await.ok();
+
+        let (username, email_local_buf);
+        let (username_ref, email_local_ref) = if let Some(ref u) = target_user {
+            username = u.username.clone();
+            email_local_buf = u
+                .email
+                .as_deref()
+                .and_then(|e| e.split('@').next())
+                .map(str::to_string);
+            (Some(username.as_str()), email_local_buf.as_deref())
+        } else {
+            (None, None)
+        };
+
+        validator::validate(&input.password, &policy, username_ref, email_local_ref)
+            .map_err(violations_to_core_error)?;
 
         let password_credential = self
             .credential_repository
@@ -705,6 +739,7 @@ mod tests {
         },
         credential::ports::MockCredentialRepository,
         crypto::MockHasherRepository,
+        password_policy::repository::MockPasswordPolicyRepository,
         realm::{entities::Realm, ports::MockRealmRepository},
         role::ports::MockRoleRepository,
         seawatch::ports::MockSecurityEventRepository,
@@ -727,6 +762,7 @@ mod tests {
         webhook_repo: Arc<MockWebhookRepository>,
         client_repo: Arc<MockClientRepository>,
         security_event_repo: Arc<MockSecurityEventRepository>,
+        password_policy_repo: Arc<MockPasswordPolicyRepository>,
     }
 
     impl UserServiceTestBuilder {
@@ -743,6 +779,7 @@ mod tests {
                 webhook_repo: Arc::new(MockWebhookRepository::new()),
                 client_repo: Arc::new(MockClientRepository::new()),
                 security_event_repo: Arc::new(MockSecurityEventRepository::new()),
+                password_policy_repo: Arc::new(MockPasswordPolicyRepository::new()),
             }
         }
 
@@ -844,6 +881,7 @@ mod tests {
             MockWebhookRepository,
             MockSecurityEventRepository,
             MockUserAttributeRepository,
+            MockPasswordPolicyRepository,
         > {
             use crate::domain::common::policies::FerriskeyPolicy;
 
@@ -864,6 +902,7 @@ mod tests {
                 self.user_attribute_repo,
                 self.webhook_repo,
                 self.security_event_repo,
+                self.password_policy_repo,
                 Arc::new(policy),
             )
         }

--- a/core/src/entity/password_policy.rs
+++ b/core/src/entity/password_policy.rs
@@ -21,6 +21,9 @@ pub struct Model {
     pub require_number: bool,
     pub require_special: bool,
     pub max_age_days: Option<i32>,
+    pub min_entropy_bits: i32,
+    pub forbid_common: bool,
+    pub check_breached: bool,
     pub created_at: DateTimeWithTimeZone,
     pub updated_at: DateTimeWithTimeZone,
 }
@@ -35,6 +38,9 @@ pub enum Column {
     RequireNumber,
     RequireSpecial,
     MaxAgeDays,
+    MinEntropyBits,
+    ForbidCommon,
+    CheckBreached,
     CreatedAt,
     UpdatedAt,
 }
@@ -68,6 +74,9 @@ impl ColumnTrait for Column {
             Self::RequireNumber => ColumnType::Boolean.def(),
             Self::RequireSpecial => ColumnType::Boolean.def(),
             Self::MaxAgeDays => ColumnType::Integer.def().null(),
+            Self::MinEntropyBits => ColumnType::Integer.def(),
+            Self::ForbidCommon => ColumnType::Boolean.def(),
+            Self::CheckBreached => ColumnType::Boolean.def(),
             Self::CreatedAt => ColumnType::TimestampWithTimeZone.def(),
             Self::UpdatedAt => ColumnType::TimestampWithTimeZone.def(),
         }

--- a/core/src/infrastructure/repositories/password_policy_repository.rs
+++ b/core/src/infrastructure/repositories/password_policy_repository.rs
@@ -33,6 +33,9 @@ impl From<crate::entity::password_policy::Model> for PasswordPolicy {
             require_number: model.require_number,
             require_special: model.require_special,
             max_age_days: model.max_age_days,
+            min_entropy_bits: model.min_entropy_bits,
+            forbid_common: model.forbid_common,
+            check_breached: model.check_breached,
             created_at: model.created_at.into(),
             updated_at: model.updated_at.into(),
         }
@@ -94,20 +97,32 @@ impl PasswordPolicyRepository for PostgresPasswordPolicyRepository {
             if let Some(max_age_days) = update.max_age_days {
                 active_model.max_age_days = Set(Some(max_age_days));
             }
+            if let Some(min_entropy_bits) = update.min_entropy_bits {
+                active_model.min_entropy_bits = Set(min_entropy_bits);
+            }
+            if let Some(forbid_common) = update.forbid_common {
+                active_model.forbid_common = Set(forbid_common);
+            }
+            if let Some(check_breached) = update.check_breached {
+                active_model.check_breached = Set(check_breached);
+            }
             active_model.updated_at = Set(now);
 
             active_model.update(&self.db).await
         } else {
-            // Create new
+            // Create new with CNIL-aligned defaults
             let active_model = crate::entity::password_policy::ActiveModel {
                 id: Set(Uuid::now_v7()),
                 realm_id: Set(realm_id),
-                min_length: Set(update.min_length.unwrap_or(8)),
-                require_uppercase: Set(update.require_uppercase.unwrap_or(false)),
-                require_lowercase: Set(update.require_lowercase.unwrap_or(false)),
-                require_number: Set(update.require_number.unwrap_or(false)),
-                require_special: Set(update.require_special.unwrap_or(false)),
+                min_length: Set(update.min_length.unwrap_or(12)),
+                require_uppercase: Set(update.require_uppercase.unwrap_or(true)),
+                require_lowercase: Set(update.require_lowercase.unwrap_or(true)),
+                require_number: Set(update.require_number.unwrap_or(true)),
+                require_special: Set(update.require_special.unwrap_or(true)),
                 max_age_days: Set(update.max_age_days),
+                min_entropy_bits: Set(update.min_entropy_bits.unwrap_or(80)),
+                forbid_common: Set(update.forbid_common.unwrap_or(true)),
+                check_breached: Set(update.check_breached.unwrap_or(false)),
                 created_at: Set(now),
                 updated_at: Set(now),
             };

--- a/front/eslint.config.js
+++ b/front/eslint.config.js
@@ -3,6 +3,9 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 export default tseslint.config(
   { ignores: ['dist', 'src/api/api.client.ts', 'src/api/api.tanstack.ts'] },
@@ -26,4 +29,4 @@ export default tseslint.config(
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   }
-)
+);

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -313,7 +313,7 @@ pub enum CoreError {
     #[error("Portal layout is referenced by one or more themes and cannot be deleted")]
     PortalLayoutInUse,
 
-    #[error("Password does not meet the realm policy")]
+    #[error("Password policy violated: {0}")]
     PasswordPolicyViolation(String),
 }
 


### PR DESCRIPTION
## Summary

- Add new docs page at `docs/device-authorization-grant.md` documenting the OAuth 2.0 Device Authorization Grant (RFC 8628).
- Include end-to-end curl flow examples:
  - initiate device authorization request
  - user verification page (`verification_uri` / `verification_uri_complete`)
  - token polling using `urn:ietf:params:oauth:grant-type:device_code`
- Document polling outcomes (`authorization_pending`, `slow_down`, `expired_token`, `access_denied`).
- List webhook triggers:
  - `auth.device_flow.initiated`
  - `auth.device_flow.denied`
  - `auth.device_flow.expired`
- Add a CLI/browserless client use case note and RFC 8628 reference.
- Add README link to the new Device Authorization Grant page.

## Notes

This is docs-only and should be quick to review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added temporary automation and branch-structure files to the project’s ignore rules.
  * Updated tooling configuration to support consistent linting in the current module setup.

* **End-user impact**
  * No new user-facing features or functionality changes are included.
  * These updates help maintain development consistency without affecting the application experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->