### PR TITLE
feat: front require pkce toggle

### DIFF
--- a/front/pnpm-workspace.yaml
+++ b/front/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  esbuild: true

--- a/front/pnpm-workspace.yaml
+++ b/front/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
+# Single-package "workspace": the front is the only package here. pnpm 9 (pinned
+# in the Dockerfile) refuses to run any command when a pnpm-workspace.yaml has no
+# `packages` field — "packages field missing or empty" — so this must stay.
+packages:
+  - '.'
+
+# pnpm 10+ blocks dependency build scripts unless approved. No-op on pnpm 9,
+# which runs them by default.
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true

--- a/front/src/pages/client/feature/page-client-settings-feature.tsx
+++ b/front/src/pages/client/feature/page-client-settings-feature.tsx
@@ -39,6 +39,7 @@ export default function PageClientSettingsFeature() {
       directAccessGrantsEnabled: clientResponse?.data.direct_access_grants_enabled ?? false,
       oauthDeviceCodeGrantEnabled:
         clientResponse?.data.oauth_device_code_grant_enabled ?? false,
+      requirePkce: clientResponse?.data.require_pkce ?? false,
       accessTokenLifetime: clientResponse?.data.access_token_lifetime ?? null,
       refreshTokenLifetime: clientResponse?.data.refresh_token_lifetime ?? null,
       idTokenLifetime: clientResponse?.data.id_token_lifetime ?? null,
@@ -55,6 +56,7 @@ export default function PageClientSettingsFeature() {
       directAccessGrantsEnabled: clientResponse.data.direct_access_grants_enabled ?? false,
       oauthDeviceCodeGrantEnabled:
         clientResponse.data.oauth_device_code_grant_enabled ?? false,
+      requirePkce: clientResponse.data.require_pkce ?? false,
       accessTokenLifetime: clientResponse.data.access_token_lifetime ?? null,
       refreshTokenLifetime: clientResponse.data.refresh_token_lifetime ?? null,
       idTokenLifetime: clientResponse.data.id_token_lifetime ?? null,
@@ -72,6 +74,7 @@ export default function PageClientSettingsFeature() {
         enabled: values.enabled,
         direct_access_grants_enabled: values.directAccessGrantsEnabled,
         oauth_device_code_grant_enabled: values.oauthDeviceCodeGrantEnabled,
+        require_pkce: values.requirePkce,
         access_token_lifetime: values.accessTokenLifetime,
         refresh_token_lifetime: values.refreshTokenLifetime,
         id_token_lifetime: values.idTokenLifetime,
@@ -93,6 +96,7 @@ export default function PageClientSettingsFeature() {
         directAccessGrantsEnabled: clientResponse.data.direct_access_grants_enabled,
         oauthDeviceCodeGrantEnabled:
           clientResponse.data.oauth_device_code_grant_enabled ?? false,
+        requirePkce: clientResponse.data.require_pkce ?? false,
         accessTokenLifetime: clientResponse.data.access_token_lifetime ?? null,
         refreshTokenLifetime: clientResponse.data.refresh_token_lifetime ?? null,
         idTokenLifetime: clientResponse.data.id_token_lifetime ?? null,

--- a/front/src/pages/client/schemas/update-client.schema.ts
+++ b/front/src/pages/client/schemas/update-client.schema.ts
@@ -6,6 +6,7 @@ export const updateClientSchema = z.object({
   enabled: z.boolean().optional(),
   directAccessGrantsEnabled: z.boolean().optional(),
   oauthDeviceCodeGrantEnabled: z.boolean().optional(),
+  requirePkce: z.boolean().optional(),
   accessTokenLifetime: z.number().nullable().optional(),
   refreshTokenLifetime: z.number().nullable().optional(),
   idTokenLifetime: z.number().nullable().optional(),

--- a/front/src/pages/client/ui/page-client-settings.tsx
+++ b/front/src/pages/client/ui/page-client-settings.tsx
@@ -188,6 +188,36 @@ export default function PageClientSettings({
             </div>
           )}
         />
+
+        {/* PKCE (RFC 7636) */}
+        <FormField
+          name='requirePkce'
+          control={form.control}
+          render={({ field }) => (
+            <div className='flex items-center justify-between py-4 border-t'>
+              <div className='w-1/3'>
+                <p className='text-sm font-medium'>Require PKCE</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>
+                  Rejects authorization requests that carry no S256 code challenge (RFC 7636). The
+                  plain method is refused when this is on.
+                  {client.public_client
+                    ? ' Strongly recommended: this client cannot keep a secret safe.'
+                    : ''}
+                </p>
+              </div>
+              <div className='w-1/2'>
+                <FormItem className='flex flex-row items-center gap-3'>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                  <FormLabel className='!mt-0 font-normal text-muted-foreground'>
+                    {field.value ? 'Required' : 'Optional'}
+                  </FormLabel>
+                </FormItem>
+              </div>
+            </div>
+          )}
+        />
       </div>
 
       {/* Access Settings section */}

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -48,6 +48,7 @@ export default function PageApplicationDetailFeature() {
         enabled: values.enabled,
         direct_access_grants_enabled: values.directAccessGrantsEnabled,
         oauth_device_code_grant_enabled: values.oauthDeviceCodeGrantEnabled,
+        require_pkce: values.requirePkce,
         access_token_lifetime: values.accessTokenLifetime,
         refresh_token_lifetime: values.refreshTokenLifetime,
         id_token_lifetime: values.idTokenLifetime,

--- a/front/src/pages/console-applications/ui/tabs/settings-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/settings-tab.tsx
@@ -23,6 +23,7 @@ export interface ApplicationSettingsValues {
   enabled: boolean
   directAccessGrantsEnabled: boolean
   oauthDeviceCodeGrantEnabled: boolean
+  requirePkce: boolean
   accessTokenLifetime: number | null
   refreshTokenLifetime: number | null
   idTokenLifetime: number | null
@@ -35,6 +36,7 @@ function settingsFromClient(c: Client): ApplicationSettingsValues {
     enabled: c.enabled,
     directAccessGrantsEnabled: c.direct_access_grants_enabled,
     oauthDeviceCodeGrantEnabled: c.oauth_device_code_grant_enabled,
+    requirePkce: c.require_pkce,
     accessTokenLifetime: c.access_token_lifetime ?? null,
     refreshTokenLifetime: c.refresh_token_lifetime ?? null,
     idTokenLifetime: c.id_token_lifetime ?? null,
@@ -73,7 +75,12 @@ export default function SettingsTab({
   )
 
   const appType = inferApplicationType(client)
-  const showRedirectUris = appType !== 'm2m' && appType !== 'device'
+  // Redirect URIs and PKCE only mean something for the authorization code flow;
+  // m2m (client credentials) and device (RFC 8628) clients never go through it.
+  const usesAuthorizationCode = appType !== 'm2m' && appType !== 'device'
+  // SPAs and native apps ship their code to the end user, so they cannot hold a
+  // secret — PKCE is their only protection against code interception.
+  const isPublicClient = appType === 'spa' || appType === 'native'
 
   const set = <K extends keyof ApplicationSettingsValues>(
     key: K,
@@ -112,7 +119,7 @@ export default function SettingsTab({
         />
       </Section>
 
-      {showRedirectUris && (
+      {usesAuthorizationCode && (
         <Section
           title='Redirect URIs'
           description='Allowed callback URLs FerrisKey may redirect to after sign-in.'
@@ -180,6 +187,24 @@ export default function SettingsTab({
           onChange={(v) => set('oauthDeviceCodeGrantEnabled', v)}
         />
       </Section>
+
+      {usesAuthorizationCode && (
+        <Section
+          title='Security'
+          description='Hardening options for the authorization code flow.'
+        >
+          <ToggleRow
+            label='Require PKCE'
+            description={
+              isPublicClient
+                ? 'Reject authorization requests without an S256 challenge (RFC 7636). Strongly recommended: this application cannot keep a client secret safe.'
+                : 'Reject authorization requests without an S256 challenge (RFC 7636). The plain method is refused when this is on.'
+            }
+            checked={values.requirePkce}
+            onChange={(v) => set('requirePkce', v)}
+          />
+        </Section>
+      )}
 
       <Section
         title='Token lifetimes'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PKCE (RFC 7636) configuration to client and application settings.
  * Added a “Require PKCE” toggle to mark PKCE as required or optional for applicable authorization-code applications.
  * Added context-aware helper text for public clients.
  * Updated settings UI to show redirect URI and PKCE security options only when relevant.

* **Bug Fixes**
  * PKCE settings are now correctly loaded, validated, and saved end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->