### PR TITLE
refactor: move email and smtp config ports into ferriskey-domain

### DIFF
--- a/core/src/domain/common/email.rs
+++ b/core/src/domain/common/email.rs
@@ -1,13 +1,4 @@
-use crate::domain::{common::entities::app_errors::CoreError, realm::entities::SmtpConfig};
-
-#[cfg_attr(test, mockall::automock)]
-pub trait EmailPort: Send + Sync {
-    fn send_email(
-        &self,
-        config: &SmtpConfig,
-        to_email: &str,
-        subject: &str,
-        body: &str,
-        html_body: Option<String>,
-    ) -> impl Future<Output = Result<(), CoreError>> + Send;
-}
+//! The `EmailPort` trait now lives in the shared `ferriskey-domain` crate (it only references
+//! `CoreError` and `realm::SmtpConfig`, both now in `ferriskey-domain`). Re-exported so existing
+//! `crate::domain::common::email::{EmailPort, MockEmailPort}` call sites keep resolving.
+pub use ferriskey_domain::common::email::*;

--- a/core/src/domain/realm/entities.rs
+++ b/core/src/domain/realm/entities.rs
@@ -1,56 +1,10 @@
-use chrono::{DateTime, Utc};
-pub use ferriskey_domain::realm::{LoginAlias, LoginAliases, Realm, RealmId, RealmSetting};
+pub use ferriskey_domain::realm::{
+    LoginAlias, LoginAliases, Realm, RealmId, RealmSetting, SmtpConfig, SmtpEncryption,
+};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 use crate::domain::abyss::identity_provider::entities::IdentityProviderPresentation;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-pub struct SmtpConfig {
-    pub id: Uuid,
-    pub realm_id: Uuid,
-    pub host: String,
-    pub port: u16,
-    pub username: String,
-    #[serde(skip_serializing)]
-    pub password: String,
-    pub from_email: String,
-    pub from_name: String,
-    pub encryption: SmtpEncryption,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum SmtpEncryption {
-    Tls,
-    StartTls,
-    None,
-}
-
-impl SmtpEncryption {
-    pub fn as_str(&self) -> &str {
-        match self {
-            SmtpEncryption::Tls => "tls",
-            SmtpEncryption::StartTls => "starttls",
-            SmtpEncryption::None => "none",
-        }
-    }
-}
-
-impl std::str::FromStr for SmtpEncryption {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "starttls" => SmtpEncryption::StartTls,
-            "none" => SmtpEncryption::None,
-            _ => SmtpEncryption::Tls,
-        })
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct RealmLoginSetting {

--- a/core/src/domain/realm/ports.rs
+++ b/core/src/domain/realm/ports.rs
@@ -92,8 +92,8 @@ pub trait MailService: Send + Sync {
 // `RealmRepository` and `RealmPolicy` now live in the shared `ferriskey-domain` crate.
 // Re-exported so existing `crate::domain::realm::ports::{RealmRepository, RealmPolicy}` sites
 // (and `MockRealmRepository`, via the `mock` feature core enables) keep resolving.
-// `RealmService` / `MailService` / `SmtpConfigRepository` stay here — they touch
-// `RealmLoginSetting` / `SmtpConfig`, which are still `core`-only types.
+// `RealmService` / `MailService` stay here — they touch `RealmLoginSetting`, still a `core`-only
+// type. `SmtpConfigRepository` (and `SmtpConfig`) now live in `ferriskey-domain`, re-exported below.
 pub use ferriskey_domain::realm::ports::*;
 
 #[derive(Debug)] // TODO derive debug for instrumetnation
@@ -153,24 +153,6 @@ pub struct UpdateRealmSettingInput {
 
 pub struct DeleteRealmInput {
     pub realm_name: String,
-}
-
-#[cfg_attr(test, mockall::automock)]
-pub trait SmtpConfigRepository: Send + Sync {
-    fn get_by_realm_id(
-        &self,
-        realm_id: RealmId,
-    ) -> impl Future<Output = Result<Option<SmtpConfig>, CoreError>> + Send;
-
-    fn upsert(
-        &self,
-        config: &SmtpConfig,
-    ) -> impl Future<Output = Result<SmtpConfig, CoreError>> + Send;
-
-    fn delete_by_realm_id(
-        &self,
-        realm_id: RealmId,
-    ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }
 
 pub struct UpsertSmtpConfigInput {

--- a/libs/ferriskey-domain/src/common/email.rs
+++ b/libs/ferriskey-domain/src/common/email.rs
@@ -1,0 +1,14 @@
+use crate::common::app_errors::CoreError;
+use crate::realm::SmtpConfig;
+
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
+pub trait EmailPort: Send + Sync {
+    fn send_email(
+        &self,
+        config: &SmtpConfig,
+        to_email: &str,
+        subject: &str,
+        body: &str,
+        html_body: Option<String>,
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
+}

--- a/libs/ferriskey-domain/src/common/mod.rs
+++ b/libs/ferriskey-domain/src/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod app_errors;
+pub mod email;
 pub mod policies;

--- a/libs/ferriskey-domain/src/realm/mod.rs
+++ b/libs/ferriskey-domain/src/realm/mod.rs
@@ -42,6 +42,52 @@ impl PartialEq<Uuid> for RealmId {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct SmtpConfig {
+    pub id: Uuid,
+    pub realm_id: Uuid,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    #[serde(skip_serializing)]
+    pub password: String,
+    pub from_email: String,
+    pub from_name: String,
+    pub encryption: SmtpEncryption,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SmtpEncryption {
+    Tls,
+    StartTls,
+    None,
+}
+
+impl SmtpEncryption {
+    pub fn as_str(&self) -> &str {
+        match self {
+            SmtpEncryption::Tls => "tls",
+            SmtpEncryption::StartTls => "starttls",
+            SmtpEncryption::None => "none",
+        }
+    }
+}
+
+impl FromStr for SmtpEncryption {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "starttls" => SmtpEncryption::StartTls,
+            "none" => SmtpEncryption::None,
+            _ => SmtpEncryption::Tls,
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, ToSchema)]
 pub struct Realm {
     pub id: RealmId,

--- a/libs/ferriskey-domain/src/realm/ports.rs
+++ b/libs/ferriskey-domain/src/realm/ports.rs
@@ -2,7 +2,7 @@ use uuid::Uuid;
 
 use crate::auth::Identity;
 use crate::common::app_errors::CoreError;
-use crate::realm::{LoginAliases, Realm, RealmId, RealmSetting};
+use crate::realm::{LoginAliases, Realm, RealmId, RealmSetting, SmtpConfig};
 
 pub trait RealmPolicy: Send + Sync {
     fn can_create_realm(
@@ -94,4 +94,22 @@ pub trait RealmRepository: Send + Sync {
         &self,
         realm_id: RealmId,
     ) -> impl Future<Output = Result<Option<RealmSetting>, CoreError>> + Send;
+}
+
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
+pub trait SmtpConfigRepository: Send + Sync {
+    fn get_by_realm_id(
+        &self,
+        realm_id: RealmId,
+    ) -> impl Future<Output = Result<Option<SmtpConfig>, CoreError>> + Send;
+
+    fn upsert(
+        &self,
+        config: &SmtpConfig,
+    ) -> impl Future<Output = Result<SmtpConfig, CoreError>> + Send;
+
+    fn delete_by_realm_id(
+        &self,
+        realm_id: RealmId,
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }


### PR DESCRIPTION
Moves three domain-layer symbols out of `core` into the shared `ferriskey-domain` crate so that the (upcoming) `email_verification` extraction — and the already-extracted feature libs — can reference them without depending on `core`:

- **`SmtpConfig` + `SmtpEncryption`** — realm SMTP value objects — moved from `core::domain::realm::entities` into `ferriskey_domain::realm`.
- **`SmtpConfigRepository`** — the SMTP config repository port — moved from `core::domain::realm::ports` into `ferriskey_domain::realm::ports`.
- **`EmailPort`** — the email-sending port — moved from `core::domain::common::email` into `ferriskey_domain::common::email`.

All are pure domain types (value objects + port traits over `CoreError`), so `ferriskey-domain` is the correct hexagonal home. `core` keeps thin re-exports at the old paths (`crate::domain::realm::entities::*`, `crate::domain::realm::ports::*`, `crate::domain::common::email::*`), so every existing call site — application wiring, SeaORM adapters, `trident`, `email_verification`, and the api handlers — keeps compiling unchanged. `RealmLoginSetting`, `MailService` and `RealmService` stay in `core` (they touch `core`-only types like `abyss`/`portal_theme`).

The `EmailPort` and `SmtpConfigRepository` automocks are widened to `#[cfg_attr(any(test, feature = "mock"), mockall::automock)]`; `MockEmailPort` / `MockSmtpConfigRepository` resolve for `trident` and `email_verification` tests via `core`'s existing `ferriskey-domain` `features = ["mock"]`.

This unblocks folding `email_verification` into `ferriskey-mail` (it imports `EmailPort` + `SmtpConfigRepository`, both `core`-only until now).

### Verification
- `cargo build --workspace`
- `cargo test -p ferriskey-core --lib --no-run`
- `cargo clippy -p ferriskey-domain --all-features` / `cargo clippy -p ferriskey-core --all-targets` (no new warnings)
- `cargo fmt --all --check`

Part of #1156 · Part of epic #1159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized SMTP configuration support, including encryption options and secure password handling.
  * Added email delivery capabilities with plaintext and optional HTML content.
  * Added repository operations to retrieve, save, and delete SMTP configurations.
* **Refactor**
  * Consolidated email and SMTP domain types into shared components while preserving existing integration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->