### PR TITLE
refactor: move session domain into ferriskey-domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "utoipa",
  "uuid",

--- a/core/src/domain/session/mod.rs
+++ b/core/src/domain/session/mod.rs
@@ -1,3 +1,5 @@
-pub mod entities;
-pub mod ports;
-pub mod services;
+//! The session domain now lives in the shared `ferriskey-domain` crate — entities, ports and the
+//! generic `UserSessionServiceImpl` (pure business logic, no SeaORM). The SeaORM-backed repository
+//! stays in `core` under `infrastructure/`. Re-exported here so existing
+//! `crate::domain::session::*` call sites keep compiling.
+pub use ferriskey_domain::session::*;

--- a/libs/ferriskey-domain/Cargo.toml
+++ b/libs/ferriskey-domain/Cargo.toml
@@ -18,6 +18,7 @@ mockall = { version = "0.14.0", optional = true }
 [dev-dependencies]
 serde_json = "1.0.149"
 mockall = "0.14.0"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]
 mock = ["mockall"]

--- a/libs/ferriskey-domain/src/lib.rs
+++ b/libs/ferriskey-domain/src/lib.rs
@@ -9,6 +9,7 @@ pub mod common;
 pub mod maintenance;
 pub mod realm;
 pub mod role;
+pub mod session;
 pub mod token_lifetime;
 pub mod user;
 

--- a/libs/ferriskey-domain/src/session/entities.rs
+++ b/libs/ferriskey-domain/src/session/entities.rs
@@ -1,9 +1,8 @@
 use chrono::{DateTime, Duration, Utc};
-use sea_orm::EnumIter;
 use thiserror::Error;
 use uuid::Uuid;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, EnumIter)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SessionState {
     Active,
     SoftExpired,

--- a/libs/ferriskey-domain/src/session/mod.rs
+++ b/libs/ferriskey-domain/src/session/mod.rs
@@ -1,0 +1,3 @@
+pub mod entities;
+pub mod ports;
+pub mod services;

--- a/libs/ferriskey-domain/src/session/ports.rs
+++ b/libs/ferriskey-domain/src/session/ports.rs
@@ -1,11 +1,9 @@
 use chrono::Duration;
 use uuid::Uuid;
 
-use crate::domain::{
-    authentication::value_objects::Identity,
-    common::entities::app_errors::CoreError,
-    session::entities::{SessionError, UserSession},
-};
+use crate::auth::Identity;
+use crate::common::app_errors::CoreError;
+use crate::session::entities::{SessionError, UserSession};
 
 pub trait UserSessionService: Send + Sync {
     fn create_session(
@@ -36,7 +34,7 @@ pub trait UserSessionManagementService: Send + Sync {
     ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }
 
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait UserSessionRepository: Send + Sync {
     fn create(
         &self,

--- a/libs/ferriskey-domain/src/session/services.rs
+++ b/libs/ferriskey-domain/src/session/services.rs
@@ -3,14 +3,13 @@ use std::sync::Arc;
 use chrono::Duration;
 use uuid::Uuid;
 
-use crate::domain::{
-    authentication::value_objects::Identity,
-    common::{entities::app_errors::CoreError, policies::Policy},
-    realm::ports::RealmRepository,
-    session::{
-        entities::{SessionError, UserSession},
-        ports::{UserSessionManagementService, UserSessionRepository, UserSessionService},
-    },
+use crate::auth::Identity;
+use crate::common::app_errors::CoreError;
+use crate::common::policies::Policy;
+use crate::realm::ports::RealmRepository;
+use crate::session::entities::{SessionError, UserSession};
+use crate::session::ports::{
+    UserSessionManagementService, UserSessionRepository, UserSessionService,
 };
 
 #[derive(Clone)]
@@ -113,15 +112,14 @@ where
                 .get_permission_for_target_realm(&actor, &realm)
                 .await?;
 
-            let has_permission =
-                crate::domain::role::entities::permission::Permissions::has_one_of_permissions(
-                    &permissions,
-                    &[
-                        crate::domain::role::entities::permission::Permissions::ManageUsers,
-                        crate::domain::role::entities::permission::Permissions::ManageRealm,
-                        crate::domain::role::entities::permission::Permissions::ViewUsers,
-                    ],
-                );
+            let has_permission = crate::role::permission::Permissions::has_one_of_permissions(
+                &permissions,
+                &[
+                    crate::role::permission::Permissions::ManageUsers,
+                    crate::role::permission::Permissions::ManageRealm,
+                    crate::role::permission::Permissions::ViewUsers,
+                ],
+            );
 
             if !has_permission {
                 return Err(CoreError::Forbidden(
@@ -160,14 +158,13 @@ where
                 .get_permission_for_target_realm(&actor, &realm)
                 .await?;
 
-            let has_permission =
-                crate::domain::role::entities::permission::Permissions::has_one_of_permissions(
-                    &permissions,
-                    &[
-                        crate::domain::role::entities::permission::Permissions::ManageUsers,
-                        crate::domain::role::entities::permission::Permissions::ManageRealm,
-                    ],
-                );
+            let has_permission = crate::role::permission::Permissions::has_one_of_permissions(
+                &permissions,
+                &[
+                    crate::role::permission::Permissions::ManageUsers,
+                    crate::role::permission::Permissions::ManageRealm,
+                ],
+            );
 
             if !has_permission {
                 return Err(CoreError::Forbidden(
@@ -200,7 +197,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::session::ports::MockUserSessionRepository;
+    use crate::session::ports::MockUserSessionRepository;
     use uuid::Uuid;
 
     fn make_session(user_id: Uuid, realm_id: Uuid) -> UserSession {
@@ -252,7 +249,7 @@ mod tests {
         let session = make_session(user_id, realm_id);
         assert_eq!(
             session.get_state(),
-            crate::domain::session::entities::SessionState::Active
+            crate::session::entities::SessionState::Active
         );
         assert!(!session.is_expired());
     }
@@ -275,7 +272,7 @@ mod tests {
         assert!(session.is_expired());
         assert_eq!(
             session.get_state(),
-            crate::domain::session::entities::SessionState::Expired
+            crate::session::entities::SessionState::Expired
         );
     }
 }


### PR DESCRIPTION
Folds the `session` domain into the shared `ferriskey-domain` crate — entities (`UserSession`, `SessionState`, `SessionError`), ports and the generic `UserSessionServiceImpl` / `UserSessionManagementServiceImpl` (pure business logic, no SeaORM). The SeaORM-backed repository stays in `core` under `infrastructure/`, and `crate::domain::session::*` call sites keep compiling via a re-export in `core/src/domain/session/mod.rs`.

`session` references only types already in `ferriskey-domain` (`auth::Identity`, `common::{app_errors, policies}`, `realm::ports`, `role::permission::Permissions`), so it folds cleanly into the kernel with no cycle.

### Notes
- Dropped a **dead** `#[derive(sea_orm::EnumIter)]` on `SessionState` — `SessionState::iter()` is never called anywhere, and the SeaORM mapper converts via `as_str()`/`match`. Removing it keeps `ferriskey-domain` free of any `sea_orm` dependency.
- Added `tokio` to `ferriskey-domain`'s dev-dependencies (the moved session tests use `#[tokio::test]`).
- `UserSessionRepository` automock widened to `#[cfg_attr(any(test, feature = "mock"), mockall::automock)]` for consistency.

### Verification
- `cargo build --workspace`
- `cargo test -p ferriskey-core --lib --no-run`
- `cargo test -p ferriskey-domain` (26 passed)
- `cargo clippy -p ferriskey-domain --all-features`
- `cargo fmt --all --check`

Part of #1156 · Part of epic #1159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated session management into the shared domain layer.
  * Preserved existing session functionality and access points during the internal module transition.
  * Updated session permission checks and state handling without changing the intended authorization rules.
* **Bug Fixes**
  * Corrected session revocation permissions so view-only access no longer permits revocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->