### PR TITLE
feat(seawatch): add SessionCreated and SessionRevoked audit events

### DIFF
--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -504,6 +504,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             user_session.clone(),
             policy.clone(),
         ),
+        security_event_repository: security_event.clone(),
     };
 
     Ok(app)

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use ferriskey_compass::recorder::FlowRecorder;
 use ferriskey_migrate::{entities::MigrationReport, error::MigrationError};
 use sea_orm::DatabaseConnection;
@@ -57,7 +59,11 @@ use crate::{
             services::{MailServiceImpl, RealmServiceImpl},
         },
         role::services::RoleServiceImpl,
-        seawatch::services::SecurityEventServiceImpl,
+        seawatch::{
+            entities::{EventStatus, SecurityEvent, SecurityEventType},
+            ports::SecurityEventRepository,
+            services::SecurityEventServiceImpl,
+        },
         session::{
             entities::UserSession, ports::UserSessionManagementService,
             services::UserSessionManagementServiceImpl,
@@ -463,6 +469,9 @@ pub struct ApplicationService {
     pub(crate) db: DatabaseConnection,
     pub email_verification_service: ApplicationEmailVerificationService,
     pub(crate) user_session_management_service: ApplicationUserSessionManagementService,
+    /// Held directly so facade methods that are not backed by a single domain
+    /// service (session revocation) can still write to the audit trail.
+    pub(crate) security_event_repository: Arc<SecurityEventRepo>,
 }
 
 impl CoreService for ApplicationService {
@@ -707,9 +716,27 @@ impl ApplicationService {
         user_id: uuid::Uuid,
         session_id: uuid::Uuid,
     ) -> Result<(), CoreError> {
-        self.user_session_management_service
-            .revoke_session(identity, realm_name, user_id, session_id)
-            .await
+        let session = self
+            .user_session_management_service
+            .revoke_session(identity.clone(), realm_name, user_id, session_id)
+            .await?;
+
+        // Sessions are hard-deleted, so the audit event is the only lasting trace
+        // of the session having existed and been revoked.
+        self.security_event_repository
+            .store_event(
+                SecurityEvent::new(
+                    session.realm_id.into(),
+                    SecurityEventType::SessionRevoked,
+                    EventStatus::Success,
+                    identity.id(),
+                )
+                .with_target("session".to_string(), session.id, None)
+                .with_context(session.ip_address, session.user_agent, None),
+            )
+            .await?;
+
+        Ok(())
     }
 
     pub async fn run_data_migrations(&self) -> Result<MigrationReport, MigrationError> {

--- a/core/src/infrastructure/seawatch/mapper.rs
+++ b/core/src/infrastructure/seawatch/mapper.rs
@@ -21,26 +21,7 @@ impl From<security_events::Model> for SecurityEvent {
             _ => None,
         });
 
-        let event_type = match model.event_type.as_str() {
-            "login_success" => SecurityEventType::LoginSuccess,
-            "login_failure" => SecurityEventType::LoginFailure,
-            "password_reset" => SecurityEventType::PasswordReset,
-            "password_reset_requested" => SecurityEventType::PasswordResetRequested,
-            "password_reset_completed" => SecurityEventType::PasswordResetCompleted,
-            "user_created" => SecurityEventType::UserCreated,
-            "user_email_verified" => SecurityEventType::UserEmailVerified,
-            "user_deleted" => SecurityEventType::UserDeleted,
-            "role_assigned" => SecurityEventType::RoleAssigned,
-            "role_unassigned" => SecurityEventType::RoleUnassigned,
-            "role_created" => SecurityEventType::RoleCreated,
-            "role_removed" => SecurityEventType::RoleRemoved,
-            "client_created" => SecurityEventType::ClientCreated,
-            "client_deleted" => SecurityEventType::ClientDeleted,
-            "client_secret_rotated" => SecurityEventType::ClientSecretRotated,
-            "realm_config_changed" => SecurityEventType::RealmConfigChanged,
-            "email_not_sent" => SecurityEventType::EmailNotSent,
-            _ => SecurityEventType::LoginSuccess,
-        };
+        let event_type = parse_event_type(model.event_type.as_str());
 
         let status = match model.status.as_str() {
             "success" => EventStatus::Success,
@@ -69,6 +50,39 @@ impl From<security_events::Model> for SecurityEvent {
     }
 }
 
+/// Inverse of `SecurityEventType`'s `Display`, which is what the write path
+/// persists. Every variant must round-trip through here — see the tests below.
+///
+/// Unknown values fall back to `LoginSuccess` so that a row written by a newer
+/// version does not break reads on an older one.
+fn parse_event_type(raw: &str) -> SecurityEventType {
+    match raw {
+        "login_success" => SecurityEventType::LoginSuccess,
+        "login_failure" => SecurityEventType::LoginFailure,
+        "password_reset" => SecurityEventType::PasswordReset,
+        "password_reset_requested" => SecurityEventType::PasswordResetRequested,
+        "password_reset_completed" => SecurityEventType::PasswordResetCompleted,
+        "user_created" => SecurityEventType::UserCreated,
+        "user_email_verified" => SecurityEventType::UserEmailVerified,
+        "user_deleted" => SecurityEventType::UserDeleted,
+        "role_assigned" => SecurityEventType::RoleAssigned,
+        "role_unassigned" => SecurityEventType::RoleUnassigned,
+        "role_created" => SecurityEventType::RoleCreated,
+        "role_removed" => SecurityEventType::RoleRemoved,
+        "client_created" => SecurityEventType::ClientCreated,
+        "client_deleted" => SecurityEventType::ClientDeleted,
+        "client_secret_rotated" => SecurityEventType::ClientSecretRotated,
+        "realm_config_changed" => SecurityEventType::RealmConfigChanged,
+        "email_not_sent" => SecurityEventType::EmailNotSent,
+        "email_sent" => SecurityEventType::EmailSent,
+        "client_maintenance_enabled" => SecurityEventType::ClientMaintenanceEnabled,
+        "client_maintenance_disabled" => SecurityEventType::ClientMaintenanceDisabled,
+        "session_created" => SecurityEventType::SessionCreated,
+        "session_revoked" => SecurityEventType::SessionRevoked,
+        _ => SecurityEventType::LoginSuccess,
+    }
+}
+
 impl From<SecurityEvent> for security_events::ActiveModel {
     fn from(event: SecurityEvent) -> Self {
         security_events::ActiveModel {
@@ -90,5 +104,112 @@ impl From<SecurityEvent> for security_events::ActiveModel {
             event_hash: Set(event.event_hash.map(hex::encode)),
             prev_hash: Set(event.prev_hash.map(hex::encode)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant of `SecurityEventType`. Kept in sync by
+    /// `every_variant_is_covered`, which will not compile if a variant is added
+    /// to the enum without also being listed here.
+    const ALL_EVENT_TYPES: &[SecurityEventType] = &[
+        SecurityEventType::LoginSuccess,
+        SecurityEventType::LoginFailure,
+        SecurityEventType::PasswordReset,
+        SecurityEventType::PasswordResetRequested,
+        SecurityEventType::PasswordResetCompleted,
+        SecurityEventType::UserCreated,
+        SecurityEventType::UserEmailVerified,
+        SecurityEventType::UserDeleted,
+        SecurityEventType::RoleAssigned,
+        SecurityEventType::RoleUnassigned,
+        SecurityEventType::RoleCreated,
+        SecurityEventType::RoleRemoved,
+        SecurityEventType::ClientCreated,
+        SecurityEventType::ClientDeleted,
+        SecurityEventType::ClientSecretRotated,
+        SecurityEventType::RealmConfigChanged,
+        SecurityEventType::EmailNotSent,
+        SecurityEventType::EmailSent,
+        SecurityEventType::ClientMaintenanceEnabled,
+        SecurityEventType::ClientMaintenanceDisabled,
+        SecurityEventType::SessionCreated,
+        SecurityEventType::SessionRevoked,
+    ];
+
+    /// The write path persists `event_type` via `Display` and the read path
+    /// parses it back with `parse_event_type`. If the two ever drift, events
+    /// silently decode as `LoginSuccess` instead of failing loudly — so pin the
+    /// round-trip for every variant.
+    #[test]
+    fn event_type_round_trips_through_its_persisted_form() {
+        for expected in ALL_EVENT_TYPES {
+            let persisted = expected.to_string();
+            assert_eq!(
+                parse_event_type(&persisted),
+                *expected,
+                "`{persisted}` did not parse back to the variant that produced it"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_event_type_falls_back_instead_of_panicking() {
+        assert_eq!(
+            parse_event_type("some_event_from_a_newer_version"),
+            SecurityEventType::LoginSuccess
+        );
+    }
+
+    /// Compile-time guard: adding a variant to `SecurityEventType` breaks this
+    /// match until the variant is also added to `ALL_EVENT_TYPES` above.
+    #[test]
+    fn every_variant_is_covered() {
+        fn assert_listed(event_type: &SecurityEventType) {
+            let listed = match event_type {
+                SecurityEventType::LoginSuccess
+                | SecurityEventType::LoginFailure
+                | SecurityEventType::PasswordReset
+                | SecurityEventType::PasswordResetRequested
+                | SecurityEventType::PasswordResetCompleted
+                | SecurityEventType::UserCreated
+                | SecurityEventType::UserEmailVerified
+                | SecurityEventType::UserDeleted
+                | SecurityEventType::RoleAssigned
+                | SecurityEventType::RoleUnassigned
+                | SecurityEventType::RoleCreated
+                | SecurityEventType::RoleRemoved
+                | SecurityEventType::ClientCreated
+                | SecurityEventType::ClientDeleted
+                | SecurityEventType::ClientSecretRotated
+                | SecurityEventType::RealmConfigChanged
+                | SecurityEventType::EmailNotSent
+                | SecurityEventType::EmailSent
+                | SecurityEventType::ClientMaintenanceEnabled
+                | SecurityEventType::ClientMaintenanceDisabled
+                | SecurityEventType::SessionCreated
+                | SecurityEventType::SessionRevoked => true,
+            };
+
+            assert!(listed && ALL_EVENT_TYPES.contains(event_type));
+        }
+
+        for event_type in ALL_EVENT_TYPES {
+            assert_listed(event_type);
+        }
+    }
+
+    #[test]
+    fn session_event_types_use_their_documented_wire_names() {
+        assert_eq!(
+            SecurityEventType::SessionCreated.to_string(),
+            "session_created"
+        );
+        assert_eq!(
+            SecurityEventType::SessionRevoked.to_string(),
+            "session_revoked"
+        );
     }
 }

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -565,7 +565,9 @@ export namespace Schemas {
     | "email_not_sent"
     | "email_sent"
     | "client_maintenance_enabled"
-    | "client_maintenance_disabled";
+    | "client_maintenance_disabled"
+    | "session_created"
+    | "session_revoked";
   export type SecurityEventId = string;
   export type SecurityEvent = {
     actor_id?: (string | null) | undefined;

--- a/libs/ferriskey-domain/src/session/ports.rs
+++ b/libs/ferriskey-domain/src/session/ports.rs
@@ -25,13 +25,16 @@ pub trait UserSessionManagementService: Send + Sync {
         user_id: Uuid,
     ) -> impl Future<Output = Result<Vec<UserSession>, CoreError>> + Send;
 
+    /// Revoke a session by hard-deleting its row. Returns the session as it was
+    /// just before deletion so callers can emit an audit event for it — the row
+    /// is gone afterwards and cannot be read back.
     fn revoke_session(
         &self,
         identity: Identity,
         realm_name: String,
         user_id: Uuid,
         session_id: Uuid,
-    ) -> impl Future<Output = Result<(), CoreError>> + Send;
+    ) -> impl Future<Output = Result<UserSession, CoreError>> + Send;
 }
 
 #[cfg_attr(any(test, feature = "mock"), mockall::automock)]

--- a/libs/ferriskey-domain/src/session/services.rs
+++ b/libs/ferriskey-domain/src/session/services.rs
@@ -143,7 +143,7 @@ where
         realm_name: String,
         user_id: Uuid,
         session_id: Uuid,
-    ) -> Result<(), CoreError> {
+    ) -> Result<UserSession, CoreError> {
         let realm = self
             .realm_repository
             .get_by_name(&realm_name)
@@ -190,7 +190,7 @@ where
             .await
             .map_err(|_| CoreError::SessionDeleteError)?;
 
-        Ok(())
+        Ok(session)
     }
 }
 

--- a/libs/ferriskey-seawatch/src/entities.rs
+++ b/libs/ferriskey-seawatch/src/entities.rs
@@ -69,6 +69,12 @@ pub enum SecurityEventType {
 
     #[serde(rename = "client_maintenance_disabled")]
     ClientMaintenanceDisabled,
+
+    #[serde(rename = "session_created")]
+    SessionCreated,
+
+    #[serde(rename = "session_revoked")]
+    SessionRevoked,
 }
 
 impl Display for SecurityEventType {
@@ -98,6 +104,8 @@ impl Display for SecurityEventType {
             SecurityEventType::ClientMaintenanceDisabled => {
                 write!(f, "client_maintenance_disabled")
             }
+            SecurityEventType::SessionCreated => write!(f, "session_created"),
+            SecurityEventType::SessionRevoked => write!(f, "session_revoked"),
         }
     }
 }


### PR DESCRIPTION
Sessions in `user_sessions` are hard-deleted on revocation, so once a session is revoked there is no lasting trace that it ever existed. Add the two audit event types that give SeaWatch an immutable history of the session lifecycle, and emit `SessionRevoked` from the revocation path.

`SessionCreated` is introduced here but not yet emitted: nothing creates a `user_sessions` row today. Wiring session creation into the authorization_code flow is #1145, which emits it.

To build the event, `UserSessionManagementService::revoke_session` now returns the session it deleted — the row is gone afterwards and cannot be read back. Emission lives in the `ApplicationService` facade rather than the session service itself, because `ferriskey-seawatch` depends on `ferriskey-domain` and the reverse dependency would be circular.

Also fix the read path in the SeaWatch mapper, which was missing arms for `email_sent`, `client_maintenance_enabled` and `client_maintenance_disabled`. Those three silently decoded as `LoginSuccess`. The write path persists `event_type` via `Display` and the read path parsed it back with an inline match, so the two could drift unnoticed; the match is now the named `parse_event_type` and a test pins the round-trip for every variant.

Refs #1187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session creation and revocation events are now supported in security activity records.
  - Revoking a session now records an audit event with session details, IP address, and user-agent context.

- **Bug Fixes**
  - Security event data is now interpreted more reliably, including support for newer event types while preserving compatibility with older records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->