### PR TITLE
fix(core): include directly-assigned realm roles in issued tokens

### DIFF
--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -648,19 +648,20 @@ where
             .await
             .unwrap_or_default();
 
+        let mut realm_roles: Vec<String> = Vec::new();
         let mut client_roles: HashMap<String, Vec<String>> = HashMap::new();
         for role in &user_roles {
-            if let Some(client) = &role.client {
-                client_roles
+            match &role.client {
+                Some(client) => client_roles
                     .entry(client.client_id.clone())
                     .or_default()
-                    .push(role.name.clone());
+                    .push(role.name.clone()),
+                None => realm_roles.push(role.name.clone()),
             }
         }
 
         // Roles inherited from the user's effective (recursive) group memberships, merged into
         // the role maps so they flow into tokens exactly like directly-assigned roles.
-        let mut realm_roles: Vec<String> = Vec::new();
         let group_role_ids = self
             .group_token_repository
             .list_effective_role_ids_for_user(input.user_id)


### PR DESCRIPTION
## Summary

Realm roles assigned directly to a user never appeared in issued tokens: with
the default `roles` client scope and an `oidc-usermodel-realm-role-mapper`
configured, `realm_access.roles` was always `[]` (#1132).

The cause is in `assemble_token_claims`
(`core/src/domain/authentication/services.rs`). The loop over the user's
directly-assigned `user_roles` only handled the `Some(client)` case, pushing
into `client_roles`. Roles with `client == None` (realm roles) had no branch,
so they were silently dropped. `realm_roles` was then populated only from
group-inherited roles, so a realm role like `staff` assigned directly to the
user never reached `MapperContext.realm_roles`, and the realm-role mapper
emitted an empty list.

The fix moves the `realm_roles` declaration above the loop and adds the
`None => realm_roles.push(...)` arm, mirroring the exact `match` already used a
few lines below for group-inherited roles. Directly-assigned and
group-inherited realm roles now both flow into `MapperContext.realm_roles`. The
now-duplicate declaration was removed. Net change is 5 lines; client-role
grouping and group-inherited realm roles are unaffected.

## Why this matters

Realm roles are a core authorization primitive. When they silently vanish from
tokens, downstream services that gate access on `realm_access.roles` see every
directly-assigned user as having no realm roles, which breaks authorization for
a common, correctly-configured setup and is hard to diagnose because nothing
errors.

`cargo check -p ferriskey-core` passes.

Closes #1132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token role processing to consistently distinguish realm-level roles from client-specific roles.
  * Preserved role information used when generating authentication token claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->