### PR TITLE
refactor: move RealmRepository and RealmPolicy into ferriskey-domain

### DIFF
--- a/core/src/domain/realm/ports.rs
+++ b/core/src/domain/realm/ports.rs
@@ -89,97 +89,12 @@ pub trait MailService: Send + Sync {
     ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }
 
-pub trait RealmPolicy: Send + Sync {
-    fn can_create_realm(
-        &self,
-        identity: &Identity,
-        target_realm: &Realm,
-    ) -> impl Future<Output = Result<bool, CoreError>> + Send;
-    fn can_delete_realm(
-        &self,
-        identity: &Identity,
-        target_realm: &Realm,
-    ) -> impl Future<Output = Result<bool, CoreError>> + Send;
-    fn can_view_realm(
-        &self,
-        identity: &Identity,
-        target_realm: &Realm,
-    ) -> impl Future<Output = Result<bool, CoreError>> + Send;
-    fn can_update_realm(
-        &self,
-        identity: &Identity,
-        target_realm: &Realm,
-    ) -> impl Future<Output = Result<bool, CoreError>> + Send;
-}
-
-#[cfg_attr(test, mockall::automock)]
-pub trait RealmRepository: Send + Sync {
-    fn fetch_realm(&self) -> impl Future<Output = Result<Vec<Realm>, CoreError>> + Send;
-
-    fn get_by_name(
-        &self,
-        name: &str,
-    ) -> impl Future<Output = Result<Option<Realm>, CoreError>> + Send;
-
-    fn get_by_id(
-        &self,
-        realm_id: RealmId,
-    ) -> impl Future<Output = Result<Option<Realm>, CoreError>> + Send;
-
-    fn create_realm(
-        &self,
-        name: String,
-        display_name: Option<String>,
-    ) -> impl Future<Output = Result<Realm, CoreError>> + Send;
-
-    fn update_realm(
-        &self,
-        realm_name: String,
-        name: String,
-        display_name: Option<String>,
-    ) -> impl Future<Output = Result<Realm, CoreError>> + Send;
-    fn delete_by_name(&self, name: &str) -> impl Future<Output = Result<(), CoreError>> + Send;
-
-    fn create_realm_settings(
-        &self,
-        realm_id: RealmId,
-        algorithm: String,
-    ) -> impl Future<Output = Result<RealmSetting, CoreError>> + Send;
-
-    #[allow(clippy::too_many_arguments)]
-    fn update_realm_setting(
-        &self,
-        realm_id: RealmId,
-        algorithm: Option<String>,
-        user_registration_enabled: Option<bool>,
-        forgot_password_enabled: Option<bool>,
-        remember_me_enabled: Option<bool>,
-        magic_link_enabled: Option<bool>,
-        magic_link_ttl: Option<u32>,
-        passkey_enabled: Option<bool>,
-        compass_enabled: Option<bool>,
-        access_token_lifetime: Option<i64>,
-        refresh_token_lifetime: Option<i64>,
-        id_token_lifetime: Option<i64>,
-        temporary_token_lifetime: Option<i64>,
-        reset_password_template_id: Option<Option<Uuid>>,
-        magic_link_template_id: Option<Option<Uuid>>,
-        email_verification_template_id: Option<Option<Uuid>>,
-        email_verification_enabled: Option<bool>,
-        email_verification_ttl_hours: Option<i64>,
-        lockout_threshold: Option<i32>,
-        lockout_duration_seconds: Option<i32>,
-        login_aliases: Option<LoginAliases>,
-        seawatch_pii_mode: Option<String>,
-        seawatch_pseudo_key: Option<Option<String>>,
-        require_mfa: Option<bool>,
-    ) -> impl Future<Output = Result<RealmSetting, CoreError>> + Send;
-
-    fn get_realm_settings(
-        &self,
-        realm_id: RealmId,
-    ) -> impl Future<Output = Result<Option<RealmSetting>, CoreError>> + Send;
-}
+// `RealmRepository` and `RealmPolicy` now live in the shared `ferriskey-domain` crate.
+// Re-exported so existing `crate::domain::realm::ports::{RealmRepository, RealmPolicy}` sites
+// (and `MockRealmRepository`, via the `mock` feature core enables) keep resolving.
+// `RealmService` / `MailService` / `SmtpConfigRepository` stay here — they touch
+// `RealmLoginSetting` / `SmtpConfig`, which are still `core`-only types.
+pub use ferriskey_domain::realm::ports::*;
 
 #[derive(Debug)] // TODO derive debug for instrumetnation
 pub struct GetRealmInput {

--- a/libs/ferriskey-domain/src/realm/mod.rs
+++ b/libs/ferriskey-domain/src/realm/mod.rs
@@ -1,3 +1,5 @@
+pub mod ports;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;

--- a/libs/ferriskey-domain/src/realm/ports.rs
+++ b/libs/ferriskey-domain/src/realm/ports.rs
@@ -1,0 +1,97 @@
+use uuid::Uuid;
+
+use crate::auth::Identity;
+use crate::common::app_errors::CoreError;
+use crate::realm::{LoginAliases, Realm, RealmId, RealmSetting};
+
+pub trait RealmPolicy: Send + Sync {
+    fn can_create_realm(
+        &self,
+        identity: &Identity,
+        target_realm: &Realm,
+    ) -> impl Future<Output = Result<bool, CoreError>> + Send;
+    fn can_delete_realm(
+        &self,
+        identity: &Identity,
+        target_realm: &Realm,
+    ) -> impl Future<Output = Result<bool, CoreError>> + Send;
+    fn can_view_realm(
+        &self,
+        identity: &Identity,
+        target_realm: &Realm,
+    ) -> impl Future<Output = Result<bool, CoreError>> + Send;
+    fn can_update_realm(
+        &self,
+        identity: &Identity,
+        target_realm: &Realm,
+    ) -> impl Future<Output = Result<bool, CoreError>> + Send;
+}
+
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
+pub trait RealmRepository: Send + Sync {
+    fn fetch_realm(&self) -> impl Future<Output = Result<Vec<Realm>, CoreError>> + Send;
+
+    fn get_by_name(
+        &self,
+        name: &str,
+    ) -> impl Future<Output = Result<Option<Realm>, CoreError>> + Send;
+
+    fn get_by_id(
+        &self,
+        realm_id: RealmId,
+    ) -> impl Future<Output = Result<Option<Realm>, CoreError>> + Send;
+
+    fn create_realm(
+        &self,
+        name: String,
+        display_name: Option<String>,
+    ) -> impl Future<Output = Result<Realm, CoreError>> + Send;
+
+    fn update_realm(
+        &self,
+        realm_name: String,
+        name: String,
+        display_name: Option<String>,
+    ) -> impl Future<Output = Result<Realm, CoreError>> + Send;
+    fn delete_by_name(&self, name: &str) -> impl Future<Output = Result<(), CoreError>> + Send;
+
+    fn create_realm_settings(
+        &self,
+        realm_id: RealmId,
+        algorithm: String,
+    ) -> impl Future<Output = Result<RealmSetting, CoreError>> + Send;
+
+    #[allow(clippy::too_many_arguments)]
+    fn update_realm_setting(
+        &self,
+        realm_id: RealmId,
+        algorithm: Option<String>,
+        user_registration_enabled: Option<bool>,
+        forgot_password_enabled: Option<bool>,
+        remember_me_enabled: Option<bool>,
+        magic_link_enabled: Option<bool>,
+        magic_link_ttl: Option<u32>,
+        passkey_enabled: Option<bool>,
+        compass_enabled: Option<bool>,
+        access_token_lifetime: Option<i64>,
+        refresh_token_lifetime: Option<i64>,
+        id_token_lifetime: Option<i64>,
+        temporary_token_lifetime: Option<i64>,
+        reset_password_template_id: Option<Option<Uuid>>,
+        magic_link_template_id: Option<Option<Uuid>>,
+        email_verification_template_id: Option<Option<Uuid>>,
+        email_verification_enabled: Option<bool>,
+        email_verification_ttl_hours: Option<i64>,
+        lockout_threshold: Option<i32>,
+        lockout_duration_seconds: Option<i32>,
+        login_aliases: Option<LoginAliases>,
+        seawatch_pii_mode: Option<String>,
+        seawatch_pseudo_key: Option<Option<String>>,
+        require_mfa: Option<bool>,
+    ) -> impl Future<Output = Result<RealmSetting, CoreError>> + Send;
+
+    fn get_realm_settings(
+        &self,
+        realm_id: RealmId,
+    ) -> impl Future<Output = Result<Option<RealmSetting>, CoreError>> + Send;
+}


### PR DESCRIPTION
## What

Moves the two **clean realm ports** — `RealmRepository` and `RealmPolicy` — out of `core` into the shared `ferriskey-domain` crate. Part of epic #1159; finishes the realm half of #1152 that PR #1161 deferred.

- `RealmRepository` keeps `#[cfg_attr(any(test, feature = "mock"), mockall::automock)]`; `core` already enables `ferriskey-domain`'s `mock` feature, so `MockRealmRepository` (used in 9 core service tests) stays available.
- `RealmPolicy` moves too; `impl RealmPolicy for FerriskeyPolicy` stays in `core` (allowed — `FerriskeyPolicy` is a local type there).
- `core/src/domain/realm/ports.rs` re-exports both via `pub use ferriskey_domain::realm::ports::*;`, so all call sites keep compiling unchanged.

## What stays in core (unchanged)

`RealmService`, `MailService`, `SmtpConfigRepository` and all the realm/SMTP input structs remain in `core`: they reference `RealmLoginSetting` (→ `PortalThemeConfig`, owned by `portal_theme`) and `SmtpConfig` / `SmtpEncryption`, which are still `core`-only. Those follow once `portal_theme` / smtp are extracted (later in the epic).

## Why now

Besides finishing #1152's realm ports, this **unblocks #1155**: the `organization` (and `abyss`/`aegis`/`compass`) services are generic over `R: RealmRepository`, so their services can't move into their `libs/` crates until `RealmRepository` lives in `ferriskey-domain`.

## Verification

- `cargo check --workspace` ✅ (zero warnings)
- `cargo clippy` on `ferriskey-domain` + `ferriskey-core` ✅ (clean; CI is `-D warnings`)
- `cargo test -p ferriskey-core --lib` → 353 passed. `MockRealmRepository` resolves via the automock `mock` feature. The 5 failures (`email_verification::services::*`, `portal_theme::validation::login_missing_password_input_fails`) **pre-exist on `main`**, unrelated.
- `cargo fmt --check` ✅

## Linking

**Part of #1152** (completes `RealmRepository` + `RealmPolicy`; the `SmtpConfig`/`RealmLoginSetting`-coupled service ports remain). No closing keyword.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated realm access and permission interfaces into a shared domain layer.
  * Existing realm management and settings operations continue to work without user-facing changes.
  * Improved consistency and reuse across realm-related functionality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->