### PR TITLE
refactor: move email_template domain into ferriskey-mail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,8 +1654,16 @@ dependencies = [
 name = "ferriskey-mail"
 version = "0.7.0"
 dependencies = [
+ "chrono",
+ "ferriskey-domain",
  "lettre",
+ "mockall 0.14.0",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "utoipa",
+ "uuid",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ ferriskey-domain = { path = "../libs/ferriskey-domain", features = ["mock"] }
 ferriskey-security = { path = "../libs/ferriskey-security", features = ["mock"] }
 ferriskey-trident = { path = "../libs/ferriskey-trident" }
 ferriskey-aegis = { path = "../libs/ferriskey-aegis" }
-ferriskey-mail = { path = "../libs/ferriskey-mail" }
+ferriskey-mail = { path = "../libs/ferriskey-mail", features = ["mock"] }
 ferriskey-compass = { path = "../libs/ferriskey-compass" }
 ferriskey-seawatch = { path = "../libs/ferriskey-seawatch", features = ["mock"] }
 ferriskey-password-policy = { path = "../libs/ferriskey-password-policy", features = ["mock"] }

--- a/core/src/domain/email_template/mod.rs
+++ b/core/src/domain/email_template/mod.rs
@@ -1,4 +1,6 @@
-pub mod entities;
-pub mod policies;
-pub mod ports;
-pub mod services;
+//! The email-template domain now lives in the `ferriskey-mail` lib crate (folded in as the
+//! `email_template` module) — entities, ports, the `EmailTemplatePolicy` impl and the generic
+//! `EmailTemplateServiceImpl` (pure business logic, no SeaORM). The SeaORM-backed repository stays
+//! in `core` under `infrastructure/`. Re-exported here so existing `crate::domain::email_template::*`
+//! call sites keep compiling.
+pub use ferriskey_mail::email_template::*;

--- a/libs/ferriskey-mail/Cargo.toml
+++ b/libs/ferriskey-mail/Cargo.toml
@@ -5,5 +5,20 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+ferriskey-domain = { path = "../ferriskey-domain" }
 lettre = { version = "0.11.19", features = ["tokio1-native-tls"] }
 thiserror = "2.0.18"
+chrono = { version = "0.4.41", features = ["serde"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.141"
+utoipa = { version = "5.4.0", features = ["chrono", "uuid"] }
+uuid = { version = "1.16.0", features = ["serde", "v4", "v7"] }
+mockall = { version = "0.14.0", optional = true }
+
+[dev-dependencies]
+mockall = "0.14.0"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+ferriskey-domain = { path = "../ferriskey-domain", features = ["mock"] }
+
+[features]
+mock = ["mockall"]

--- a/libs/ferriskey-mail/src/email_template/entities.rs
+++ b/libs/ferriskey-mail/src/email_template/entities.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::domain::common::entities::app_errors::CoreError;
+use ferriskey_domain::common::app_errors::CoreError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]

--- a/libs/ferriskey-mail/src/email_template/mod.rs
+++ b/libs/ferriskey-mail/src/email_template/mod.rs
@@ -1,0 +1,4 @@
+pub mod entities;
+pub mod policies;
+pub mod ports;
+pub mod services;

--- a/libs/ferriskey-mail/src/email_template/policies.rs
+++ b/libs/ferriskey-mail/src/email_template/policies.rs
@@ -1,15 +1,11 @@
-use crate::domain::{
-    authentication::value_objects::Identity,
-    client::ports::ClientRepository,
-    common::{
-        entities::app_errors::CoreError,
-        policies::{FerriskeyPolicy, Policy},
-    },
-    email_template::ports::EmailTemplatePolicy,
-    realm::entities::Realm,
-    role::entities::permission::Permissions,
-    user::ports::{UserRepository, UserRoleRepository},
-};
+use crate::email_template::ports::EmailTemplatePolicy;
+use ferriskey_domain::auth::Identity;
+use ferriskey_domain::client::ports::ClientRepository;
+use ferriskey_domain::common::app_errors::CoreError;
+use ferriskey_domain::common::policies::{FerriskeyPolicy, Policy};
+use ferriskey_domain::realm::Realm;
+use ferriskey_domain::role::permission::Permissions;
+use ferriskey_domain::user::ports::{UserRepository, UserRoleRepository};
 
 impl<U, C, UR> EmailTemplatePolicy for FerriskeyPolicy<U, C, UR>
 where

--- a/libs/ferriskey-mail/src/email_template/ports.rs
+++ b/libs/ferriskey-mail/src/email_template/ports.rs
@@ -2,12 +2,10 @@ use std::future::Future;
 
 use uuid::Uuid;
 
-use crate::domain::{
-    authentication::value_objects::Identity,
-    common::entities::app_errors::CoreError,
-    email_template::entities::{EmailTemplate, EmailType},
-    realm::entities::Realm,
-};
+use crate::email_template::entities::{EmailTemplate, EmailType};
+use ferriskey_domain::auth::Identity;
+use ferriskey_domain::common::app_errors::CoreError;
+use ferriskey_domain::realm::Realm;
 
 pub trait EmailTemplateService: Send + Sync {
     fn get_templates_by_realm(
@@ -46,7 +44,7 @@ pub trait EmailTemplateService: Send + Sync {
     ) -> impl Future<Output = Result<String, CoreError>> + Send;
 }
 
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait EmailTemplateRepository: Send + Sync {
     fn fetch_by_realm(
         &self,

--- a/libs/ferriskey-mail/src/email_template/services.rs
+++ b/libs/ferriskey-mail/src/email_template/services.rs
@@ -2,24 +2,18 @@ use std::sync::Arc;
 
 use uuid::Uuid;
 
-use crate::domain::{
-    authentication::value_objects::Identity,
-    client::ports::ClientRepository,
-    common::{
-        entities::app_errors::CoreError,
-        policies::{FerriskeyPolicy, ensure_policy},
-    },
-    email_template::{
-        entities::EmailTemplate,
-        ports::{
-            CreateEmailTemplateInput, DeleteEmailTemplateInput, EmailTemplatePolicy,
-            EmailTemplateRepository, EmailTemplateService, GetEmailTemplateInput,
-            GetEmailTemplatesInput, TemplateRenderer, UpdateEmailTemplateInput,
-        },
-    },
-    realm::ports::RealmRepository,
-    user::ports::{UserRepository, UserRoleRepository},
+use crate::email_template::entities::EmailTemplate;
+use crate::email_template::ports::{
+    CreateEmailTemplateInput, DeleteEmailTemplateInput, EmailTemplatePolicy,
+    EmailTemplateRepository, EmailTemplateService, GetEmailTemplateInput, GetEmailTemplatesInput,
+    TemplateRenderer, UpdateEmailTemplateInput,
 };
+use ferriskey_domain::auth::Identity;
+use ferriskey_domain::client::ports::ClientRepository;
+use ferriskey_domain::common::app_errors::CoreError;
+use ferriskey_domain::common::policies::{FerriskeyPolicy, ensure_policy};
+use ferriskey_domain::realm::ports::RealmRepository;
+use ferriskey_domain::user::ports::{UserRepository, UserRoleRepository};
 
 #[derive(Clone, Debug)]
 pub struct EmailTemplateServiceImpl<R, U, C, UR, ET, TR>
@@ -228,17 +222,16 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{
-        client::ports::MockClientRepository,
-        email_template::{entities::EmailType, ports::MockEmailTemplateRepository},
-        realm::{entities::Realm, ports::MockRealmRepository},
-        role::entities::Role,
-        user::{
-            entities::User,
-            ports::{MockUserRepository, MockUserRoleRepository},
-        },
-    };
+    use crate::email_template::entities::EmailType;
+    use crate::email_template::ports::MockEmailTemplateRepository;
     use chrono::Utc;
+    use ferriskey_domain::client::ports::MockClientRepository;
+    use ferriskey_domain::realm::{Realm, ports::MockRealmRepository};
+    use ferriskey_domain::role::entities::Role;
+    use ferriskey_domain::user::{
+        entities::User,
+        ports::{MockUserRepository, MockUserRoleRepository},
+    };
     use mockall::predicate::*;
     use serde_json::json;
 

--- a/libs/ferriskey-mail/src/lib.rs
+++ b/libs/ferriskey-mail/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod adapters;
+pub mod email_template;
 pub mod entities;
 pub mod error;
 pub mod ports;


### PR DESCRIPTION
Folds the `email_template` domain into the existing `ferriskey-mail` lib crate (as the `email_template` module) — entities, ports, the `EmailTemplatePolicy` impl and the generic `EmailTemplateServiceImpl` (pure business logic, no SeaORM). The SeaORM-backed repository stays in `core` under `infrastructure/`, and `crate::domain::email_template::*` call sites keep compiling via a re-export in `core/src/domain/email_template/mod.rs`.

`email_template` depends only on `ferriskey-domain`, so folding it in requires `ferriskey-mail` to gain a `ferriskey-domain` dependency (plus chrono/serde/serde_json/utoipa/uuid). This is the first of the two email domains; it also unblocks `email_verification`, which imports `email_template`'s ports and `interpolate_variables`.

### Notes
- `EmailTemplateRepository` automock widened to `#[cfg_attr(any(test, feature = "mock"), mockall::automock)]`; `core` now depends on `ferriskey-mail` with `features = ["mock"]` (its `MockEmailTemplateRepository` is used by `trident` and `email_verification` tests, still in core).

### Verification
- `cargo build --workspace`
- `cargo test -p ferriskey-core --lib --no-run`
- `cargo test -p ferriskey-mail` (17/17 green)
- `cargo clippy -p ferriskey-mail --all-features`
- `cargo fmt --all --check`

Part of #1156 · Part of epic #1159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reusable email template capabilities, including template entities, policies, repositories, and services.
  - Enabled optional mock support for email template integrations and testing.
  - Exposed email template functionality through the shared mail library.

- **Refactor**
  - Consolidated email template functionality into the shared mail component while preserving existing access paths and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->