### PR TITLE
feat: add client scopes "Evaluate" tab to preview mappers, roles & tokens

### DIFF
--- a/api/src/application/http/client/handlers.rs
+++ b/api/src/application/http/client/handlers.rs
@@ -5,6 +5,7 @@ pub mod create_role;
 pub mod delete_client;
 pub mod delete_post_logout_redirect_uri;
 pub mod delete_redirect_uri;
+pub mod evaluate_scopes;
 pub mod get_client;
 pub mod get_client_roles;
 pub mod get_clients;

--- a/api/src/application/http/client/handlers/evaluate_scopes.rs
+++ b/api/src/application/http/client/handlers/evaluate_scopes.rs
@@ -1,0 +1,63 @@
+use crate::application::http::authentication::handlers::auth::root_scoped_base_url;
+use crate::application::http::client::validators::EvaluateScopesValidator;
+use crate::application::http::server::{
+    api_entities::{
+        api_error::{ApiError, ApiErrorResponse, ValidateJson},
+        response::Response,
+    },
+    app_state::AppState,
+};
+use crate::application::url::FullUrl;
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::authentication::value_objects::{
+    EvaluateClientScopesRequest, EvaluateClientScopesResult, Identity,
+};
+use uuid::Uuid;
+
+#[utoipa::path(
+    post,
+    operation_id = "evaluate_client_scopes",
+    summary = "Evaluate client scopes for a user",
+    description = "Previews the effective protocol mappers, roles and token claims (access token, ID token, userinfo) a user would receive from this client for a given scope set — without issuing (signing or persisting) a real token.",
+    path = "/{client_id}/evaluate-scopes",
+    tag = "client",
+    params(
+        ("realm_name" = String, Path, description = "Realm name"),
+        ("client_id" = Uuid, Path, description = "Client ID"),
+    ),
+    request_body = EvaluateScopesValidator,
+    responses(
+        (status = 200, body = EvaluateClientScopesResult, description = "Evaluation preview"),
+        (status = 401, description = "Realm not found", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+pub async fn evaluate_scopes(
+    Path((realm_name, client_id)): Path<(String, Uuid)>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+    FullUrl(_, base_url): FullUrl,
+    ValidateJson(payload): ValidateJson<EvaluateScopesValidator>,
+) -> Result<Response<EvaluateClientScopesResult>, ApiError> {
+    let base_url = root_scoped_base_url(&base_url, &state.args.server.root_path);
+
+    let result = state
+        .service
+        .evaluate_client_scopes(
+            identity,
+            EvaluateClientScopesRequest {
+                realm_name,
+                client_id,
+                base_url,
+                user_id: payload.user_id,
+                scope: payload.scope,
+            },
+        )
+        .await?;
+
+    Ok(Response::OK(result))
+}

--- a/api/src/application/http/client/router.rs
+++ b/api/src/application/http/client/router.rs
@@ -16,6 +16,7 @@ use super::handlers::{
         __path_delete_post_logout_redirect_uri, delete_post_logout_redirect_uri,
     },
     delete_redirect_uri::{__path_delete_redirect_uri, delete_redirect_uri},
+    evaluate_scopes::{__path_evaluate_scopes, evaluate_scopes},
     get_client::{__path_get_client, get_client},
     get_client_roles::{__path_get_client_roles, get_client_roles},
     get_clients::{__path_get_clients, get_clients},
@@ -48,7 +49,8 @@ use crate::application::{auth::auth, http::server::app_state::AppState};
         update_post_logout_redirect_uri,
         delete_redirect_uri,
         delete_post_logout_redirect_uri,
-        get_client_roles
+        get_client_roles,
+        evaluate_scopes
     ),
 
     tags(
@@ -163,6 +165,13 @@ pub fn client_routes(state: AppState) -> Router<AppState> {
                 state.args.server.root_path
             ),
             get(get_client_roles),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/clients/{{client_id}}/evaluate-scopes",
+                state.args.server.root_path
+            ),
+            post(evaluate_scopes),
         )
         .layer(middleware::from_fn_with_state(state.clone(), auth))
 }

--- a/api/src/application/http/client/validators.rs
+++ b/api/src/application/http/client/validators.rs
@@ -1,7 +1,18 @@
 use ferriskey_core::domain::client::entities::ClientType;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use uuid::Uuid;
 use validator::Validate;
+
+#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+pub struct EvaluateScopesValidator {
+    /// User whose token would be previewed.
+    pub user_id: Uuid,
+    /// Requested scope string (space-separated). Default scopes always apply; optional scopes
+    /// apply only when named here.
+    #[serde(default)]
+    pub scope: Option<String>,
+}
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct CreateClientValidator {

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -22,9 +22,16 @@ use crate::{
             entities::{ExchangeTokenInput, JwtToken},
             ports::AuthService,
             services::AuthServiceImpl,
-            value_objects::{GenerateTokensForUserInput, Identity},
+            value_objects::{
+                EvaluateClientScopesInput, EvaluateClientScopesRequest, EvaluateClientScopesResult,
+                GenerateTokensForUserInput, Identity,
+            },
         },
-        client::{ports::ClientRepository, services::ClientServiceImpl},
+        client::{
+            entities::GetClientInput,
+            ports::{ClientRepository, ClientService},
+            services::ClientServiceImpl,
+        },
         common::{
             entities::{InitializationResult, StartupConfig, app_errors::CoreError},
             ports::CoreService,
@@ -500,6 +507,47 @@ impl ApplicationService {
             .ok_or(CoreError::InvalidRealm)?;
         self.password_policy_service
             .get_policy_public(realm.id.into())
+            .await
+    }
+
+    /// Preview the token claims a user would receive from a client for a given scope set,
+    /// without issuing (signing/persisting) a token. Backs the "Evaluate" client-scopes tab.
+    ///
+    /// Authorization reuses the client view policy: `get_client_by_id` enforces
+    /// `can_view_client` and returns the resolved client.
+    pub async fn evaluate_client_scopes(
+        &self,
+        identity: Identity,
+        request: EvaluateClientScopesRequest,
+    ) -> Result<EvaluateClientScopesResult, CoreError> {
+        let client = self
+            .client_service
+            .get_client_by_id(
+                identity,
+                GetClientInput {
+                    client_id: request.client_id,
+                    realm_name: request.realm_name.clone(),
+                },
+            )
+            .await?;
+
+        let realm = self
+            .realm_service
+            .realm_repository
+            .get_by_name(&request.realm_name)
+            .await?
+            .ok_or(CoreError::InvalidRealm)?;
+
+        self.auth_service
+            .evaluate_client_scopes(EvaluateClientScopesInput {
+                base_url: request.base_url,
+                realm_id: realm.id,
+                realm_name: realm.name,
+                client_uuid: client.id,
+                client_id: client.client_id,
+                user_id: request.user_id,
+                scope: request.scope,
+            })
             .await
     }
 

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -11,6 +11,7 @@ use subtle::ConstantTimeEq;
 use tracing::{Instrument, error, info, info_span, instrument, warn};
 use uuid::Uuid;
 
+use ferriskey_aegis::entities::{ClientScope, ProtocolMapper};
 use ferriskey_aegis::ports::{ClientScopeMappingRepository, ProtocolMapperRepository};
 use ferriskey_compass::entities::{FlowId, FlowStatus, FlowStepName, StepStatus};
 use ferriskey_compass::recorder::FlowRecorder;
@@ -36,8 +37,9 @@ use crate::domain::{
         ports::{AuthService, AuthSessionRepository},
         value_objects::{
             AuthenticationResult, CodeChallengeMethod, EndSessionInput, EndSessionOutput,
-            GenerateTokenInput, GenerateTokensForUserInput, GetUserInfoInput, GrantTypeParams,
-            Identity, IntrospectTokenInput, RegisterUserInput, RegisterUserOutput,
+            EvaluateClientScopesInput, EvaluateClientScopesResult, EvaluatedMapper, EvaluatedRoles,
+            EvaluatedScope, GenerateTokenInput, GenerateTokensForUserInput, GetUserInfoInput,
+            GrantTypeParams, Identity, IntrospectTokenInput, RegisterUserInput, RegisterUserOutput,
             RegisterUserUrlContext, RevokeTokenInput, UserInfoResponse,
         },
     },
@@ -133,6 +135,20 @@ fn pkce_validate_verifier(verifier: &str) -> bool {
     verifier
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~'))
+}
+
+/// Token claims assembled from a client's scopes + protocol mappers for a given user,
+/// independent of signing and persistence. Reused by `create_jwt` (real issuance) and by the
+/// client-scope evaluation preview, so the preview reflects exactly what a real token carries.
+struct AssembledClaims {
+    access_claims: JwtClaim,
+    /// ID-token additional claims produced by `IdToken` mappers; `None` when the `openid`
+    /// scope is absent (no ID token is issued in that case).
+    id_mapper_claims: Option<HashMap<String, serde_json::Value>>,
+    /// Client scopes that applied (default scopes + requested optional scopes).
+    effective_scopes: Vec<ClientScope>,
+    /// Protocol mappers gathered from the effective scopes.
+    effective_mappers: Vec<ProtocolMapper>,
 }
 
 #[derive(Clone, Debug)]
@@ -508,16 +524,14 @@ where
         Ok(Jwt { token, expires_at })
     }
 
-    async fn create_jwt(
+    /// Assemble access-token claims (and the ID-token mapper claims) for `input`, applying the
+    /// client's scopes and protocol mappers. Pure computation: it neither signs nor persists a
+    /// token. `create_jwt` uses it before signing/persisting; the client-scope evaluation
+    /// preview uses it directly to show exactly what a real token would contain.
+    async fn assemble_token_claims(
         &self,
-        input: GenerateTokenInput,
-    ) -> Result<(Jwt, Jwt, Option<Jwt>), CoreError> {
-        let jwt_key_pair = self
-            .keystore_repository
-            .get_or_generate_key(input.realm_id)
-            .await
-            .map_err(|_| CoreError::InternalServerError)?;
-
+        input: &GenerateTokenInput,
+    ) -> Result<AssembledClaims, CoreError> {
         let iss = format!("{}/realms/{}", input.base_url, input.realm_name);
         let realm_audit = format!("{}-realm", input.realm_name);
 
@@ -641,32 +655,216 @@ where
             self.mapper_engine
                 .apply_mappers(&all_mappers, &context, TokenType::AccessToken)?;
 
-        let mut claims = JwtClaim::new(
+        let mut access_claims = JwtClaim::new(
             input.user_id,
-            input.username,
+            input.username.clone(),
             iss,
             vec![realm_audit, "account".to_string()],
             ClaimsTyp::Bearer,
-            input.client_id,
-            Some(input.email),
+            input.client_id.clone(),
+            Some(input.email.clone()),
             input.scope.clone(),
             input.access_token_lifetime,
         );
 
         // Apply mapper output to claims
         for aud in &access_mapper_output.additional_audiences {
-            if !claims.aud.contains(aud) {
-                claims.aud.push(aud.clone());
+            if !access_claims.aud.contains(aud) {
+                access_claims.aud.push(aud.clone());
             }
         }
-        claims.additional_claims = access_mapper_output.claims;
+        access_claims.additional_claims = access_mapper_output.claims;
 
         // `preferred_username` and `email` are now injected exclusively via protocol
         // mappers bound to the `profile` / `email` scopes.  Clearing the hard-coded
         // defaults here ensures they never leak into tokens whose scope set does not
         // include those scopes.
-        claims.preferred_username = None;
-        claims.email = None;
+        access_claims.preferred_username = None;
+        access_claims.email = None;
+
+        // ID-token mapper claims are only produced when the `openid` scope is present.
+        let id_mapper_claims = if input.scope.as_ref().is_some_and(|s| s.contains("openid")) {
+            let id_mapper_output =
+                self.mapper_engine
+                    .apply_mappers(&all_mappers, &context, TokenType::IdToken)?;
+            Some(id_mapper_output.claims)
+        } else {
+            None
+        };
+
+        Ok(AssembledClaims {
+            access_claims,
+            id_mapper_claims,
+            effective_scopes: applicable_scopes,
+            effective_mappers: all_mappers,
+        })
+    }
+
+    /// Build the ID-token claims from already-assembled access-token claims plus the ID-token
+    /// mapper output. `at_hash` is passed in because it depends on the *signed* access token
+    /// (so it is `None` for previews that never sign a token).
+    fn build_id_token_claims(
+        access_claims: &JwtClaim,
+        id_mapper_claims: HashMap<String, serde_json::Value>,
+        at_hash: Option<String>,
+        nonce: Option<String>,
+        id_token_lifetime: i64,
+    ) -> IdTokenClaims {
+        let iat = Utc::now().timestamp();
+        // Identity claims (preferred_username, email, email_verified) are injected into
+        // `additional_claims` by the protocol mappers attached to the `profile`/`email`
+        // scopes. The dedicated struct fields are intentionally left `None` to avoid
+        // duplicate keys in the serialised JWT payload.
+        IdTokenClaims {
+            iss: access_claims.iss.clone(),
+            aud: access_claims.azp.clone(),
+            azp: Some(access_claims.azp.clone()),
+            auth_time: None,
+            email: None,
+            email_verified: None,
+            exp: iat + id_token_lifetime,
+            iat,
+            jti: Uuid::new_v4(),
+            sid: None,
+            at_hash,
+            nonce,
+            preferred_username: None,
+            sub: access_claims.sub,
+            typ: ClaimsTyp::Id,
+            additional_claims: id_mapper_claims,
+        }
+    }
+
+    /// Compute the token claims a user would receive from this client for the given scopes,
+    /// **without signing or persisting anything**. Powers the "Evaluate" client-scopes preview.
+    /// Authorization and realm/client resolution are the caller's responsibility.
+    pub async fn evaluate_client_scopes(
+        &self,
+        input: EvaluateClientScopesInput,
+    ) -> Result<EvaluateClientScopesResult, CoreError> {
+        let user = self.user_repository.get_by_id(input.user_id).await?;
+        let lifetimes = self
+            .resolve_token_lifetimes(input.realm_id, input.client_uuid)
+            .await?;
+
+        let gen_input = GenerateTokenInput {
+            base_url: input.base_url,
+            realm_name: input.realm_name,
+            user_id: user.id,
+            username: user.username.clone(),
+            firstname: user.firstname.clone().unwrap_or_default(),
+            lastname: user.lastname.clone().unwrap_or_default(),
+            email_verified: user.email_verified,
+            client_id: input.client_id,
+            client_uuid: input.client_uuid,
+            email: user.email.clone().unwrap_or_default(),
+            realm_id: input.realm_id,
+            scope: input.scope,
+            access_token_lifetime: lifetimes.access_token,
+            refresh_token_lifetime: lifetimes.refresh_token,
+            id_token_lifetime: lifetimes.id_token,
+            nonce: None,
+            refresh_jti_override: None,
+        };
+
+        let assembled = self.assemble_token_claims(&gen_input).await?;
+
+        // Effective role scope mappings, resolved from the user's role assignments.
+        let user_roles = self
+            .user_role_repository
+            .get_user_roles(user.id)
+            .await
+            .unwrap_or_default();
+        let mut realm_roles = Vec::new();
+        let mut client_roles: HashMap<String, Vec<String>> = HashMap::new();
+        for role in &user_roles {
+            match &role.client {
+                Some(client) => client_roles
+                    .entry(client.client_id.clone())
+                    .or_default()
+                    .push(role.name.clone()),
+                None => realm_roles.push(role.name.clone()),
+            }
+        }
+
+        let access_token = serde_json::to_value(&assembled.access_claims)
+            .map_err(|_| CoreError::InternalServerError)?;
+
+        let sub = assembled.access_claims.sub.to_string();
+        let (id_token, userinfo) = match assembled.id_mapper_claims {
+            Some(id_mapper_claims) => {
+                // No signed access token in a preview → no `at_hash`.
+                let id_claims = Self::build_id_token_claims(
+                    &assembled.access_claims,
+                    id_mapper_claims.clone(),
+                    None,
+                    None,
+                    gen_input.id_token_lifetime,
+                );
+                let id_token =
+                    serde_json::to_value(&id_claims).map_err(|_| CoreError::InternalServerError)?;
+
+                // OIDC userinfo carries at least `sub` plus the ID-token mapper claims.
+                let mut userinfo: serde_json::Map<String, serde_json::Value> =
+                    id_mapper_claims.into_iter().collect();
+                userinfo.insert("sub".to_string(), serde_json::Value::String(sub));
+                (Some(id_token), serde_json::Value::Object(userinfo))
+            }
+            None => {
+                let mut userinfo = serde_json::Map::new();
+                userinfo.insert("sub".to_string(), serde_json::Value::String(sub));
+                (None, serde_json::Value::Object(userinfo))
+            }
+        };
+
+        let effective_scopes = assembled
+            .effective_scopes
+            .into_iter()
+            .map(|s| EvaluatedScope {
+                name: s.name,
+                protocol: s.protocol,
+                default_scope_type: format!("{:?}", s.default_scope_type),
+            })
+            .collect();
+
+        let effective_mappers = assembled
+            .effective_mappers
+            .into_iter()
+            .map(|m| EvaluatedMapper {
+                name: m.name,
+                mapper_type: m.mapper_type,
+                config: m.config,
+            })
+            .collect();
+
+        Ok(EvaluateClientScopesResult {
+            effective_scopes,
+            effective_mappers,
+            effective_roles: EvaluatedRoles {
+                realm_roles,
+                client_roles,
+            },
+            access_token,
+            id_token,
+            userinfo,
+        })
+    }
+
+    async fn create_jwt(
+        &self,
+        input: GenerateTokenInput,
+    ) -> Result<(Jwt, Jwt, Option<Jwt>), CoreError> {
+        let jwt_key_pair = self
+            .keystore_repository
+            .get_or_generate_key(input.realm_id)
+            .await
+            .map_err(|_| CoreError::InternalServerError)?;
+
+        let AssembledClaims {
+            access_claims: claims,
+            id_mapper_claims,
+            ..
+        } = self.assemble_token_claims(&input).await?;
 
         let jwt = Self::encode_token_with_key(&claims, claims.exp.unwrap_or(0), &jwt_key_pair)
             .map_err(|e| {
@@ -703,46 +901,20 @@ where
             &jwt_key_pair,
         )?;
 
-        let contains_openid_scope = input.scope.as_ref().is_some_and(|s| s.contains("openid"));
-        let iat = Utc::now().timestamp();
-        let id_token_exp = iat + input.id_token_lifetime;
-
-        let id_token: Option<Jwt> = if contains_openid_scope {
-            // Apply mappers for ID token
-            let id_mapper_output =
-                self.mapper_engine
-                    .apply_mappers(&all_mappers, &context, TokenType::IdToken)?;
-
-            let aud = claims.azp.clone();
-
+        let id_token: Option<Jwt> = if let Some(id_mapper_claims) = id_mapper_claims {
             // at_hash = base64url(left-half of SHA-256(access_token))
             let at_hash = {
                 let digest = Sha256::digest(jwt.token.as_bytes());
                 Some(BASE64_URL_SAFE_NO_PAD.encode(&digest[..digest.len() / 2]))
             };
 
-            // Identity claims (preferred_username, email, email_verified) are injected
-            // into `additional_claims` by the protocol mappers attached to the `profile`
-            // and `email` scopes.  The dedicated struct fields are intentionally left as
-            // `None` to avoid duplicate keys in the serialised JWT payload.
-            let id_claims = IdTokenClaims {
-                iss: claims.iss.clone(),
-                aud,
-                azp: Some(claims.azp.clone()),
-                auth_time: None,
-                email: None,
-                email_verified: None,
-                exp: id_token_exp,
-                iat,
-                jti: Uuid::new_v4(),
-                sid: None,
+            let id_claims = Self::build_id_token_claims(
+                &claims,
+                id_mapper_claims,
                 at_hash,
-                nonce: input.nonce.clone(),
-                preferred_username: None,
-                sub: claims.sub,
-                typ: ClaimsTyp::Id,
-                additional_claims: id_mapper_output.claims,
-            };
+                input.nonce.clone(),
+                input.id_token_lifetime,
+            );
             let t = Self::encode_token_with_key(&id_claims, id_claims.exp, &jwt_key_pair)?;
 
             Some(t)

--- a/core/src/domain/authentication/value_objects.rs
+++ b/core/src/domain/authentication/value_objects.rs
@@ -198,6 +198,64 @@ pub struct GetUserInfoInput {
     pub claims: JwtClaim,
 }
 
+/// Request received by the application layer for a client-scope evaluation. The application
+/// service authorizes it (view access to the client) and resolves the realm/client before
+/// delegating to the auth service.
+pub struct EvaluateClientScopesRequest {
+    pub realm_name: String,
+    pub client_id: Uuid,
+    /// Realm-scoped issuer base URL, already root-path scoped by the HTTP layer.
+    pub base_url: String,
+    pub user_id: Uuid,
+    pub scope: Option<String>,
+}
+
+/// Input to the client-scope evaluation ("Evaluate") preview. The realm/client are already
+/// resolved (and authorized) by the caller; this only carries what the claim assembly needs.
+pub struct EvaluateClientScopesInput {
+    pub base_url: String,
+    pub realm_id: RealmId,
+    pub realm_name: String,
+    pub client_uuid: Uuid,
+    /// The client's string `client_id` (e.g. `"backend"`), used as the token `azp`.
+    pub client_id: String,
+    pub user_id: Uuid,
+    /// Requested scope string (default scopes are always applied; optional scopes apply when named here).
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EvaluatedScope {
+    pub name: String,
+    pub protocol: String,
+    pub default_scope_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EvaluatedMapper {
+    pub name: String,
+    pub mapper_type: String,
+    pub config: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EvaluatedRoles {
+    pub realm_roles: Vec<String>,
+    pub client_roles: std::collections::HashMap<String, Vec<String>>,
+}
+
+/// Result of a client-scope evaluation: the effective scopes/mappers/roles plus the decoded
+/// (unsigned, non-persisted) token claims a real token would carry.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EvaluateClientScopesResult {
+    pub effective_scopes: Vec<EvaluatedScope>,
+    pub effective_mappers: Vec<EvaluatedMapper>,
+    pub effective_roles: EvaluatedRoles,
+    pub access_token: serde_json::Value,
+    pub id_token: Option<serde_json::Value>,
+    pub userinfo: serde_json::Value,
+}
+
 pub struct IntrospectTokenInput {
     pub realm_name: String,
     pub client_id: String,

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -136,7 +136,6 @@ export namespace Schemas {
     client_type: ClientType
     created_at: string
     direct_access_grants_enabled: boolean
-    oauth_device_code_grant_enabled: boolean
     enabled: boolean
     id: string
     id_token_lifetime?: (number | null) | undefined
@@ -144,11 +143,13 @@ export namespace Schemas {
     maintenance_reason?: (string | null) | undefined
     maintenance_session_strategy: MaintenanceSessionStrategy
     name: string
+    oauth_device_code_grant_enabled: boolean
     protocol: string
     public_client: boolean
     realm_id: RealmId
     redirect_uris?: (Array<RedirectUri> | null) | undefined
     refresh_token_lifetime?: (number | null) | undefined
+    require_pkce: boolean
     secret?: (string | null) | undefined
     service_account_enabled: boolean
     temporary_token_lifetime?: (number | null) | undefined
@@ -180,6 +181,7 @@ export namespace Schemas {
   }
   export type ClientScopesResponse = { data: Array<ClientScope> }
   export type ClientsResponse = { data: Array<Client> }
+  export type CodeChallengeMethod = 'S256' | 'PLAIN'
   export type FlowId = string
   export type FlowStatus = 'pending' | 'success' | 'failure' | 'expired'
   export type FlowStepId = string
@@ -236,9 +238,9 @@ export namespace Schemas {
     client_id?: string | undefined
     client_type: ClientType
     direct_access_grants_enabled?: boolean | undefined
-    oauth_device_code_grant_enabled?: boolean | undefined
     enabled?: boolean | undefined
     name?: string | undefined
+    oauth_device_code_grant_enabled?: boolean | undefined
     protocol?: string | undefined
     public_client?: boolean | undefined
     service_account_enabled?: boolean | undefined
@@ -513,6 +515,21 @@ export namespace Schemas {
   export type DeviceVerifyAction = 'approve' | 'deny'
   export type DeviceVerifyRequest = { action: DeviceVerifyAction; user_code: string }
   export type DeviceVerifyResponse = { status: string }
+  export type EvaluatedMapper = { config: unknown; mapper_type: string; name: string }
+  export type EvaluatedRoles = {
+    client_roles: Record<string, Array<string>>
+    realm_roles: Array<string>
+  }
+  export type EvaluatedScope = { default_scope_type: string; name: string; protocol: string }
+  export type EvaluateClientScopesResult = {
+    access_token: unknown
+    effective_mappers: Array<EvaluatedMapper>
+    effective_roles: EvaluatedRoles
+    effective_scopes: Array<EvaluatedScope>
+    id_token?: unknown | undefined
+    userinfo: unknown
+  }
+  export type EvaluateScopesValidator = { scope?: (string | null) | undefined; user_id: string }
   export type EventStatus = 'success' | 'failure'
   export type FlowStats = {
     avg_duration_ms?: (number | null) | undefined
@@ -539,10 +556,13 @@ export namespace Schemas {
     authorization_endpoint: string
     end_session_endpoint: string
     grant_types_supported: Array<string>
+    id_token_signing_alg_values_supported: Array<string>
     introspection_endpoint: string
     issuer: string
     jwks_uri: string
+    response_types_supported: Array<string>
     revocation_endpoint: string
+    subject_types_supported: Array<string>
     token_endpoint: string
     token_endpoint_auth_methods_supported: Array<string>
     userinfo_endpoint: string
@@ -606,6 +626,7 @@ export namespace Schemas {
     | 'client_credentials'
     | 'refresh_token'
     | 'urn:ietf:params:oauth:grant-type:device_code'
+    | 'urn:ietf:params:oauth:grant-type:token-exchange'
   export type IdentityProviderPresentation = {
     display_name: string
     icon: string
@@ -683,6 +704,17 @@ export namespace Schemas {
   }
   export type ListProvidersResponse = { data: Array<ProviderResponse> }
   export type ListThemesResponse = { data: Array<PortalTheme> }
+  export type UserSessionDto = {
+    created_at: string
+    expires_at: string
+    id: string
+    ip_address?: (string | null) | undefined
+    last_seen_at?: (string | null) | undefined
+    realm_id: string
+    user_agent?: (string | null) | undefined
+    user_id: string
+  }
+  export type ListUserSessionsResponse = { data: Array<UserSessionDto> }
   export type LogoutRequestValidator = Partial<{
     client_id: string | null
     id_token_hint: string | null
@@ -770,6 +802,13 @@ export namespace Schemas {
   export type PublicKeyCredential = Record<string, unknown>
   export type PublicKeyCredentialCreationOptionsJSON = Record<string, unknown>
   export type PublicKeyCredentialRequestOptionsJSON = Record<string, unknown>
+  export type PublicPasswordPolicy = {
+    min_length: number
+    require_lowercase: boolean
+    require_number: boolean
+    require_special: boolean
+    require_uppercase: boolean
+  }
   export type RealmLoginSetting = {
     display_name?: (string | null) | undefined
     email_verification_enabled: boolean
@@ -885,6 +924,7 @@ export namespace Schemas {
     client_id: string | null
     client_secret: string | null
     code: string | null
+    code_verifier: string | null
     device_code: string | null
     grant_type: GrantType
     password: string | null
@@ -904,11 +944,12 @@ export namespace Schemas {
     access_token_lifetime: number | null
     client_id: string | null
     direct_access_grants_enabled: boolean | null
-    oauth_device_code_grant_enabled: boolean | null
     enabled: boolean | null
     id_token_lifetime: number | null
     name: string | null
+    oauth_device_code_grant_enabled: boolean | null
     refresh_token_lifetime: number | null
+    require_pkce: boolean | null
     temporary_token_lifetime: number | null
   }>
   export type UpdateEmailTemplateResponse = { data: EmailTemplate }
@@ -1440,6 +1481,22 @@ export namespace Endpoints {
       path: { realm_name: string; client_id: string; scope_id: string }
     }
     responses: { 200: unknown }
+  }
+  export type post_Evaluate_client_scopes = {
+    method: 'POST'
+    path: '/realms/{realm_name}/clients/{client_id}/evaluate-scopes'
+    requestFormat: 'json'
+    parameters: {
+      path: { realm_name: string; client_id: string }
+
+      body: Schemas.EvaluateScopesValidator
+    }
+    responses: {
+      200: Schemas.EvaluateClientScopesResult
+      401: Schemas.ApiErrorResponse
+      403: Schemas.ApiErrorResponse
+      500: Schemas.ApiErrorResponse
+    }
   }
   export type put_Toggle_maintenance = {
     method: 'PUT'
@@ -2506,6 +2563,19 @@ export namespace Endpoints {
       500: Schemas.ApiErrorResponse
     }
   }
+  export type get_Get_public_password_policy = {
+    method: 'GET'
+    path: '/realms/{realm_name}/password-policy/public'
+    requestFormat: 'json'
+    parameters: {
+      path: { realm_name: string }
+    }
+    responses: {
+      200: Schemas.PublicPasswordPolicy
+      401: Schemas.ApiErrorResponse
+      500: Schemas.ApiErrorResponse
+    }
+  }
   export type get_List_layouts = {
     method: 'GET'
     path: '/realms/{realm_name}/portal-layouts'
@@ -2835,6 +2905,9 @@ export namespace Endpoints {
         redirect_uri: string
         scope: string
         state: string
+        nonce: string
+        code_challenge: string
+        code_challenge_method: 'S256' | 'PLAIN'
       }>
       path: { realm_name: string }
     }
@@ -3396,6 +3469,36 @@ export namespace Endpoints {
       500: Schemas.ApiErrorResponse
     }
   }
+  export type get_List_user_sessions = {
+    method: 'GET'
+    path: '/realms/{realm_name}/users/{user_id}/sessions'
+    requestFormat: 'json'
+    parameters: {
+      path: { realm_name: string; user_id: string }
+    }
+    responses: {
+      200: Schemas.ListUserSessionsResponse
+      401: Schemas.ApiErrorResponse
+      403: Schemas.ApiErrorResponse
+      404: Schemas.ApiErrorResponse
+      500: Schemas.ApiErrorResponse
+    }
+  }
+  export type delete_Revoke_user_session = {
+    method: 'DELETE'
+    path: '/realms/{realm_name}/users/{user_id}/sessions/{session_id}'
+    requestFormat: 'json'
+    parameters: {
+      path: { realm_name: string; user_id: string; session_id: string }
+    }
+    responses: {
+      204: unknown
+      401: Schemas.ApiErrorResponse
+      403: Schemas.ApiErrorResponse
+      404: Schemas.ApiErrorResponse
+      500: Schemas.ApiErrorResponse
+    }
+  }
   export type get_Fetch_webhooks = {
     method: 'GET'
     path: '/realms/{realm_name}/webhooks'
@@ -3512,6 +3615,7 @@ export type EndpointByMethod = {
     '/realms/{realm_name}/organizations/{organization_id}/attributes': Endpoints.get_List_attributes
     '/realms/{realm_name}/organizations/{organization_id}/members': Endpoints.get_List_members
     '/realms/{realm_name}/password-policy': Endpoints.get_Get_password_policy
+    '/realms/{realm_name}/password-policy/public': Endpoints.get_Get_public_password_policy
     '/realms/{realm_name}/portal-layouts': Endpoints.get_List_layouts
     '/realms/{realm_name}/portal-layouts/public/default': Endpoints.get_Get_public_default_layout
     '/realms/{realm_name}/portal-layouts/public/{layout_id}': Endpoints.get_Get_public_layout
@@ -3538,6 +3642,7 @@ export type EndpointByMethod = {
     '/realms/{realm_name}/users/{user_id}/organizations': Endpoints.get_List_user_organizations
     '/realms/{realm_name}/users/{user_id}/permissions': Endpoints.get_Get_user_permissions
     '/realms/{realm_name}/users/{user_id}/roles': Endpoints.get_Get_user_roles
+    '/realms/{realm_name}/users/{user_id}/sessions': Endpoints.get_List_user_sessions
     '/realms/{realm_name}/webhooks': Endpoints.get_Fetch_webhooks
     '/realms/{realm_name}/webhooks/{webhook_id}': Endpoints.get_Get_webhook
   }
@@ -3548,6 +3653,7 @@ export type EndpointByMethod = {
     '/realms/{realm_name}/client-scopes/{scope_id}/protocol-mappers': Endpoints.post_Create_protocol_mapper
     '/realms/{realm_name}/clients': Endpoints.post_Create_client
     '/realms/{realm_name}/clients/settings/maintenance/whitelist': Endpoints.post_Add_realm_whitelist_entry
+    '/realms/{realm_name}/clients/{client_id}/evaluate-scopes': Endpoints.post_Evaluate_client_scopes
     '/realms/{realm_name}/clients/{client_id}/maintenance/whitelist': Endpoints.post_Add_client_whitelist_entry
     '/realms/{realm_name}/clients/{client_id}/post-logout-redirects': Endpoints.post_Create_post_logout_redirect_uri
     '/realms/{realm_name}/clients/{client_id}/redirects': Endpoints.post_Create_redirect_uri
@@ -3644,6 +3750,7 @@ export type EndpointByMethod = {
     '/realms/{realm_name}/users/{user_id}/attributes/{key}': Endpoints.delete_Delete_user_attribute
     '/realms/{realm_name}/users/{user_id}/credentials/{credential_id}': Endpoints.delete_Delete_user_credential
     '/realms/{realm_name}/users/{user_id}/roles/{role_id}': Endpoints.delete_Unassign_role
+    '/realms/{realm_name}/users/{user_id}/sessions/{session_id}': Endpoints.delete_Revoke_user_session
     '/realms/{realm_name}/webhooks/{webhook_id}': Endpoints.delete_Delete_webhook
   }
   patch: {

--- a/front/src/api/client.api.ts
+++ b/front/src/api/client.api.ts
@@ -94,6 +94,31 @@ export const useGetClientRoles = ({ realm, clientId }: BaseQuery & { clientId?: 
   })
 }
 
+export interface EvaluateClientScopesParams {
+  realm: string
+  clientId: string
+  userId: string
+  scope?: string
+}
+
+export const useEvaluateClientScopes = () => {
+  return useMutation({
+    mutationFn: async ({ realm, clientId, userId, scope }: EvaluateClientScopesParams) =>
+      window.tanstackApi
+        .mutation('post', '/realms/{realm_name}/clients/{client_id}/evaluate-scopes')
+        .mutationOptions.mutationFn({
+          path: {
+            realm_name: realm,
+            client_id: clientId,
+          },
+          body: {
+            user_id: userId,
+            scope,
+          },
+        }),
+  })
+}
+
 export const useGetClientScopes = ({ realm, clientId }: BaseQuery & { clientId?: string }) => {
   return useQuery({
     ...window.tanstackApi.get('/realms/{realm_name}/clients/{client_id}/client-scopes', {

--- a/front/src/pages/client/ui/components/client-scopes-evaluate.tsx
+++ b/front/src/pages/client/ui/components/client-scopes-evaluate.tsx
@@ -1,0 +1,210 @@
+import { useMemo, useState } from 'react'
+import { Schemas } from '@/api/api.client'
+import { useEvaluateClientScopes } from '@/api/client.api'
+import { useGetUsers } from '@/api/user.api'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { ChevronDown } from 'lucide-react'
+
+export interface ClientScopesEvaluateProps {
+  realm?: string
+  clientId?: string
+  assignedScopes: Schemas.ClientScope[]
+}
+
+function JsonPanel({ title, value }: { title: string; value: unknown }) {
+  if (value === undefined || value === null) return null
+  return (
+    <Collapsible defaultOpen className='border rounded-md'>
+      <CollapsibleTrigger className='flex w-full items-center justify-between px-4 py-3 text-sm font-medium'>
+        {title}
+        <ChevronDown className='h-4 w-4 text-muted-foreground' />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <pre className='overflow-x-auto border-t bg-muted/40 px-4 py-3 text-xs'>
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+export default function ClientScopesEvaluate({
+  realm,
+  clientId,
+  assignedScopes,
+}: ClientScopesEvaluateProps) {
+  const { data: usersData } = useGetUsers({ realm })
+  const users = usersData?.data ?? []
+
+  const optionalScopes = useMemo(
+    () => assignedScopes.filter((s) => s.default_scope_type === 'OPTIONAL'),
+    [assignedScopes]
+  )
+  const defaultScopeNames = useMemo(
+    () =>
+      assignedScopes
+        .filter((s) => s.default_scope_type === 'DEFAULT')
+        .map((s) => s.name),
+    [assignedScopes]
+  )
+
+  const [userId, setUserId] = useState<string>('')
+  const [selectedOptional, setSelectedOptional] = useState<string[]>([])
+
+  const evaluate = useEvaluateClientScopes()
+
+  const toggleOptional = (name: string) => {
+    setSelectedOptional((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]
+    )
+  }
+
+  const handleEvaluate = () => {
+    if (!realm || !clientId || !userId) return
+    // Default scopes always apply on the backend; include them in the requested scope string
+    // so the `scope` claim is realistic, plus the optional scopes the admin selected.
+    const scope = [...new Set([...defaultScopeNames, ...selectedOptional])].join(' ')
+    evaluate.mutate({ realm, clientId, userId, scope: scope || undefined })
+  }
+
+  const result = evaluate.data
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='flex flex-col gap-4 rounded-md border p-4'>
+        <div className='flex flex-col gap-2'>
+          <label className='text-sm font-medium'>User</label>
+          <Select value={userId} onValueChange={setUserId}>
+            <SelectTrigger className='max-w-md'>
+              <SelectValue placeholder='Select a user to evaluate' />
+            </SelectTrigger>
+            <SelectContent>
+              {users.map((user) => (
+                <SelectItem key={user.id} value={user.id}>
+                  {user.username}
+                  {user.email ? ` (${user.email})` : ''}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {optionalScopes.length > 0 && (
+          <div className='flex flex-col gap-2'>
+            <label className='text-sm font-medium'>Optional scopes</label>
+            <div className='flex flex-wrap gap-2'>
+              {optionalScopes.map((scope) => {
+                const active = selectedOptional.includes(scope.name)
+                return (
+                  <button
+                    key={scope.id}
+                    type='button'
+                    onClick={() => toggleOptional(scope.name)}
+                  >
+                    <Badge variant={active ? 'default' : 'secondary'}>{scope.name}</Badge>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <Button onClick={handleEvaluate} disabled={!userId || evaluate.isPending}>
+            {evaluate.isPending ? 'Evaluating…' : 'Evaluate'}
+          </Button>
+        </div>
+      </div>
+
+      {result && (
+        <div className='flex flex-col gap-6'>
+          {/* Effective protocol mappers */}
+          <div className='flex flex-col gap-2'>
+            <h4 className='text-sm font-semibold'>
+              Effective protocol mappers ({result.effective_mappers.length})
+            </h4>
+            <div className='overflow-hidden rounded-md border'>
+              <table className='w-full text-sm'>
+                <thead className='bg-muted/40 text-left'>
+                  <tr>
+                    <th className='px-4 py-2 font-medium'>Name</th>
+                    <th className='px-4 py-2 font-medium'>Type</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.effective_mappers.map((mapper, i) => (
+                    <tr key={`${mapper.name}-${i}`} className='border-t'>
+                      <td className='px-4 py-2'>{mapper.name}</td>
+                      <td className='px-4 py-2 text-muted-foreground'>{mapper.mapper_type}</td>
+                    </tr>
+                  ))}
+                  {result.effective_mappers.length === 0 && (
+                    <tr>
+                      <td className='px-4 py-3 text-muted-foreground' colSpan={2}>
+                        No protocol mappers apply for this scope set.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Effective roles */}
+          <div className='flex flex-col gap-2'>
+            <h4 className='text-sm font-semibold'>Effective roles</h4>
+            <div className='flex flex-col gap-3 rounded-md border p-4'>
+              <div className='flex flex-col gap-1'>
+                <span className='text-xs text-muted-foreground'>Realm roles</span>
+                <div className='flex flex-wrap gap-2'>
+                  {result.effective_roles.realm_roles.length > 0 ? (
+                    result.effective_roles.realm_roles.map((role) => (
+                      <Badge key={role} variant='secondary'>
+                        {role}
+                      </Badge>
+                    ))
+                  ) : (
+                    <span className='text-sm text-muted-foreground'>None</span>
+                  )}
+                </div>
+              </div>
+              {Object.entries(result.effective_roles.client_roles).map(([client, roles]) => (
+                <div key={client} className='flex flex-col gap-1'>
+                  <span className='text-xs text-muted-foreground'>{client}</span>
+                  <div className='flex flex-wrap gap-2'>
+                    {roles.map((role) => (
+                      <Badge key={`${client}-${role}`} variant='secondary'>
+                        {role}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Generated tokens */}
+          <div className='flex flex-col gap-3'>
+            <h4 className='text-sm font-semibold'>Generated token claims</h4>
+            <JsonPanel title='Access token' value={result.access_token} />
+            <JsonPanel title='ID token' value={result.id_token} />
+            <JsonPanel title='Userinfo' value={result.userinfo} />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/front/src/pages/client/ui/page-client-scopes.tsx
+++ b/front/src/pages/client/ui/page-client-scopes.tsx
@@ -6,8 +6,10 @@ import { useState } from 'react'
 import AddScopeModal from './components/add-scope-modal'
 import AssignedScopesTable from './components/assigned-scopes-table'
 import EffectiveScopesPreview from './components/effective-scopes-preview'
+import ClientScopesEvaluate from './components/client-scopes-evaluate'
 import { OverviewList } from '@/components/ui/overview-list'
 import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Link } from 'react-router-dom'
 import {
   CLIENT_SCOPE_DETAILS_URL,
@@ -35,7 +37,13 @@ export default function PageClientScopes() {
   }
 
   return (
-    <div className='flex flex-col gap-6'>
+    <Tabs defaultValue='assigned' className='flex flex-col gap-6'>
+      <TabsList>
+        <TabsTrigger value='assigned'>Assigned scopes</TabsTrigger>
+        <TabsTrigger value='evaluate'>Evaluate</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value='assigned' className='flex flex-col gap-6'>
       {/* Assigned Scopes Section - Using OverviewList pattern */}
       <OverviewList
         data={assignedScopes}
@@ -101,6 +109,15 @@ export default function PageClientScopes() {
         onClose={() => setIsAddModalOpen(false)}
         assignedScopeIds={assignedScopes.map((scope) => scope.id)}
       />
-    </div>
+      </TabsContent>
+
+      <TabsContent value='evaluate'>
+        <ClientScopesEvaluate
+          realm={realm_name}
+          clientId={client_id}
+          assignedScopes={assignedScopes}
+        />
+      </TabsContent>
+    </Tabs>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Evaluate” tab on client scope pages to preview how scopes resolve for a selected user.
  * Introduced a client scope evaluation action that returns effective roles, protocol mappers, and token/claim previews.
  * Expanded API support for newer OAuth/OpenID fields and additional client/session/password-policy endpoints.

* **Bug Fixes**
  * Improved scope and token claim handling so preview results align more closely with actual token output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->