### PR TITLE
chore(docker): halve the api and operator image sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,12 @@ resolver = "2"
 version = "0.7.0"
 authors = ["nathaelb <pro.nathaelbonnal@gmail.com>", "Baptiste Parmantier <baptiste.parmantier.pro@gmail.com>"]
 edition = "2024"
+
+[profile.release]
+# Debug symbols account for ~13 MB of the 59 MB ferriskey-api binary and are
+# useless in the container images.
+strip = "symbols"
+# Thin LTO + a single codegen unit let the linker drop cross-crate dead code.
+# Slower to build, noticeably smaller (and faster) binaries.
+lto = "thin"
+codegen-units = 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,30 +17,20 @@ COPY --from=planner /usr/local/src/ferriskey/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
-RUN cargo build --release
+# Only these two binaries are shipped; skip the rest of the workspace.
+RUN cargo build --release --bin ferriskey-api --bin ferriskey-operator
 
 # ── Shared runtime base ───────────────────────────────────────────────────────
-FROM debian:bookworm-slim AS runtime
+# distroless/cc ships glibc, libgcc_s, libssl3/libcrypto3 and ca-certificates —
+# exactly the dynamic dependencies of our binaries — in ~34 MB, where
+# debian:bookworm-slim plus the equivalent apt packages costs ~106 MB.
+# It has no shell and no package manager: every entrypoint used against these
+# images (`ferriskey-api`, `ferriskey-operator`, `sqlx migrate run`) is an exec
+# of a binary on PATH, so nothing depends on /bin/sh.
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 
-RUN \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates=20230311+deb12u1 \
-    libssl3=3.0.17-1~deb12u2 && \
-    rm -rf /var/lib/apt/lists/* && \
-    addgroup \
-    --system \
-    --gid 1000 \
-    ferriskey && \
-    adduser \
-    --system \
-    --no-create-home \
-    --disabled-login \
-    --uid 1000 \
-    --gid 1000 \
-    ferriskey
-
-USER ferriskey
+# distroless defaults WORKDIR to /home/nonroot; keep / as before.
+WORKDIR /
 
 # ── API image ─────────────────────────────────────────────────────────────────
 FROM runtime AS api


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Release builds now use optimized linking and symbol stripping for smaller, more efficient binaries.

* **Deployment**
  * Container builds now produce only the required API and operator binaries.
  * Runtime images use a lightweight, non-root environment to reduce image size and improve security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->