### PR TITLE
fix: bind clients scopes mappers and templates to the request realm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "mockall 0.14.0",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "utoipa",
  "uuid",

--- a/api/tests/client_cross_realm_test.rs
+++ b/api/tests/client_cross_realm_test.rs
@@ -1,0 +1,762 @@
+/// Integration test: cross-realm IDOR on OAuth clients (FK-005).
+///
+/// `ClientService` decided authorization against the realm named in the URL, then
+/// loaded the client by **bare UUID**. Thirteen of its fifteen methods never checked
+/// that the client actually belonged to that realm, so an administrator of one
+/// tenant could reach into another tenant's clients:
+///
+///   * **Secret theft.** `Client.secret` is stored unhashed and serialized in full by
+///     `GET /realms/{realm}/clients/{id}` — no masking. A stolen secret is directly
+///     replayable against the victim tenant's token endpoint.
+///   * **Weakening.** `PATCH` could flip `require_pkce` to `false`, turn on
+///     `direct_access_grants_enabled`, or stretch token lifetimes on a third party.
+///   * **Destruction.** `DELETE` cascades onto roles, the service account, scope
+///     mappings and post-logout redirect URIs. Deleting a realm's console client
+///     takes its administration UI offline.
+///   * **Redirect URI injection**, which combined with the neighbouring findings
+///     hijacks the victim tenant's authorization codes.
+///
+/// Cross-realm access **from `master` is intentional** (`can_access_realm` grants it
+/// on the literal name `master`). The finding is strictly the tenant → other tenant
+/// escalation, so the attacker below is an administrator of a *tenant* realm, never
+/// the master admin — otherwise the test would be exercising designed behaviour.
+///
+/// Every attack asserts a side effect as well as the status code: a 404 obtained for
+/// the wrong reason proves nothing. The load-bearing assertion is that the response
+/// body of the attacker's `GET` does not contain the victim client's real secret,
+/// read back through the master admin.
+///
+/// Requires a running PostgreSQL instance. Marked `#[ignore]` so it does not run in
+/// regular `cargo test`. Run explicitly with:
+///
+///   cargo test -p ferriskey-api --test client_cross_realm_test -- --ignored
+///
+/// Environment variables (defaults shown):
+///   DATABASE_HOST     = localhost
+///   DATABASE_PORT     = 5432
+///   DATABASE_NAME     = ferriskey
+///   DATABASE_USER     = ferriskey
+///   DATABASE_PASSWORD = ferriskey
+#[cfg(test)]
+mod tests {
+    use std::{env, sync::Arc};
+
+    use axum::{Router, http::HeaderValue};
+    use axum_test::TestServer;
+    use ferriskey_api::{
+        application::http::server::{app_state::AppState, http_server::router},
+        args::Args,
+    };
+    use ferriskey_core::{
+        application::create_service,
+        domain::common::{
+            DatabaseConfig, FerriskeyConfig, entities::StartupConfig, ports::CoreService,
+        },
+    };
+    use serde_json::{Value, json};
+    use sqlx::Executor;
+    use uuid::Uuid;
+
+    const WEBAPP_URL: &str = "http://localhost:5555";
+
+    /// `create_realm` resolves the parent realm through `get_by_name("master")` and
+    /// `can_access_realm` grants cross-realm on the same literal, so the master realm
+    /// must be seeded under exactly this name or no tenant can be created at all.
+    const MASTER_REALM: &str = "master";
+
+    /// Naming the seeded client `admin-cli` short-circuits its seeding (#1086).
+    const SEEDED_CLIENT_ID: &str = "ferriskey-admin";
+
+    const MASTER_ADMIN_USERNAME: &str = "admin";
+    const MASTER_ADMIN_PASSWORD: &str = "admin";
+
+    /// The attacker's realm.
+    const TENANT_A: &str = "tenant-a";
+    /// The victim's realm.
+    const TENANT_B: &str = "tenant-b";
+
+    /// Administrator of `tenant-a`. Holds `manage_clients` and `view_clients` inside
+    /// her own realm and nothing at all in `tenant-b`.
+    const ALICE_USERNAME: &str = "alice";
+    /// Default CNIL policy: at least 12 characters over 4 character classes.
+    const ALICE_PASSWORD: &str = "Att4cker-Passw0rd!";
+
+    fn env_or(key: &str, default: &str) -> String {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+
+    fn env_u16_or(key: &str, default: u16) -> u16 {
+        env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    struct SharedContext {
+        app: std::sync::Mutex<Router>,
+    }
+
+    // `router()` installs a *global* Prometheus recorder, so it can only be built
+    // once per test binary (#1086). Every test shares this one router and runtime,
+    // hence `#[test]` + `rt().block_on(..)` rather than `#[tokio::test]`.
+    static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    static CTX: std::sync::OnceLock<SharedContext> = std::sync::OnceLock::new();
+
+    fn rt() -> &'static tokio::runtime::Runtime {
+        RUNTIME.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build shared runtime")
+        })
+    }
+
+    fn shared_ctx() -> &'static SharedContext {
+        CTX.get_or_init(|| match tokio::runtime::Handle::try_current() {
+            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(init_shared_ctx())),
+            Err(_) => rt().block_on(init_shared_ctx()),
+        })
+    }
+
+    async fn init_shared_ctx() -> SharedContext {
+        let db_host = env_or("DATABASE_HOST", "localhost");
+        let db_port = env_u16_or("DATABASE_PORT", 5432);
+        let db_name = env_or("DATABASE_NAME", "ferriskey");
+        let db_user = env_or("DATABASE_USER", "ferriskey");
+        let db_password = env_or("DATABASE_PASSWORD", "ferriskey");
+
+        // A throwaway schema per run: the realms below carry fixed names, so runs
+        // would otherwise collide.
+        let schema = format!("client_cross_realm_test_{}", Uuid::new_v4().simple());
+
+        let admin_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+
+        let admin_pool = sqlx::PgPool::connect(&admin_url)
+            .await
+            .expect("connect admin pool");
+
+        admin_pool
+            .execute(sqlx::query(&format!(
+                "CREATE SCHEMA IF NOT EXISTS \"{}\"",
+                schema
+            )))
+            .await
+            .expect("create schema");
+
+        let schema_url = format!(
+            "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
+            db_user,
+            db_password,
+            db_host,
+            db_port,
+            db_name,
+            urlencoding::encode(&schema)
+        );
+
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+
+        sqlx::migrate!("../core/migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let service = create_service(FerriskeyConfig {
+            webapp_url: WEBAPP_URL.to_string(),
+            database: DatabaseConfig {
+                host: db_host,
+                port: db_port,
+                username: db_user,
+                password: db_password,
+                name: db_name,
+                schema: schema.clone(),
+            },
+        })
+        .await
+        .expect("create service");
+
+        service
+            .initialize_application(StartupConfig {
+                webapp_url: WEBAPP_URL.to_string(),
+                master_realm_name: MASTER_REALM.to_string(),
+                admin_username: MASTER_ADMIN_USERNAME.to_string(),
+                admin_password: MASTER_ADMIN_PASSWORD.to_string(),
+                admin_email: "admin@test.local".to_string(),
+                default_client_id: SEEDED_CLIENT_ID.to_string(),
+            })
+            .await
+            .expect("initialize application");
+
+        let args = Arc::new(Args::default());
+        let state = AppState::new(args, service);
+        let app = router(state).expect("build router");
+
+        let ctx = SharedContext {
+            app: std::sync::Mutex::new(app),
+        };
+
+        seed_tenants(&ctx).await;
+
+        ctx
+    }
+
+    /// Build the two tenant realms and the attacker account. Runs once, inside
+    /// `init_shared_ctx`, before any test observes the context.
+    async fn seed_tenants(ctx: &SharedContext) {
+        let app = ctx.app.lock().expect("router mutex poisoned").clone();
+        let server = TestServer::new(app).expect("create test server");
+
+        let master = get_token(
+            &server,
+            MASTER_REALM,
+            MASTER_ADMIN_USERNAME,
+            MASTER_ADMIN_PASSWORD,
+        )
+        .await;
+
+        for realm in [TENANT_A, TENANT_B] {
+            let response = server
+                .post("/realms")
+                .add_header("Authorization", auth_header(&master))
+                .json(&json!({ "name": realm, "display_name": realm }))
+                .await;
+            assert_eq!(
+                response.status_code(),
+                201,
+                "creating realm {realm} failed: {}",
+                response.text()
+            );
+        }
+
+        // Alice: administrator of tenant-a only.
+        let response = server
+            .post(&format!("/realms/{TENANT_A}/users"))
+            .add_header("Authorization", auth_header(&master))
+            .json(&json!({
+                "username": ALICE_USERNAME,
+                "firstname": "Alice",
+                "lastname": "Tenant A",
+                "email": format!("{ALICE_USERNAME}@tenant-a.local"),
+                "email_verified": true,
+            }))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            200,
+            "creating alice failed: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        let alice_id = body["data"]["id"].as_str().expect("alice id").to_string();
+
+        let response = server
+            .put(&format!(
+                "/realms/{TENANT_A}/users/{alice_id}/reset-password"
+            ))
+            .add_header("Authorization", auth_header(&master))
+            .json(&json!({
+                "value": ALICE_PASSWORD,
+                "temporary": false,
+                "credential_type": "password",
+            }))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            200,
+            "setting alice's password failed: {}",
+            response.text()
+        );
+
+        // `can_view_client` accepts ManageRealm or ViewClients; the create / update /
+        // delete policies accept ManageRealm or ManageClients. Alice therefore needs
+        // both client permissions, and deliberately not ManageRealm.
+        let response = server
+            .post(&format!("/realms/{TENANT_A}/roles"))
+            .add_header("Authorization", auth_header(&master))
+            .json(&json!({
+                "name": "tenant-a-client-admin",
+                "description": "manage clients inside tenant-a",
+                "permissions": ["manage_clients", "view_clients"],
+            }))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            201,
+            "creating alice's role failed: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        let role_id = body["data"]["id"].as_str().expect("role id").to_string();
+
+        let response = server
+            .post(&format!(
+                "/realms/{TENANT_A}/users/{alice_id}/roles/{role_id}"
+            ))
+            .add_header("Authorization", auth_header(&master))
+            .json(&json!({}))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            200,
+            "assigning alice's role failed: {}",
+            response.text()
+        );
+
+        // Mint and discard one token per realm while seeding is still single
+        // threaded. `KeystoreRepository::get_or_generate_key` is a read-then-insert
+        // with no unique index on `jwt_keys.realm_id`, so the first *concurrent*
+        // logins to a cold realm each insert a key pair; `find().one()` then returns
+        // an arbitrary one and tokens signed with the other fail verification with a
+        // bare 401. Warming the key here keeps the tests from tripping over that
+        // unrelated race.
+        get_token(&server, TENANT_A, ALICE_USERNAME, ALICE_PASSWORD).await;
+    }
+
+    fn make_server() -> TestServer {
+        let app = shared_ctx()
+            .app
+            .lock()
+            .expect("router mutex poisoned")
+            .clone();
+        TestServer::new(app).expect("create test server")
+    }
+
+    fn auth_header(token: &str) -> HeaderValue {
+        format!("Bearer {}", token)
+            .parse()
+            .expect("bearer header is valid ASCII")
+    }
+
+    /// Direct-grant login through the realm's own `admin-cli`, which `create_realm`
+    /// seeds with `direct_access_grants_enabled`.
+    async fn get_token(server: &TestServer, realm: &str, username: &str, password: &str) -> String {
+        let response = server
+            .post(&format!("/realms/{realm}/protocol/openid-connect/token"))
+            .form(&[
+                ("grant_type", "password"),
+                ("client_id", "admin-cli"),
+                ("username", username),
+                ("password", password),
+            ])
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            200,
+            "token request for {username}@{realm} failed: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        body["access_token"]
+            .as_str()
+            .expect("access_token in response")
+            .to_string()
+    }
+
+    async fn master_token(server: &TestServer) -> String {
+        get_token(
+            server,
+            MASTER_REALM,
+            MASTER_ADMIN_USERNAME,
+            MASTER_ADMIN_PASSWORD,
+        )
+        .await
+    }
+
+    async fn alice_token(server: &TestServer) -> String {
+        get_token(server, TENANT_A, ALICE_USERNAME, ALICE_PASSWORD).await
+    }
+
+    struct VictimClient {
+        uuid: String,
+        secret: String,
+    }
+
+    /// Create a confidential client in `tenant-b` — confidential so the repository
+    /// generates a secret — harden it with `require_pkce`, and register one redirect
+    /// URI so the injection test has a baseline to compare against.
+    ///
+    /// Each test gets its own victim: the deletion test would otherwise destroy the
+    /// fixture the others depend on.
+    async fn create_victim_client(server: &TestServer, master: &str) -> VictimClient {
+        let client_id = format!("victim-{}", Uuid::new_v4().simple());
+
+        let response = server
+            .post(&format!("/realms/{TENANT_B}/clients"))
+            .add_header("Authorization", auth_header(master))
+            .json(&json!({
+                "client_id": client_id,
+                "name": "Tenant B confidential client",
+                "client_type": "confidential",
+                "protocol": "openid-connect",
+                "public_client": false,
+                "service_account_enabled": false,
+                "direct_access_grants_enabled": false,
+                "enabled": true,
+                "oauth_device_code_grant_enabled": false,
+            }))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            201,
+            "creating the victim client failed: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        let uuid = body["id"].as_str().expect("victim client id").to_string();
+
+        // `create_client` always persists `require_pkce: false`; the update attack
+        // needs it on so that flipping it off is an observable weakening.
+        let response = server
+            .patch(&format!("/realms/{TENANT_B}/clients/{uuid}"))
+            .add_header("Authorization", auth_header(master))
+            .json(&json!({ "require_pkce": true }))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            200,
+            "hardening the victim client failed: {}",
+            response.text()
+        );
+
+        let response = server
+            .post(&format!("/realms/{TENANT_B}/clients/{uuid}/redirects"))
+            .add_header("Authorization", auth_header(master))
+            .json(&json!({ "value": "https://tenant-b.example/callback", "enabled": true }))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            201,
+            "registering the victim's redirect URI failed: {}",
+            response.text()
+        );
+
+        let client = read_victim_client(server, master, &uuid).await;
+        let secret = client["secret"]
+            .as_str()
+            .expect("a confidential client carries a secret")
+            .to_string();
+        assert!(
+            !secret.is_empty(),
+            "the victim client must carry a non-empty secret for the leak assertion to mean anything"
+        );
+
+        VictimClient { uuid, secret }
+    }
+
+    /// Read a `tenant-b` client back through the master admin, whose cross-realm
+    /// access is intentional. This is the oracle every side-effect assertion uses.
+    async fn read_victim_client(server: &TestServer, master: &str, uuid: &str) -> Value {
+        let response = server
+            .get(&format!("/realms/{TENANT_B}/clients/{uuid}"))
+            .add_header("Authorization", auth_header(master))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            200,
+            "master admin could not read the victim client {uuid}: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        body["data"].clone()
+    }
+
+    async fn read_victim_redirect_uris(
+        server: &TestServer,
+        master: &str,
+        uuid: &str,
+    ) -> Vec<String> {
+        let response = server
+            .get(&format!("/realms/{TENANT_B}/clients/{uuid}/redirects"))
+            .add_header("Authorization", auth_header(master))
+            .await;
+        assert_eq!(
+            response.status_code(),
+            200,
+            "master admin could not list the victim's redirect URIs: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        body.as_array()
+            .expect("redirect URI list")
+            .iter()
+            .map(|uri| uri["value"].as_str().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test client_cross_realm_test -- --ignored"]
+    fn tenant_admin_cannot_read_another_tenants_client_secret() {
+        // The headline exploit. `Client.secret` is unhashed and serialized in the
+        // clear, so a successful read hands the attacker credentials replayable on
+        // tenant-b's own token endpoint.
+        rt().block_on(async {
+            let server = make_server();
+            let master = master_token(&server).await;
+            let victim = create_victim_client(&server, &master).await;
+            let alice = alice_token(&server).await;
+
+            let response = server
+                .get(&format!("/realms/{TENANT_A}/clients/{}", victim.uuid))
+                .add_header("Authorization", auth_header(&alice))
+                .await;
+
+            let status = response.status_code();
+            let body = response.text();
+
+            // Asserted before the status code: on the vulnerable build this is the
+            // failure that carries the stolen secret into the test output.
+            assert!(
+                !body.contains(&victim.secret),
+                "FK-005: the tenant-a administrator read tenant-b's client secret \
+                 ({secret}). HTTP {status}, body: {body}",
+                secret = victim.secret,
+            );
+            assert!(
+                !body.contains(&victim.uuid),
+                "FK-005: tenant-a received tenant-b's client representation. \
+                 HTTP {status}, body: {body}",
+            );
+            assert_eq!(
+                status, 404,
+                "expected 404 for a client outside the URL realm, body: {body}",
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test client_cross_realm_test -- --ignored"]
+    fn tenant_admin_cannot_weaken_another_tenants_client() {
+        // Turning `require_pkce` off on someone else's confidential client removes
+        // the defence that makes a stolen authorization code useless.
+        rt().block_on(async {
+            let server = make_server();
+            let master = master_token(&server).await;
+            let victim = create_victim_client(&server, &master).await;
+            let alice = alice_token(&server).await;
+
+            let response = server
+                .patch(&format!("/realms/{TENANT_A}/clients/{}", victim.uuid))
+                .add_header("Authorization", auth_header(&alice))
+                .json(&json!({
+                    "require_pkce": false,
+                    "direct_access_grants_enabled": true,
+                }))
+                .await;
+
+            let status = response.status_code();
+            let body = response.text();
+            assert_eq!(
+                status, 404,
+                "expected 404 when updating a client outside the URL realm, body: {body}",
+            );
+
+            let client = read_victim_client(&server, &master, &victim.uuid).await;
+            assert_eq!(
+                client["require_pkce"].as_bool(),
+                Some(true),
+                "FK-005: tenant-a turned require_pkce off on tenant-b's client. \
+                 Attack returned HTTP {status}; client is now {client}",
+            );
+            assert_eq!(
+                client["direct_access_grants_enabled"].as_bool(),
+                Some(false),
+                "FK-005: tenant-a enabled direct access grants on tenant-b's client. \
+                 Attack returned HTTP {status}; client is now {client}",
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test client_cross_realm_test -- --ignored"]
+    fn tenant_admin_cannot_delete_another_tenants_client() {
+        // The delete cascades onto roles, the service account, scope mappings and
+        // post-logout redirect URIs — deleting a realm's console client takes its
+        // administration UI offline.
+        rt().block_on(async {
+            let server = make_server();
+            let master = master_token(&server).await;
+            let victim = create_victim_client(&server, &master).await;
+            let alice = alice_token(&server).await;
+
+            let response = server
+                .delete(&format!("/realms/{TENANT_A}/clients/{}", victim.uuid))
+                .add_header("Authorization", auth_header(&alice))
+                .await;
+
+            let status = response.status_code();
+            let body = response.text();
+            assert_eq!(
+                status, 404,
+                "expected 404 when deleting a client outside the URL realm, body: {body}",
+            );
+
+            // The oracle doubles as the survival check: it asserts a 200 itself.
+            let client = read_victim_client(&server, &master, &victim.uuid).await;
+            assert_eq!(
+                client["id"].as_str(),
+                Some(victim.uuid.as_str()),
+                "FK-005: tenant-b's client did not survive the cross-realm delete. \
+                 Attack returned HTTP {status}",
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test client_cross_realm_test -- --ignored"]
+    fn tenant_admin_cannot_inject_a_redirect_uri_into_another_tenants_client() {
+        // Registering a redirect URI on a victim client is the delivery half of an
+        // authorization-code hijack.
+        rt().block_on(async {
+            let server = make_server();
+            let master = master_token(&server).await;
+            let victim = create_victim_client(&server, &master).await;
+            let alice = alice_token(&server).await;
+
+            let before = read_victim_redirect_uris(&server, &master, &victim.uuid).await;
+            let hostile = "https://attacker.tenant-a.example/steal";
+
+            let response = server
+                .post(&format!(
+                    "/realms/{TENANT_A}/clients/{}/redirects",
+                    victim.uuid
+                ))
+                .add_header("Authorization", auth_header(&alice))
+                .json(&json!({ "value": hostile, "enabled": true }))
+                .await;
+
+            let status = response.status_code();
+            let body = response.text();
+            assert_eq!(
+                status, 404,
+                "expected 404 when adding a redirect URI to a client outside the URL \
+                 realm, body: {body}",
+            );
+
+            let after = read_victim_redirect_uris(&server, &master, &victim.uuid).await;
+            assert!(
+                !after.iter().any(|uri| uri == hostile),
+                "FK-005: tenant-a injected {hostile} into tenant-b's client. \
+                 Attack returned HTTP {status}; redirect URIs are now {after:?}",
+            );
+            assert_eq!(
+                before, after,
+                "the victim's redirect URI list changed. Attack returned HTTP {status}",
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test client_cross_realm_test -- --ignored"]
+    fn tenant_admin_retains_full_control_of_their_own_clients() {
+        // Non-regression. Without this, a fix that simply denied every client
+        // operation would look like a success above.
+        rt().block_on(async {
+            let server = make_server();
+            let alice = alice_token(&server).await;
+            let client_id = format!("own-{}", Uuid::new_v4().simple());
+
+            let response = server
+                .post(&format!("/realms/{TENANT_A}/clients"))
+                .add_header("Authorization", auth_header(&alice))
+                .json(&json!({
+                    "client_id": client_id,
+                    "name": "Tenant A own client",
+                    "client_type": "confidential",
+                    "protocol": "openid-connect",
+                    "public_client": false,
+                    "service_account_enabled": false,
+                    "direct_access_grants_enabled": false,
+                    "enabled": true,
+                    "oauth_device_code_grant_enabled": false,
+                }))
+                .await;
+            assert_eq!(
+                response.status_code(),
+                201,
+                "alice could not create a client in her own realm: {}",
+                response.text()
+            );
+            let body: Value = response.json();
+            let uuid = body["id"].as_str().expect("own client id").to_string();
+
+            // Read: she still sees her own client, secret included.
+            let response = server
+                .get(&format!("/realms/{TENANT_A}/clients/{uuid}"))
+                .add_header("Authorization", auth_header(&alice))
+                .await;
+            assert_eq!(
+                response.status_code(),
+                200,
+                "alice could not read her own client: {}",
+                response.text()
+            );
+            let body: Value = response.json();
+            assert!(
+                body["data"]["secret"]
+                    .as_str()
+                    .is_some_and(|s| !s.is_empty()),
+                "alice's own confidential client should expose its secret to her: {body}"
+            );
+
+            // Update.
+            let response = server
+                .patch(&format!("/realms/{TENANT_A}/clients/{uuid}"))
+                .add_header("Authorization", auth_header(&alice))
+                .json(&json!({ "require_pkce": true }))
+                .await;
+            assert_eq!(
+                response.status_code(),
+                200,
+                "alice could not update her own client: {}",
+                response.text()
+            );
+            let body: Value = response.json();
+            assert_eq!(
+                body["data"]["require_pkce"].as_bool(),
+                Some(true),
+                "alice's update did not take effect: {body}"
+            );
+
+            // Sub-resource: the realm binding must not break child writes.
+            let response = server
+                .post(&format!("/realms/{TENANT_A}/clients/{uuid}/redirects"))
+                .add_header("Authorization", auth_header(&alice))
+                .json(&json!({ "value": "https://tenant-a.example/callback", "enabled": true }))
+                .await;
+            assert_eq!(
+                response.status_code(),
+                201,
+                "alice could not register a redirect URI on her own client: {}",
+                response.text()
+            );
+
+            // Delete, then confirm it is really gone.
+            let response = server
+                .delete(&format!("/realms/{TENANT_A}/clients/{uuid}"))
+                .add_header("Authorization", auth_header(&alice))
+                .await;
+            assert_eq!(
+                response.status_code(),
+                200,
+                "alice could not delete her own client: {}",
+                response.text()
+            );
+
+            let response = server
+                .get(&format!("/realms/{TENANT_A}/clients/{uuid}"))
+                .add_header("Authorization", auth_header(&alice))
+                .await;
+            assert_eq!(
+                response.status_code(),
+                404,
+                "the deleted client is still readable: {}",
+                response.text()
+            );
+        });
+    }
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ ferriskey-organization = { path = "../libs/ferriskey-organization", features = [
 ferriskey-domain = { path = "../libs/ferriskey-domain", features = ["mock"] }
 ferriskey-security = { path = "../libs/ferriskey-security", features = ["mock"] }
 ferriskey-trident = { path = "../libs/ferriskey-trident" }
-ferriskey-aegis = { path = "../libs/ferriskey-aegis" }
+ferriskey-aegis = { path = "../libs/ferriskey-aegis", features = ["mock"] }
 ferriskey-mail = { path = "../libs/ferriskey-mail", features = ["mock"] }
 ferriskey-compass = { path = "../libs/ferriskey-compass" }
 ferriskey-seawatch = { path = "../libs/ferriskey-seawatch", features = ["mock"] }

--- a/core/src/application/email_template/mod.rs
+++ b/core/src/application/email_template/mod.rs
@@ -1,5 +1,3 @@
-use uuid::Uuid;
-
 use crate::{
     ApplicationService,
     domain::{
@@ -9,7 +7,8 @@ use crate::{
             entities::EmailTemplate,
             ports::{
                 CreateEmailTemplateInput, DeleteEmailTemplateInput, EmailTemplateService,
-                GetEmailTemplateInput, GetEmailTemplatesInput, UpdateEmailTemplateInput,
+                GetEmailTemplateInput, GetEmailTemplatesInput, RenderEmailTemplateInput,
+                UpdateEmailTemplateInput,
             },
         },
     },
@@ -66,9 +65,13 @@ impl EmailTemplateService for ApplicationService {
             .await
     }
 
-    async fn render_template_html(&self, template_id: Uuid) -> Result<String, CoreError> {
+    async fn render_template_html(
+        &self,
+        identity: Identity,
+        input: RenderEmailTemplateInput,
+    ) -> Result<String, CoreError> {
         self.email_template_service
-            .render_template_html(template_id)
+            .render_template_html(identity, input)
             .await
     }
 }

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -460,6 +460,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
         ),
         scope_mapping_service: ScopeMappingServiceImpl::new(
             realm.clone(),
+            client.clone(),
             client_scope.clone(),
             scope_mapping.clone(),
             policy.clone(),

--- a/core/src/domain/abyss/broker_services.rs
+++ b/core/src/domain/abyss/broker_services.rs
@@ -523,7 +523,7 @@ where
 
         let client = self
             .client_repository
-            .get_by_id(broker_session.client_id)
+            .get_by_id(broker_session.realm_id, broker_session.client_id)
             .await?;
 
         let oauth_config: OAuthProviderConfig = idp.config.clone().try_into()?;

--- a/core/src/domain/aegis/mod.rs
+++ b/core/src/domain/aegis/mod.rs
@@ -4,11 +4,6 @@ pub use ferriskey_aegis::entities;
 pub use ferriskey_aegis::ports;
 pub use ferriskey_aegis::value_objects;
 
-/// The aegis repository ports are `automock`ed in `ferriskey-aegis` behind its `mock`
-/// feature, which `core` enables. This module used to re-declare all four of them in
-/// hand-written `mockall::mock!` blocks; every port signature change then had to be
-/// copied here by hand, and a stale copy failed to compile long after the real trait
-/// had moved on. Re-export the generated mocks instead.
 #[cfg(test)]
 pub mod mocks {
     pub use ferriskey_aegis::ports::{

--- a/core/src/domain/aegis/mod.rs
+++ b/core/src/domain/aegis/mod.rs
@@ -4,114 +4,15 @@ pub use ferriskey_aegis::entities;
 pub use ferriskey_aegis::ports;
 pub use ferriskey_aegis::value_objects;
 
+/// The aegis repository ports are `automock`ed in `ferriskey-aegis` behind its `mock`
+/// feature, which `core` enables. This module used to re-declare all four of them in
+/// hand-written `mockall::mock!` blocks; every port signature change then had to be
+/// copied here by hand, and a stale copy failed to compile long after the real trait
+/// had moved on. Re-export the generated mocks instead.
 #[cfg(test)]
 pub mod mocks {
-    use mockall::mock;
-    use uuid::Uuid;
-
-    use crate::domain::common::entities::app_errors::CoreError;
-    use ferriskey_aegis::{
-        entities::{ClientScope, ClientScopeMapping, ProtocolMapper},
-        value_objects::{
-            CreateClientScopeRequest, CreateProtocolMapperRequest, UpdateClientScopeRequest,
-            UpdateProtocolMapperRequest,
-        },
+    pub use ferriskey_aegis::ports::{
+        MockClientScopeAttributeRepository, MockClientScopeMappingRepository,
+        MockClientScopeRepository, MockProtocolMapperRepository,
     };
-    use ferriskey_domain::realm::RealmId;
-
-    mock! {
-        pub ClientScopeRepository {}
-        impl ferriskey_aegis::ports::ClientScopeRepository for ClientScopeRepository {
-            fn create(
-                &self,
-                payload: CreateClientScopeRequest,
-            ) -> impl Future<Output = Result<ClientScope, CoreError>> + Send;
-
-            fn get_by_id(
-                &self,
-                id: Uuid,
-            ) -> impl Future<Output = Result<Option<ClientScope>, CoreError>> + Send;
-
-            fn find_by_realm_id(
-                &self,
-                realm_id: RealmId,
-            ) -> impl Future<Output = Result<Vec<ClientScope>, CoreError>> + Send;
-
-            fn find_by_name(
-                &self,
-                name: String,
-                realm_id: RealmId,
-            ) -> impl Future<Output = Result<Option<ClientScope>, CoreError>> + Send;
-
-            fn update_by_id(
-                &self,
-                id: Uuid,
-                payload: UpdateClientScopeRequest,
-            ) -> impl Future<Output = Result<ClientScope, CoreError>> + Send;
-
-            fn delete_by_id(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
-        }
-    }
-
-    mock! {
-        pub ClientScopeMappingRepository {}
-        impl ferriskey_aegis::ports::ClientScopeMappingRepository for ClientScopeMappingRepository {
-            fn assign_scope_to_client(
-                &self,
-                client_id: Uuid,
-                scope_id: Uuid,
-                is_default: bool,
-                is_optional: bool,
-            ) -> impl Future<Output = Result<ClientScopeMapping, CoreError>> + Send;
-
-            fn remove_scope_from_client(
-                &self,
-                client_id: Uuid,
-                scope_id: Uuid,
-            ) -> impl Future<Output = Result<(), CoreError>> + Send;
-
-            fn get_client_scopes(
-                &self,
-                client_id: Uuid,
-            ) -> impl Future<Output = Result<Vec<ferriskey_aegis::entities::ClientScopeMapping>, CoreError>> + Send;
-
-            fn get_default_scopes(
-                &self,
-                client_id: Uuid,
-            ) -> impl Future<Output = Result<Vec<ClientScope>, CoreError>> + Send;
-
-            fn get_optional_scopes(
-                &self,
-                client_id: Uuid,
-            ) -> impl Future<Output = Result<Vec<ClientScope>, CoreError>> + Send;
-        }
-    }
-
-    mock! {
-        pub ProtocolMapperRepository {}
-        impl ferriskey_aegis::ports::ProtocolMapperRepository for ProtocolMapperRepository {
-            fn create(
-                &self,
-                payload: CreateProtocolMapperRequest,
-            ) -> impl Future<Output = Result<ProtocolMapper, CoreError>> + Send;
-
-            fn get_by_id(
-                &self,
-                id: Uuid,
-            ) -> impl Future<Output = Result<Option<ProtocolMapper>, CoreError>> + Send;
-
-            fn get_by_scope_id(
-                &self,
-                scope_id: Uuid,
-            ) -> impl Future<Output = Result<Vec<ProtocolMapper>, CoreError>> + Send;
-
-            fn update_by_id(
-                &self,
-                id: Uuid,
-                payload: UpdateProtocolMapperRequest,
-            ) -> impl Future<Output = Result<ProtocolMapper, CoreError>> + Send;
-
-            fn delete_by_id(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
-        }
-    }
 }

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -3198,8 +3198,6 @@ where
                     CoreError::InvalidClient
                 })?;
 
-                // Bound to the realm the token was just verified against: a service
-                // account must not resolve to a client of another realm.
                 let client = self
                     .client_repository
                     .get_by_id(user.realm_id, client_id)

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -765,7 +765,7 @@ where
 
         let client = self
             .client_repository
-            .get_by_id(client_uuid)
+            .get_by_id(realm_id, client_uuid)
             .await
             .map_err(|_| CoreError::InvalidClient)?;
 
@@ -3198,7 +3198,12 @@ where
                     CoreError::InvalidClient
                 })?;
 
-                let client = self.client_repository.get_by_id(client_id).await?;
+                // Bound to the realm the token was just verified against: a service
+                // account must not resolve to a client of another realm.
+                let client = self
+                    .client_repository
+                    .get_by_id(user.realm_id, client_id)
+                    .await?;
 
                 Identity::Client(client)
             }

--- a/core/src/domain/client/ports.rs
+++ b/core/src/domain/client/ports.rs
@@ -2,10 +2,6 @@
 //! `RedirectUriRepository` use `#[cfg_attr(any(test, feature = "mock"), mockall::automock)]`;
 //! `core` enables ferriskey-domain's `mock` feature, so `MockClientRepository` /
 //! `MockRedirectUriRepository` come through this glob re-export (same convention as user/realm).
-//! `PostLogoutRedirectUriRepository` is a core-local port (no ferriskey-domain trait), so it lives
-//! here — with `automock` like every other port, not a hand-written `mock!`. The hand-written one
-//! silently drifted from the trait and had to be fixed by hand on every signature change. Gated on
-//! `test` alone, not on a `mock` feature: nothing outside `core` consumes this port.
 pub use ferriskey_domain::client::ports::*;
 use uuid::Uuid;
 
@@ -31,10 +27,6 @@ pub trait PostLogoutRedirectUriRepository: Send + Sync {
         client_id: Uuid,
     ) -> impl Future<Output = Result<Vec<RedirectUri>, CoreError>> + Send;
 
-    /// Update a redirect URI, **within `client_id` only**.
-    ///
-    /// The parent is a parameter rather than a caller-side check: without it a bare
-    /// `uri_id` reaches any client of any realm (FK-005).
     fn update_enabled(
         &self,
         client_id: Uuid,
@@ -42,7 +34,6 @@ pub trait PostLogoutRedirectUriRepository: Send + Sync {
         enabled: bool,
     ) -> impl Future<Output = Result<RedirectUri, CoreError>> + Send;
 
-    /// Delete a redirect URI, **within `client_id` only**. Same reason as above.
     fn delete(
         &self,
         client_id: Uuid,

--- a/core/src/domain/client/ports.rs
+++ b/core/src/domain/client/ports.rs
@@ -2,56 +2,17 @@
 //! `RedirectUriRepository` use `#[cfg_attr(any(test, feature = "mock"), mockall::automock)]`;
 //! `core` enables ferriskey-domain's `mock` feature, so `MockClientRepository` /
 //! `MockRedirectUriRepository` come through this glob re-export (same convention as user/realm).
-//! `PostLogoutRedirectUriRepository` is a core-local port (no ferriskey-domain trait), so it and
-//! its hand-written mock stay here.
+//! `PostLogoutRedirectUriRepository` is a core-local port (no ferriskey-domain trait), so it lives
+//! here — with `automock` like every other port, not a hand-written `mock!`. The hand-written one
+//! silently drifted from the trait and had to be fixed by hand on every signature change. Gated on
+//! `test` alone, not on a `mock` feature: nothing outside `core` consumes this port.
 pub use ferriskey_domain::client::ports::*;
 use uuid::Uuid;
 
 use crate::domain::common::entities::app_errors::CoreError;
 use ferriskey_domain::client::entities::redirect_uri::RedirectUri;
 
-#[cfg(test)]
-pub use mocks::MockPostLogoutRedirectUriRepository;
-
-#[cfg(test)]
-mod mocks {
-    use mockall::mock;
-    use uuid::Uuid;
-
-    use crate::domain::common::entities::app_errors::CoreError;
-    use ferriskey_domain::client::entities::redirect_uri::RedirectUri;
-
-    mock! {
-        pub PostLogoutRedirectUriRepository {}
-        impl super::PostLogoutRedirectUriRepository for PostLogoutRedirectUriRepository {
-            fn create_redirect_uri(
-                &self,
-                client_id: Uuid,
-                value: String,
-                enabled: bool,
-            ) -> impl Future<Output = Result<RedirectUri, CoreError>> + Send;
-
-            fn get_by_client_id(
-                &self,
-                client_id: Uuid,
-            ) -> impl Future<Output = Result<Vec<RedirectUri>, CoreError>> + Send;
-
-            fn get_enabled_by_client_id(
-                &self,
-                client_id: Uuid,
-            ) -> impl Future<Output = Result<Vec<RedirectUri>, CoreError>> + Send;
-
-            fn update_enabled(
-                &self,
-                id: Uuid,
-                enabled: bool,
-            ) -> impl Future<Output = Result<RedirectUri, CoreError>> + Send;
-
-            fn delete(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
-        }
-    }
-}
-
+#[cfg_attr(test, mockall::automock)]
 pub trait PostLogoutRedirectUriRepository: Send + Sync {
     fn create_redirect_uri(
         &self,
@@ -70,11 +31,21 @@ pub trait PostLogoutRedirectUriRepository: Send + Sync {
         client_id: Uuid,
     ) -> impl Future<Output = Result<Vec<RedirectUri>, CoreError>> + Send;
 
+    /// Update a redirect URI, **within `client_id` only**.
+    ///
+    /// The parent is a parameter rather than a caller-side check: without it a bare
+    /// `uri_id` reaches any client of any realm (FK-005).
     fn update_enabled(
         &self,
+        client_id: Uuid,
         id: Uuid,
         enabled: bool,
     ) -> impl Future<Output = Result<RedirectUri, CoreError>> + Send;
 
-    fn delete(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
+    /// Delete a redirect URI, **within `client_id` only**. Same reason as above.
+    fn delete(
+        &self,
+        client_id: Uuid,
+        id: Uuid,
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }

--- a/core/src/domain/client/services.rs
+++ b/core/src/domain/client/services.rs
@@ -21,7 +21,7 @@ use crate::domain::{
         generate_random_string,
         policies::{FerriskeyPolicy, ensure_policy},
     },
-    realm::ports::RealmRepository,
+    realm::{entities::Realm, ports::RealmRepository},
     role::{
         entities::Role,
         ports::{RolePolicy, RoleRepository},
@@ -38,6 +38,7 @@ use crate::domain::{
     },
 };
 use ferriskey_aegis::ports::{ClientScopeMappingRepository, ClientScopeRepository};
+use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub struct ClientServiceImpl<R, U, C, UR, W, RU, PLRU, RO, SE, CS, CSM>
@@ -110,6 +111,29 @@ where
             scope_mapping_repository,
             policy,
         }
+    }
+
+    /// Load a client, refusing to look outside `realm` (FK-005).
+    ///
+    /// Authorization is decided against the realm named in the URL, but the client
+    /// used to be fetched by bare UUID. A tenant administrator could therefore read
+    /// any other realm's client — **secret included**, since it is stored unhashed
+    /// and serialized in full — rewrite its security settings (`require_pkce`,
+    /// `direct_access_grants_enabled`), inject a redirect URI, or delete it outright,
+    /// cascading onto its roles, service account and scope mappings.
+    ///
+    /// The realm bound also lives in the SQL (`ClientRepository::get_by_id`); this
+    /// helper exists so sub-resource operations bind their parent before touching a
+    /// child by id.
+    async fn load_client_in_realm(
+        &self,
+        client_id: Uuid,
+        realm: &Realm,
+    ) -> Result<Client, CoreError> {
+        self.client_repository
+            .get_by_id(realm.id, client_id)
+            .await
+            .map_err(|_| CoreError::NotFound)
     }
 }
 
@@ -241,6 +265,8 @@ where
             self.policy.can_create_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         let redirect_uri = self
             .redirect_uri_repository
@@ -279,6 +305,8 @@ where
             self.policy.can_create_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         let redirect_uri = self
             .post_logout_redirect_uri_repository
@@ -317,6 +345,8 @@ where
             self.policy.can_create_role(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         let role = self
             .role_repository
@@ -373,9 +403,8 @@ where
         )?;
 
         self.client_repository
-            .delete_by_id(input.client_id)
-            .await
-            .map_err(|_| CoreError::InternalServerError)?;
+            .delete_by_id(realm_id, input.client_id)
+            .await?;
 
         self.webhook_repository
             .notify(
@@ -420,9 +449,11 @@ where
             self.policy.can_update_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.redirect_uri_repository
-            .delete(input.uri_id)
+            .delete(input.client_id, input.uri_id)
             .await
             .map_err(|_| CoreError::RedirectUriNotFound)?;
 
@@ -457,9 +488,11 @@ where
             self.policy.can_update_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.post_logout_redirect_uri_repository
-            .delete(input.uri_id)
+            .delete(input.client_id, input.uri_id)
             .await
             .map_err(|_| CoreError::RedirectUriNotFound)?;
 
@@ -495,9 +528,9 @@ where
         )?;
 
         self.client_repository
-            .get_by_id(input.client_id)
+            .get_by_id(realm.id, input.client_id)
             .await
-            .map_err(|_| CoreError::InvalidClient)
+            .map_err(|_| CoreError::NotFound)
     }
 
     async fn get_client_roles(
@@ -516,6 +549,8 @@ where
             self.policy.can_view_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.role_repository
             .get_by_client_id(input.client_id)
@@ -563,6 +598,8 @@ where
             self.policy.can_view_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.redirect_uri_repository
             .get_by_client_id(input.client_id)
@@ -586,6 +623,8 @@ where
             self.policy.can_view_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.post_logout_redirect_uri_repository
             .get_by_client_id(input.client_id)
@@ -613,7 +652,7 @@ where
 
         let client = self
             .client_repository
-            .update_client(input.client_id, input.payload)
+            .update_client(realm_id, input.client_id, input.payload)
             .await
             .map_err(|_| CoreError::NotFound)?;
 
@@ -648,10 +687,12 @@ where
             self.policy.can_update_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         let redirect_uri = self
             .redirect_uri_repository
-            .update_enabled(input.redirect_uri_id, input.enabled)
+            .update_enabled(input.client_id, input.redirect_uri_id, input.enabled)
             .await
             .map_err(|_| CoreError::NotFound)?;
 
@@ -686,10 +727,12 @@ where
             self.policy.can_update_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
+        // Bind the parent to the realm before touching any child by id.
+        self.load_client_in_realm(input.client_id, &realm).await?;
 
         let redirect_uri = self
             .post_logout_redirect_uri_repository
-            .update_enabled(input.redirect_uri_id, input.enabled)
+            .update_enabled(input.client_id, input.redirect_uri_id, input.enabled)
             .await
             .map_err(|_| CoreError::NotFound)?;
 

--- a/core/src/domain/client/services.rs
+++ b/core/src/domain/client/services.rs
@@ -113,18 +113,6 @@ where
         }
     }
 
-    /// Load a client, refusing to look outside `realm` (FK-005).
-    ///
-    /// Authorization is decided against the realm named in the URL, but the client
-    /// used to be fetched by bare UUID. A tenant administrator could therefore read
-    /// any other realm's client — **secret included**, since it is stored unhashed
-    /// and serialized in full — rewrite its security settings (`require_pkce`,
-    /// `direct_access_grants_enabled`), inject a redirect URI, or delete it outright,
-    /// cascading onto its roles, service account and scope mappings.
-    ///
-    /// The realm bound also lives in the SQL (`ClientRepository::get_by_id`); this
-    /// helper exists so sub-resource operations bind their parent before touching a
-    /// child by id.
     async fn load_client_in_realm(
         &self,
         client_id: Uuid,
@@ -265,7 +253,6 @@ where
             self.policy.can_create_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         let redirect_uri = self
@@ -305,7 +292,6 @@ where
             self.policy.can_create_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         let redirect_uri = self
@@ -345,7 +331,6 @@ where
             self.policy.can_create_role(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         let role = self
@@ -449,7 +434,6 @@ where
             self.policy.can_update_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.redirect_uri_repository
@@ -488,7 +472,6 @@ where
             self.policy.can_update_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.post_logout_redirect_uri_repository
@@ -549,7 +532,6 @@ where
             self.policy.can_view_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.role_repository
@@ -598,7 +580,6 @@ where
             self.policy.can_view_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.redirect_uri_repository
@@ -623,7 +604,6 @@ where
             self.policy.can_view_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         self.post_logout_redirect_uri_repository
@@ -687,7 +667,6 @@ where
             self.policy.can_update_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         let redirect_uri = self
@@ -727,7 +706,6 @@ where
             self.policy.can_update_client(&identity, &realm).await,
             "insufficient permissions",
         )?;
-        // Bind the parent to the realm before touching any child by id.
         self.load_client_in_realm(input.client_id, &realm).await?;
 
         let redirect_uri = self

--- a/core/src/domain/maintenance/services.rs
+++ b/core/src/domain/maintenance/services.rs
@@ -113,9 +113,11 @@ where
             "insufficient permissions to toggle maintenance",
         )?;
 
+        // FK-005: bound to the realm in the path, so maintenance cannot be toggled
+        // on another tenant's client — a denial of service on their authentication.
         let client = self
             .client_repository
-            .get_by_id(client_id)
+            .get_by_id(realm.id, client_id)
             .await
             .map_err(|_| CoreError::ClientNotFound)?;
 
@@ -136,7 +138,7 @@ where
         };
 
         self.client_repository
-            .update_client(client_id, update)
+            .update_client(realm.id, client_id, update)
             .await
             .map_err(|_| CoreError::InternalServerError)?;
 

--- a/core/src/domain/maintenance/services.rs
+++ b/core/src/domain/maintenance/services.rs
@@ -113,8 +113,6 @@ where
             "insufficient permissions to toggle maintenance",
         )?;
 
-        // FK-005: bound to the realm in the path, so maintenance cannot be toggled
-        // on another tenant's client — a denial of service on their authentication.
         let client = self
             .client_repository
             .get_by_id(realm.id, client_id)

--- a/core/src/domain/realm/services.rs
+++ b/core/src/domain/realm/services.rs
@@ -601,7 +601,9 @@ where
             .delete_by_name(&input.realm_name)
             .await?;
 
-        self.client_repository.delete_by_id(client.id).await?;
+        self.client_repository
+            .delete_by_id(realm_id, client.id)
+            .await?;
 
         Ok(())
     }

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -340,13 +340,17 @@ where
 
     async fn render_email_template(
         &self,
+        realm_id: Uuid,
         template_id: Uuid,
         user: &crate::domain::user::entities::User,
         extra_vars: &[(&str, &str)],
     ) -> Result<String, CoreError> {
+        // FK-005: the password-reset and magic-link mails render their template
+        // through here. Unscoped, another tenant's template could be rendered — and
+        // rewritten upstream to point `{{reset_link}}` at an attacker's domain.
         let template = self
             .email_template_repository
-            .get_by_id(template_id)
+            .get_by_id(realm_id, template_id)
             .await?
             .ok_or(CoreError::EmailTemplateNotFound)?;
 
@@ -1372,6 +1376,7 @@ where
 
                 let html_body = self
                     .render_email_template(
+                        realm.id.into(),
                         tid,
                         &user,
                         &[
@@ -1687,6 +1692,7 @@ where
 
                 let html_body = self
                     .render_email_template(
+                        realm.id.into(),
                         tid,
                         &user,
                         &[

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -345,9 +345,6 @@ where
         user: &crate::domain::user::entities::User,
         extra_vars: &[(&str, &str)],
     ) -> Result<String, CoreError> {
-        // FK-005: the password-reset and magic-link mails render their template
-        // through here. Unscoped, another tenant's template could be rendered — and
-        // rewritten upstream to point `{{reset_link}}` at an attacker's domain.
         let template = self
             .email_template_repository
             .get_by_id(realm_id, template_id)

--- a/core/src/infrastructure/aegis/repositories/client_scope_postgres_repository.rs
+++ b/core/src/infrastructure/aegis/repositories/client_scope_postgres_repository.rs
@@ -56,9 +56,14 @@ impl ClientScopeRepository for PostgresClientScopeRepository {
     }
 
     #[instrument(skip(self))]
-    async fn get_by_id(&self, id: Uuid) -> Result<Option<ClientScope>, CoreError> {
+    async fn get_by_id(
+        &self,
+        realm_id: RealmId,
+        id: Uuid,
+    ) -> Result<Option<ClientScope>, CoreError> {
         let model = client_scopes::Entity::find()
             .filter(client_scopes::Column::Id.eq(id))
+            .filter(client_scopes::Column::RealmId.eq::<Uuid>(realm_id.into()))
             .one(&self.db)
             .await
             .map_err(|e| {
@@ -105,11 +110,13 @@ impl ClientScopeRepository for PostgresClientScopeRepository {
     #[instrument(skip(self, payload))]
     async fn update_by_id(
         &self,
+        realm_id: RealmId,
         id: Uuid,
         payload: UpdateClientScopeRequest,
     ) -> Result<ClientScope, CoreError> {
         let model = client_scopes::Entity::find()
             .filter(client_scopes::Column::Id.eq(id))
+            .filter(client_scopes::Column::RealmId.eq::<Uuid>(realm_id.into()))
             .one(&self.db)
             .await
             .map_err(|e| {
@@ -151,9 +158,10 @@ impl ClientScopeRepository for PostgresClientScopeRepository {
     }
 
     #[instrument(skip(self))]
-    async fn delete_by_id(&self, id: Uuid) -> Result<(), CoreError> {
+    async fn delete_by_id(&self, realm_id: RealmId, id: Uuid) -> Result<(), CoreError> {
         let result = client_scopes::Entity::delete_many()
             .filter(client_scopes::Column::Id.eq(id))
+            .filter(client_scopes::Column::RealmId.eq::<Uuid>(realm_id.into()))
             .exec(&self.db)
             .await
             .map_err(|e| {

--- a/core/src/infrastructure/aegis/repositories/protocol_mapper_postgres_repository.rs
+++ b/core/src/infrastructure/aegis/repositories/protocol_mapper_postgres_repository.rs
@@ -53,9 +53,14 @@ impl ProtocolMapperRepository for PostgresProtocolMapperRepository {
     }
 
     #[instrument(skip(self))]
-    async fn get_by_id(&self, id: Uuid) -> Result<Option<ProtocolMapper>, CoreError> {
+    async fn get_by_id(
+        &self,
+        client_scope_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<ProtocolMapper>, CoreError> {
         let model = client_scope_protocol_mappers::Entity::find()
             .filter(client_scope_protocol_mappers::Column::Id.eq(id))
+            .filter(client_scope_protocol_mappers::Column::ClientScopeId.eq(client_scope_id))
             .one(&self.db)
             .await
             .map_err(|e| {
@@ -83,11 +88,13 @@ impl ProtocolMapperRepository for PostgresProtocolMapperRepository {
     #[instrument(skip(self, payload))]
     async fn update_by_id(
         &self,
+        client_scope_id: Uuid,
         id: Uuid,
         payload: UpdateProtocolMapperRequest,
     ) -> Result<ProtocolMapper, CoreError> {
         let model = client_scope_protocol_mappers::Entity::find()
             .filter(client_scope_protocol_mappers::Column::Id.eq(id))
+            .filter(client_scope_protocol_mappers::Column::ClientScopeId.eq(client_scope_id))
             .one(&self.db)
             .await
             .map_err(|e| {
@@ -120,9 +127,10 @@ impl ProtocolMapperRepository for PostgresProtocolMapperRepository {
     }
 
     #[instrument(skip(self))]
-    async fn delete_by_id(&self, id: Uuid) -> Result<(), CoreError> {
+    async fn delete_by_id(&self, client_scope_id: Uuid, id: Uuid) -> Result<(), CoreError> {
         let result = client_scope_protocol_mappers::Entity::delete_many()
             .filter(client_scope_protocol_mappers::Column::Id.eq(id))
+            .filter(client_scope_protocol_mappers::Column::ClientScopeId.eq(client_scope_id))
             .exec(&self.db)
             .await
             .map_err(|e| {

--- a/core/src/infrastructure/client/repositories/client_postgres_repository.rs
+++ b/core/src/infrastructure/client/repositories/client_postgres_repository.rs
@@ -87,9 +87,11 @@ impl ClientRepository for PostgresClientRepository {
         Ok(client)
     }
 
-    async fn get_by_id(&self, id: uuid::Uuid) -> Result<Client, CoreError> {
+    async fn get_by_id(&self, realm_id: RealmId, id: uuid::Uuid) -> Result<Client, CoreError> {
         let clients_model = ClientEntity::find()
             .filter(crate::entity::clients::Column::Id.eq(id))
+            // FK-005: the tenant bound lives in the query, so a foreign id yields no row.
+            .filter(crate::entity::clients::Column::RealmId.eq(Uuid::from(realm_id)))
             .find_with_related(crate::entity::redirect_uris::Entity)
             .all(&self.db)
             .await
@@ -127,11 +129,13 @@ impl ClientRepository for PostgresClientRepository {
 
     async fn update_client(
         &self,
+        realm_id: RealmId,
         client_id: Uuid,
         data: UpdateClientRequest,
     ) -> Result<Client, CoreError> {
         let client = ClientEntity::find()
             .filter(crate::entity::clients::Column::Id.eq(client_id))
+            .filter(crate::entity::clients::Column::RealmId.eq(Uuid::from(realm_id)))
             .one(&self.db)
             .await
             .map_err(|_| CoreError::InternalServerError)?
@@ -196,9 +200,10 @@ impl ClientRepository for PostgresClientRepository {
         Ok(client.into())
     }
 
-    async fn delete_by_id(&self, id: Uuid) -> Result<(), CoreError> {
+    async fn delete_by_id(&self, realm_id: RealmId, id: Uuid) -> Result<(), CoreError> {
         let result = ClientEntity::delete_many()
             .filter(crate::entity::clients::Column::Id.eq(id))
+            .filter(crate::entity::clients::Column::RealmId.eq(Uuid::from(realm_id)))
             .exec(&self.db)
             .await
             .map_err(|e| {
@@ -206,8 +211,10 @@ impl ClientRepository for PostgresClientRepository {
                 CoreError::InternalServerError
             })?;
 
+        // No row deleted now means "absent, or belonging to another realm" — the two
+        // must stay indistinguishable, hence `NotFound` rather than a 500.
         if result.rows_affected == 0 {
-            return Err(CoreError::InternalServerError);
+            return Err(CoreError::NotFound);
         }
 
         Ok(())

--- a/core/src/infrastructure/client/repositories/client_postgres_repository.rs
+++ b/core/src/infrastructure/client/repositories/client_postgres_repository.rs
@@ -90,7 +90,6 @@ impl ClientRepository for PostgresClientRepository {
     async fn get_by_id(&self, realm_id: RealmId, id: uuid::Uuid) -> Result<Client, CoreError> {
         let clients_model = ClientEntity::find()
             .filter(crate::entity::clients::Column::Id.eq(id))
-            // FK-005: the tenant bound lives in the query, so a foreign id yields no row.
             .filter(crate::entity::clients::Column::RealmId.eq(Uuid::from(realm_id)))
             .find_with_related(crate::entity::redirect_uris::Entity)
             .all(&self.db)
@@ -211,8 +210,6 @@ impl ClientRepository for PostgresClientRepository {
                 CoreError::InternalServerError
             })?;
 
-        // No row deleted now means "absent, or belonging to another realm" — the two
-        // must stay indistinguishable, hence `NotFound` rather than a 500.
         if result.rows_affected == 0 {
             return Err(CoreError::NotFound);
         }

--- a/core/src/infrastructure/client/repositories/post_logout_redirect_uri_postgres_repository.rs
+++ b/core/src/infrastructure/client/repositories/post_logout_redirect_uri_postgres_repository.rs
@@ -75,9 +75,17 @@ impl PostLogoutRedirectUriRepository for PostgresPostLogoutRedirectUriRepository
         Ok(redirect_uris)
     }
 
-    async fn update_enabled(&self, id: Uuid, enabled: bool) -> Result<RedirectUri, CoreError> {
+    async fn update_enabled(
+        &self,
+        client_id: Uuid,
+        id: Uuid,
+        enabled: bool,
+    ) -> Result<RedirectUri, CoreError> {
         let redirect_uri = crate::entity::post_logout_redirect_uris::Entity::find()
             .filter(crate::entity::post_logout_redirect_uris::Column::Id.eq(id))
+            // FK-005: the parent bound lives in the query, so a bare `id` cannot
+            // reach a URI belonging to another client — or another tenant.
+            .filter(crate::entity::post_logout_redirect_uris::Column::ClientId.eq(client_id))
             .one(&self.db)
             .await
             .map_err(|_| CoreError::RedirectUriNotFound)?;
@@ -99,11 +107,18 @@ impl PostLogoutRedirectUriRepository for PostgresPostLogoutRedirectUriRepository
         }
     }
 
-    async fn delete(&self, id: Uuid) -> Result<(), CoreError> {
-        crate::entity::post_logout_redirect_uris::Entity::delete_by_id(id)
+    async fn delete(&self, client_id: Uuid, id: Uuid) -> Result<(), CoreError> {
+        let result = crate::entity::post_logout_redirect_uris::Entity::delete_many()
+            .filter(crate::entity::post_logout_redirect_uris::Column::Id.eq(id))
+            .filter(crate::entity::post_logout_redirect_uris::Column::ClientId.eq(client_id))
             .exec(&self.db)
             .await
             .map_err(|_| CoreError::InternalServerError)?;
+
+        // Absent and "belongs to another client" must stay indistinguishable.
+        if result.rows_affected == 0 {
+            return Err(CoreError::RedirectUriNotFound);
+        }
 
         Ok(())
     }

--- a/core/src/infrastructure/client/repositories/post_logout_redirect_uri_postgres_repository.rs
+++ b/core/src/infrastructure/client/repositories/post_logout_redirect_uri_postgres_repository.rs
@@ -83,8 +83,6 @@ impl PostLogoutRedirectUriRepository for PostgresPostLogoutRedirectUriRepository
     ) -> Result<RedirectUri, CoreError> {
         let redirect_uri = crate::entity::post_logout_redirect_uris::Entity::find()
             .filter(crate::entity::post_logout_redirect_uris::Column::Id.eq(id))
-            // FK-005: the parent bound lives in the query, so a bare `id` cannot
-            // reach a URI belonging to another client — or another tenant.
             .filter(crate::entity::post_logout_redirect_uris::Column::ClientId.eq(client_id))
             .one(&self.db)
             .await
@@ -115,7 +113,6 @@ impl PostLogoutRedirectUriRepository for PostgresPostLogoutRedirectUriRepository
             .await
             .map_err(|_| CoreError::InternalServerError)?;
 
-        // Absent and "belongs to another client" must stay indistinguishable.
         if result.rows_affected == 0 {
             return Err(CoreError::RedirectUriNotFound);
         }

--- a/core/src/infrastructure/client/repositories/redirect_uri_postgres_repository.rs
+++ b/core/src/infrastructure/client/repositories/redirect_uri_postgres_repository.rs
@@ -77,9 +77,17 @@ impl RedirectUriRepository for PostgresRedirectUriRepository {
         Ok(redirect_uris)
     }
 
-    async fn update_enabled(&self, id: Uuid, enabled: bool) -> Result<RedirectUri, CoreError> {
+    async fn update_enabled(
+        &self,
+        client_id: Uuid,
+        id: Uuid,
+        enabled: bool,
+    ) -> Result<RedirectUri, CoreError> {
         let redirect_uri = RedirectUriEntity::find()
             .filter(crate::entity::redirect_uris::Column::Id.eq(id))
+            // FK-005: the parent bound lives in the query, so a bare `id` cannot
+            // reach a URI belonging to another client — or another tenant.
+            .filter(crate::entity::redirect_uris::Column::ClientId.eq(client_id))
             .one(&self.db)
             .await
             .map_err(|_| CoreError::RedirectUriNotFound)?;
@@ -101,11 +109,18 @@ impl RedirectUriRepository for PostgresRedirectUriRepository {
         }
     }
 
-    async fn delete(&self, id: Uuid) -> Result<(), CoreError> {
-        RedirectUriEntity::delete_by_id(id)
+    async fn delete(&self, client_id: Uuid, id: Uuid) -> Result<(), CoreError> {
+        let result = RedirectUriEntity::delete_many()
+            .filter(crate::entity::redirect_uris::Column::Id.eq(id))
+            .filter(crate::entity::redirect_uris::Column::ClientId.eq(client_id))
             .exec(&self.db)
             .await
             .map_err(|_| CoreError::InternalServerError)?;
+
+        // Absent and "belongs to another client" must stay indistinguishable.
+        if result.rows_affected == 0 {
+            return Err(CoreError::RedirectUriNotFound);
+        }
 
         Ok(())
     }

--- a/core/src/infrastructure/client/repositories/redirect_uri_postgres_repository.rs
+++ b/core/src/infrastructure/client/repositories/redirect_uri_postgres_repository.rs
@@ -85,8 +85,6 @@ impl RedirectUriRepository for PostgresRedirectUriRepository {
     ) -> Result<RedirectUri, CoreError> {
         let redirect_uri = RedirectUriEntity::find()
             .filter(crate::entity::redirect_uris::Column::Id.eq(id))
-            // FK-005: the parent bound lives in the query, so a bare `id` cannot
-            // reach a URI belonging to another client — or another tenant.
             .filter(crate::entity::redirect_uris::Column::ClientId.eq(client_id))
             .one(&self.db)
             .await
@@ -117,7 +115,6 @@ impl RedirectUriRepository for PostgresRedirectUriRepository {
             .await
             .map_err(|_| CoreError::InternalServerError)?;
 
-        // Absent and "belongs to another client" must stay indistinguishable.
         if result.rows_affected == 0 {
             return Err(CoreError::RedirectUriNotFound);
         }

--- a/core/src/infrastructure/email_template/repositories/email_template_repository.rs
+++ b/core/src/infrastructure/email_template/repositories/email_template_repository.rs
@@ -37,8 +37,13 @@ impl EmailTemplateRepository for PostgresEmailTemplateRepository {
             })
     }
 
-    async fn get_by_id(&self, template_id: Uuid) -> Result<Option<EmailTemplate>, CoreError> {
+    async fn get_by_id(
+        &self,
+        realm_id: Uuid,
+        template_id: Uuid,
+    ) -> Result<Option<EmailTemplate>, CoreError> {
         EmailTemplateEntity::find_by_id(template_id)
+            .filter(EmailTemplateColumn::RealmId.eq(realm_id))
             .one(&self.db)
             .await
             .map(|model| model.map(EmailTemplate::from))
@@ -82,12 +87,14 @@ impl EmailTemplateRepository for PostgresEmailTemplateRepository {
 
     async fn update(
         &self,
+        realm_id: Uuid,
         template_id: Uuid,
         name: String,
         structure: serde_json::Value,
         mjml: String,
     ) -> Result<EmailTemplate, CoreError> {
         let existing = EmailTemplateEntity::find_by_id(template_id)
+            .filter(EmailTemplateColumn::RealmId.eq(realm_id))
             .one(&self.db)
             .await
             .map_err(|e| {
@@ -112,8 +119,10 @@ impl EmailTemplateRepository for PostgresEmailTemplateRepository {
             })
     }
 
-    async fn delete(&self, template_id: Uuid) -> Result<(), CoreError> {
-        EmailTemplateEntity::delete_by_id(template_id)
+    async fn delete(&self, realm_id: Uuid, template_id: Uuid) -> Result<(), CoreError> {
+        EmailTemplateEntity::delete_many()
+            .filter(EmailTemplateColumn::Id.eq(template_id))
+            .filter(EmailTemplateColumn::RealmId.eq(realm_id))
             .exec(&self.db)
             .await
             .map(|_| ())

--- a/libs/ferriskey-aegis/Cargo.toml
+++ b/libs/ferriskey-aegis/Cargo.toml
@@ -12,6 +12,12 @@ serde_json = "1.0.149"
 tracing = "0.1.44"
 utoipa = { version = "5.4.0", features = ["uuid", "chrono"] }
 uuid = { version = "1.21.0", features = ["serde"] }
+mockall = { version = "0.14.0", optional = true }
 
 [dev-dependencies]
+ferriskey-domain = { path = "../ferriskey-domain", features = ["mock"] }
 mockall = "0.14.0"
+tokio = { version = "1", features = ["rt", "macros"] }
+
+[features]
+mock = ["mockall"]

--- a/libs/ferriskey-aegis/src/ports.rs
+++ b/libs/ferriskey-aegis/src/ports.rs
@@ -25,13 +25,6 @@ pub trait ClientScopeRepository: Send + Sync {
         payload: CreateClientScopeRequest,
     ) -> impl Future<Output = Result<ClientScope, CoreError>> + Send;
 
-    /// Load a client scope **within `realm_id` only** (FK-005).
-    ///
-    /// Authorization is decided against the realm named in the URL; fetching the
-    /// scope by bare UUID afterwards let a tenant administrator read the scopes —
-    /// and the protocol mappers — of any other realm. The realm belongs in the
-    /// query rather than in a caller-side check, so an id from another tenant
-    /// matches no row and no future caller can forget it.
     fn get_by_id(
         &self,
         realm_id: RealmId,
@@ -49,8 +42,6 @@ pub trait ClientScopeRepository: Send + Sync {
         realm_id: RealmId,
     ) -> impl Future<Output = Result<Option<ClientScope>, CoreError>> + Send;
 
-    /// Update a client scope **within `realm_id` only** (FK-005). An id from
-    /// another tenant updates no row and yields [`CoreError::NotFound`].
     fn update_by_id(
         &self,
         realm_id: RealmId,
@@ -58,8 +49,6 @@ pub trait ClientScopeRepository: Send + Sync {
         payload: UpdateClientScopeRequest,
     ) -> impl Future<Output = Result<ClientScope, CoreError>> + Send;
 
-    /// Delete a client scope **within `realm_id` only** (FK-005). An id from
-    /// another tenant deletes no row and yields [`CoreError::NotFound`].
     fn delete_by_id(
         &self,
         realm_id: RealmId,
@@ -95,12 +84,6 @@ pub trait ProtocolMapperRepository: Send + Sync {
         payload: CreateProtocolMapperRequest,
     ) -> impl Future<Output = Result<ProtocolMapper, CoreError>> + Send;
 
-    /// Load a mapper **within `client_scope_id` only** (FK-005).
-    ///
-    /// A mapper is a sub-resource of its scope, and the scope is what carries the
-    /// realm. Binding the query to the parent scope of the URL means a mapper id
-    /// belonging to any other scope — hence possibly to any other tenant —
-    /// matches no row.
     fn get_by_id(
         &self,
         client_scope_id: Uuid,
@@ -112,8 +95,6 @@ pub trait ProtocolMapperRepository: Send + Sync {
         scope_id: Uuid,
     ) -> impl Future<Output = Result<Vec<ProtocolMapper>, CoreError>> + Send;
 
-    /// Update a mapper **within `client_scope_id` only** (FK-005). A mapper of
-    /// another scope updates no row and yields [`CoreError::NotFound`].
     fn update_by_id(
         &self,
         client_scope_id: Uuid,
@@ -121,8 +102,6 @@ pub trait ProtocolMapperRepository: Send + Sync {
         payload: UpdateProtocolMapperRequest,
     ) -> impl Future<Output = Result<ProtocolMapper, CoreError>> + Send;
 
-    /// Delete a mapper **within `client_scope_id` only** (FK-005). A mapper of
-    /// another scope deletes no row and yields [`CoreError::NotFound`].
     fn delete_by_id(
         &self,
         client_scope_id: Uuid,

--- a/libs/ferriskey-aegis/src/ports.rs
+++ b/libs/ferriskey-aegis/src/ports.rs
@@ -18,15 +18,23 @@ use crate::{
     },
 };
 
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait ClientScopeRepository: Send + Sync {
     fn create(
         &self,
         payload: CreateClientScopeRequest,
     ) -> impl Future<Output = Result<ClientScope, CoreError>> + Send;
 
+    /// Load a client scope **within `realm_id` only** (FK-005).
+    ///
+    /// Authorization is decided against the realm named in the URL; fetching the
+    /// scope by bare UUID afterwards let a tenant administrator read the scopes —
+    /// and the protocol mappers — of any other realm. The realm belongs in the
+    /// query rather than in a caller-side check, so an id from another tenant
+    /// matches no row and no future caller can forget it.
     fn get_by_id(
         &self,
+        realm_id: RealmId,
         id: Uuid,
     ) -> impl Future<Output = Result<Option<ClientScope>, CoreError>> + Send;
 
@@ -41,16 +49,25 @@ pub trait ClientScopeRepository: Send + Sync {
         realm_id: RealmId,
     ) -> impl Future<Output = Result<Option<ClientScope>, CoreError>> + Send;
 
+    /// Update a client scope **within `realm_id` only** (FK-005). An id from
+    /// another tenant updates no row and yields [`CoreError::NotFound`].
     fn update_by_id(
         &self,
+        realm_id: RealmId,
         id: Uuid,
         payload: UpdateClientScopeRequest,
     ) -> impl Future<Output = Result<ClientScope, CoreError>> + Send;
 
-    fn delete_by_id(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
+    /// Delete a client scope **within `realm_id` only** (FK-005). An id from
+    /// another tenant deletes no row and yields [`CoreError::NotFound`].
+    fn delete_by_id(
+        &self,
+        realm_id: RealmId,
+        id: Uuid,
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }
 
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait ClientScopeAttributeRepository: Send + Sync {
     fn set_attribute(
         &self,
@@ -71,15 +88,22 @@ pub trait ClientScopeAttributeRepository: Send + Sync {
     ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }
 
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait ProtocolMapperRepository: Send + Sync {
     fn create(
         &self,
         payload: CreateProtocolMapperRequest,
     ) -> impl Future<Output = Result<ProtocolMapper, CoreError>> + Send;
 
+    /// Load a mapper **within `client_scope_id` only** (FK-005).
+    ///
+    /// A mapper is a sub-resource of its scope, and the scope is what carries the
+    /// realm. Binding the query to the parent scope of the URL means a mapper id
+    /// belonging to any other scope — hence possibly to any other tenant —
+    /// matches no row.
     fn get_by_id(
         &self,
+        client_scope_id: Uuid,
         id: Uuid,
     ) -> impl Future<Output = Result<Option<ProtocolMapper>, CoreError>> + Send;
 
@@ -88,16 +112,25 @@ pub trait ProtocolMapperRepository: Send + Sync {
         scope_id: Uuid,
     ) -> impl Future<Output = Result<Vec<ProtocolMapper>, CoreError>> + Send;
 
+    /// Update a mapper **within `client_scope_id` only** (FK-005). A mapper of
+    /// another scope updates no row and yields [`CoreError::NotFound`].
     fn update_by_id(
         &self,
+        client_scope_id: Uuid,
         id: Uuid,
         payload: UpdateProtocolMapperRequest,
     ) -> impl Future<Output = Result<ProtocolMapper, CoreError>> + Send;
 
-    fn delete_by_id(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
+    /// Delete a mapper **within `client_scope_id` only** (FK-005). A mapper of
+    /// another scope deletes no row and yields [`CoreError::NotFound`].
+    fn delete_by_id(
+        &self,
+        client_scope_id: Uuid,
+        id: Uuid,
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }
 
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait ClientScopeMappingRepository: Send + Sync {
     fn assign_scope_to_client(
         &self,

--- a/libs/ferriskey-aegis/src/services/client_scope_service.rs
+++ b/libs/ferriskey-aegis/src/services/client_scope_service.rs
@@ -136,7 +136,7 @@ where
 
         let mut client_scope = self
             .client_scope_repository
-            .get_by_id(input.scope_id)
+            .get_by_id(realm.id, input.scope_id)
             .await?
             .ok_or(CoreError::NotFound)?;
 
@@ -218,7 +218,7 @@ where
 
         let client_scope = self
             .client_scope_repository
-            .update_by_id(input.scope_id, input.payload)
+            .update_by_id(realm.id, input.scope_id, input.payload)
             .await?;
 
         Ok(client_scope)
@@ -251,9 +251,306 @@ where
         )?;
 
         self.client_scope_repository
-            .delete_by_id(input.scope_id)
+            .delete_by_id(realm.id, input.scope_id)
             .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ferriskey_domain::client::ports::MockClientRepository;
+    use ferriskey_domain::realm::Realm;
+    use ferriskey_domain::realm::ports::MockRealmRepository;
+    use ferriskey_domain::role::entities::Role;
+    use ferriskey_domain::user::ports::{MockUserRepository, MockUserRoleRepository};
+
+    use crate::ports::{MockClientScopeRepository, MockProtocolMapperRepository};
+    use crate::services::test_support::{
+        make_admin_role, make_realm, make_scope, make_user, mock_client_repository, mock_policy,
+        mock_realm_repository, row_in_realm,
+    };
+    use crate::value_objects::UpdateClientScopeRequest;
+
+    type TestService = ClientScopeServiceImpl<
+        MockRealmRepository,
+        MockUserRepository,
+        MockClientRepository,
+        MockUserRoleRepository,
+        MockClientScopeRepository,
+        MockProtocolMapperRepository,
+    >;
+
+    fn build_service(
+        realms: Vec<Realm>,
+        roles: Vec<Role>,
+        scope_repository: MockClientScopeRepository,
+        mapper_repository: MockProtocolMapperRepository,
+    ) -> TestService {
+        ClientScopeServiceImpl::new(
+            Arc::new(mock_realm_repository(realms)),
+            Arc::new(scope_repository),
+            Arc::new(mapper_repository),
+            mock_policy(roles, Arc::new(mock_client_repository(vec![]))),
+        )
+    }
+
+    /// FK-005: the scope lives in `tenant-b`, the request travels through
+    /// `tenant-a` — reading it must be indistinguishable from a missing scope.
+    #[tokio::test]
+    async fn get_client_scope_rejects_a_scope_from_another_realm() {
+        let realm_a = make_realm("tenant-a");
+        let realm_b = make_realm("tenant-b");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let foreign_scope = make_scope(realm_b.id);
+        let scope_id = foreign_scope.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&foreign_scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapper_repository = MockProtocolMapperRepository::new();
+        mapper_repository
+            .expect_get_by_scope_id()
+            .returning(|_| Box::pin(async { Ok(vec![]) }));
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            mapper_repository,
+        );
+
+        let result = service
+            .get_client_scope(
+                Identity::User(user),
+                GetClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn get_client_scope_returns_a_scope_of_the_path_realm() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapper_repository = MockProtocolMapperRepository::new();
+        mapper_repository
+            .expect_get_by_scope_id()
+            .returning(|_| Box::pin(async { Ok(vec![]) }));
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            mapper_repository,
+        );
+
+        let result = service
+            .get_client_scope(
+                Identity::User(user),
+                GetClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                },
+            )
+            .await;
+
+        assert_eq!(
+            result.expect("scope of the path realm is readable").id,
+            scope_id
+        );
+    }
+
+    /// FK-005: writing to a scope of another tenant must not be possible.
+    #[tokio::test]
+    async fn update_client_scope_rejects_a_scope_from_another_realm() {
+        let realm_a = make_realm("tenant-a");
+        let realm_b = make_realm("tenant-b");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let foreign_scope = make_scope(realm_b.id);
+        let scope_id = foreign_scope.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_update_by_id()
+            .returning(move |realm_id, id, _| {
+                let found = row_in_realm(&foreign_scope, realm_id, id);
+                Box::pin(async move { found.ok_or(CoreError::NotFound) })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            MockProtocolMapperRepository::new(),
+        );
+
+        let result = service
+            .update_client_scope(
+                Identity::User(user),
+                UpdateClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                    payload: UpdateClientScopeRequest {
+                        name: Some("hijacked".to_string()),
+                        description: None,
+                        protocol: None,
+                        is_default: None,
+                    },
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    /// Mirror of the test above, and the one that pins *which* realm travels to
+    /// the repository: it fails if the service forwards anything but the realm
+    /// of the path.
+    #[tokio::test]
+    async fn update_client_scope_updates_a_scope_of_the_path_realm() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_update_by_id()
+            .returning(move |realm_id, id, _| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { found.ok_or(CoreError::NotFound) })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            MockProtocolMapperRepository::new(),
+        );
+
+        let result = service
+            .update_client_scope(
+                Identity::User(user),
+                UpdateClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                    payload: UpdateClientScopeRequest {
+                        name: Some("renamed".to_string()),
+                        description: None,
+                        protocol: None,
+                        is_default: None,
+                    },
+                },
+            )
+            .await;
+
+        assert_eq!(
+            result.expect("a scope of the path realm is updatable").id,
+            scope_id
+        );
+    }
+
+    /// FK-005: deleting a scope of another tenant must not be possible.
+    #[tokio::test]
+    async fn delete_client_scope_rejects_a_scope_from_another_realm() {
+        let realm_a = make_realm("tenant-a");
+        let realm_b = make_realm("tenant-b");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let foreign_scope = make_scope(realm_b.id);
+        let scope_id = foreign_scope.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_delete_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&foreign_scope, realm_id, id);
+                Box::pin(async move { found.map(|_| ()).ok_or(CoreError::NotFound) })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            MockProtocolMapperRepository::new(),
+        );
+
+        let result = service
+            .delete_client_scope(
+                Identity::User(user),
+                DeleteClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    /// Same pinning as for the update: a wrong realm forwarded to the delete
+    /// would make this fail.
+    #[tokio::test]
+    async fn delete_client_scope_deletes_a_scope_of_the_path_realm() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_delete_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { found.map(|_| ()).ok_or(CoreError::NotFound) })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            MockProtocolMapperRepository::new(),
+        );
+
+        let result = service
+            .delete_client_scope(
+                Identity::User(user),
+                DeleteClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                },
+            )
+            .await;
+
+        result.expect("a scope of the path realm is deletable");
     }
 }

--- a/libs/ferriskey-aegis/src/services/mod.rs
+++ b/libs/ferriskey-aegis/src/services/mod.rs
@@ -2,6 +2,9 @@ pub mod client_scope_service;
 pub mod protocol_mapper_service;
 pub mod scope_mapping_service;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 pub use client_scope_service::ClientScopeServiceImpl;
 pub use protocol_mapper_service::ProtocolMapperServiceImpl;
 pub use scope_mapping_service::ScopeMappingServiceImpl;

--- a/libs/ferriskey-aegis/src/services/protocol_mapper_service.rs
+++ b/libs/ferriskey-aegis/src/services/protocol_mapper_service.rs
@@ -85,7 +85,7 @@ where
         )?;
 
         self.client_scope_repository
-            .get_by_id(input.scope_id)
+            .get_by_id(realm.id, input.scope_id)
             .await?
             .ok_or(CoreError::NotFound)?;
 
@@ -120,13 +120,13 @@ where
         )?;
 
         self.client_scope_repository
-            .get_by_id(input.scope_id)
+            .get_by_id(realm.id, input.scope_id)
             .await?
             .ok_or(CoreError::NotFound)?;
 
         let mapper = self
             .protocol_mapper_repository
-            .update_by_id(input.mapper_id, input.payload)
+            .update_by_id(input.scope_id, input.mapper_id, input.payload)
             .await?;
 
         Ok(mapper)
@@ -150,14 +150,363 @@ where
         )?;
 
         self.client_scope_repository
-            .get_by_id(input.scope_id)
+            .get_by_id(realm.id, input.scope_id)
             .await?
             .ok_or(CoreError::NotFound)?;
 
         self.protocol_mapper_repository
-            .delete_by_id(input.mapper_id)
+            .delete_by_id(input.scope_id, input.mapper_id)
             .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ferriskey_domain::client::ports::MockClientRepository;
+    use ferriskey_domain::realm::Realm;
+    use ferriskey_domain::realm::ports::MockRealmRepository;
+    use ferriskey_domain::role::entities::Role;
+    use ferriskey_domain::user::ports::{MockUserRepository, MockUserRoleRepository};
+    use uuid::Uuid;
+
+    use crate::ports::{MockClientScopeRepository, MockProtocolMapperRepository};
+    use crate::services::test_support::{
+        make_admin_role, make_mapper, make_realm, make_scope, make_user, mock_client_repository,
+        mock_policy, mock_realm_repository, row_in_realm, row_in_scope,
+    };
+    use crate::value_objects::UpdateProtocolMapperRequest;
+
+    type TestService = ProtocolMapperServiceImpl<
+        MockRealmRepository,
+        MockUserRepository,
+        MockClientRepository,
+        MockUserRoleRepository,
+        MockClientScopeRepository,
+        MockProtocolMapperRepository,
+    >;
+
+    fn build_service(
+        realms: Vec<Realm>,
+        roles: Vec<Role>,
+        scope_repository: MockClientScopeRepository,
+        mapper_repository: MockProtocolMapperRepository,
+    ) -> TestService {
+        ProtocolMapperServiceImpl::new(
+            Arc::new(mock_realm_repository(realms)),
+            Arc::new(scope_repository),
+            Arc::new(mapper_repository),
+            mock_policy(roles, Arc::new(mock_client_repository(vec![]))),
+        )
+    }
+
+    fn mapper_config() -> serde_json::Value {
+        serde_json::json!({ "claim.name": "realm_access.roles" })
+    }
+
+    /// FK-005: a mapper may not be grafted onto a scope of another tenant.
+    #[tokio::test]
+    async fn create_protocol_mapper_rejects_a_scope_from_another_realm() {
+        let realm_a = make_realm("tenant-a");
+        let realm_b = make_realm("tenant-b");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let foreign_scope = make_scope(realm_b.id);
+        let scope_id = foreign_scope.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&foreign_scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapper_repository = MockProtocolMapperRepository::new();
+        mapper_repository.expect_create().returning(move |payload| {
+            let mapper = make_mapper(payload.client_scope_id);
+            Box::pin(async move { Ok(mapper) })
+        });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            mapper_repository,
+        );
+
+        let result = service
+            .create_protocol_mapper(
+                Identity::User(user),
+                CreateProtocolMapperInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                    name: "forged-roles".to_string(),
+                    mapper_type: "oidc-hardcoded-claim-mapper".to_string(),
+                    config: mapper_config(),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    /// The mapper belongs to another scope than the one in the path: refuse it,
+    /// otherwise every mapper of the instance stays writable through any scope.
+    #[tokio::test]
+    async fn update_protocol_mapper_rejects_a_mapper_of_another_scope() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+        let foreign_mapper = make_mapper(Uuid::new_v4());
+        let mapper_id = foreign_mapper.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapper_repository = MockProtocolMapperRepository::new();
+        mapper_repository
+            .expect_update_by_id()
+            .returning(move |client_scope_id, id, _| {
+                let found = row_in_scope(&foreign_mapper, client_scope_id, id);
+                Box::pin(async move { found.ok_or(CoreError::NotFound) })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            mapper_repository,
+        );
+
+        let result = service
+            .update_protocol_mapper(
+                Identity::User(user),
+                UpdateProtocolMapperInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                    mapper_id,
+                    payload: UpdateProtocolMapperRequest {
+                        name: Some("hijacked".to_string()),
+                        mapper_type: None,
+                        config: None,
+                    },
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    /// Pins *which* parent id travels to the repository: forwarding anything but
+    /// the scope of the path makes this fail.
+    #[tokio::test]
+    async fn update_protocol_mapper_updates_a_mapper_of_the_path_scope() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+        let mapper = make_mapper(scope_id);
+        let mapper_id = mapper.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapper_repository = MockProtocolMapperRepository::new();
+        mapper_repository
+            .expect_update_by_id()
+            .returning(move |client_scope_id, id, _| {
+                let found = row_in_scope(&mapper, client_scope_id, id);
+                Box::pin(async move { found.ok_or(CoreError::NotFound) })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            mapper_repository,
+        );
+
+        let result = service
+            .update_protocol_mapper(
+                Identity::User(user),
+                UpdateProtocolMapperInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                    mapper_id,
+                    payload: UpdateProtocolMapperRequest {
+                        name: Some("renamed".to_string()),
+                        mapper_type: None,
+                        config: None,
+                    },
+                },
+            )
+            .await;
+
+        assert_eq!(
+            result.expect("a mapper of the path scope is updatable").id,
+            mapper_id
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_protocol_mapper_rejects_a_mapper_of_another_scope() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+        let foreign_mapper = make_mapper(Uuid::new_v4());
+        let mapper_id = foreign_mapper.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapper_repository = MockProtocolMapperRepository::new();
+        mapper_repository
+            .expect_delete_by_id()
+            .returning(move |client_scope_id, id| {
+                let found = row_in_scope(&foreign_mapper, client_scope_id, id);
+                Box::pin(async move { found.map(|_| ()).ok_or(CoreError::NotFound) })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            mapper_repository,
+        );
+
+        let result = service
+            .delete_protocol_mapper(
+                Identity::User(user),
+                DeleteProtocolMapperInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                    mapper_id,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    /// Same pinning as for the update.
+    #[tokio::test]
+    async fn delete_protocol_mapper_deletes_a_mapper_of_the_path_scope() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+        let mapper = make_mapper(scope_id);
+        let mapper_id = mapper.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapper_repository = MockProtocolMapperRepository::new();
+        mapper_repository
+            .expect_delete_by_id()
+            .returning(move |client_scope_id, id| {
+                let found = row_in_scope(&mapper, client_scope_id, id);
+                Box::pin(async move { found.map(|_| ()).ok_or(CoreError::NotFound) })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            mapper_repository,
+        );
+
+        let result = service
+            .delete_protocol_mapper(
+                Identity::User(user),
+                DeleteProtocolMapperInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                    mapper_id,
+                },
+            )
+            .await;
+
+        result.expect("a mapper of the path scope is deletable");
+    }
+
+    #[tokio::test]
+    async fn create_protocol_mapper_accepts_a_scope_of_the_path_realm() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapper_repository = MockProtocolMapperRepository::new();
+        mapper_repository.expect_create().returning(move |payload| {
+            let mapper = make_mapper(payload.client_scope_id);
+            Box::pin(async move { Ok(mapper) })
+        });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            scope_repository,
+            mapper_repository,
+        );
+
+        let result = service
+            .create_protocol_mapper(
+                Identity::User(user),
+                CreateProtocolMapperInput {
+                    realm_name: "tenant-a".to_string(),
+                    scope_id,
+                    name: "roles".to_string(),
+                    mapper_type: "oidc-usermodel-realm-role-mapper".to_string(),
+                    config: mapper_config(),
+                },
+            )
+            .await;
+
+        assert_eq!(
+            result
+                .expect("a mapper can be created on a scope of the path realm")
+                .client_scope_id,
+            scope_id
+        );
     }
 }

--- a/libs/ferriskey-aegis/src/services/scope_mapping_service.rs
+++ b/libs/ferriskey-aegis/src/services/scope_mapping_service.rs
@@ -14,8 +14,10 @@ use ferriskey_domain::auth::Identity;
 use ferriskey_domain::client::ports::ClientRepository;
 use ferriskey_domain::common::app_errors::CoreError;
 use ferriskey_domain::common::policies::{FerriskeyPolicy, ensure_policy};
+use ferriskey_domain::realm::RealmId;
 use ferriskey_domain::realm::ports::RealmRepository;
 use ferriskey_domain::user::ports::{UserRepository, UserRoleRepository};
+use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub struct ScopeMappingServiceImpl<R, U, C, UR, CS, CSM>
@@ -28,6 +30,7 @@ where
     CSM: ClientScopeMappingRepository,
 {
     realm_repository: Arc<R>,
+    client_repository: Arc<C>,
     client_scope_repository: Arc<CS>,
     scope_mapping_repository: Arc<CSM>,
     policy: Arc<FerriskeyPolicy<U, C, UR>>,
@@ -44,16 +47,51 @@ where
 {
     pub fn new(
         realm_repository: Arc<R>,
+        client_repository: Arc<C>,
         client_scope_repository: Arc<CS>,
         scope_mapping_repository: Arc<CSM>,
         policy: Arc<FerriskeyPolicy<U, C, UR>>,
     ) -> Self {
         Self {
             realm_repository,
+            client_repository,
             client_scope_repository,
             scope_mapping_repository,
             policy,
         }
+    }
+
+    /// Both ends of a scope mapping must belong to the realm named in the URL
+    /// (FK-005). Without this, a tenant administrator could graft one of his own
+    /// client scopes — mappers included — onto a client of another tenant, and
+    /// forge the claims of every token that client issues afterwards.
+    ///
+    /// Both lookups are realm-bound in the query, and a foreign id is reported as
+    /// [`CoreError::NotFound`] so the endpoint never becomes an existence oracle.
+    async fn ensure_client_in_realm(
+        &self,
+        realm_id: RealmId,
+        client_id: Uuid,
+    ) -> Result<(), CoreError> {
+        self.client_repository
+            .get_by_id(realm_id, client_id)
+            .await
+            .map_err(|_| CoreError::NotFound)?;
+
+        Ok(())
+    }
+
+    async fn ensure_scope_in_realm(
+        &self,
+        realm_id: RealmId,
+        scope_id: Uuid,
+    ) -> Result<(), CoreError> {
+        self.client_scope_repository
+            .get_by_id(realm_id, scope_id)
+            .await?
+            .ok_or(CoreError::NotFound)?;
+
+        Ok(())
     }
 }
 
@@ -93,10 +131,9 @@ where
             "insufficient permissions",
         )?;
 
-        self.client_scope_repository
-            .get_by_id(input.scope_id)
-            .await?
-            .ok_or(CoreError::NotFound)?;
+        self.ensure_client_in_realm(realm.id, input.client_id)
+            .await?;
+        self.ensure_scope_in_realm(realm.id, input.scope_id).await?;
 
         let mapping = self
             .scope_mapping_repository
@@ -138,6 +175,10 @@ where
             "insufficient permissions",
         )?;
 
+        self.ensure_client_in_realm(realm.id, input.client_id)
+            .await?;
+        self.ensure_scope_in_realm(realm.id, input.scope_id).await?;
+
         self.scope_mapping_repository
             .remove_scope_from_client(input.client_id, input.scope_id)
             .await?;
@@ -171,6 +212,9 @@ where
             "insufficient permissions",
         )?;
 
+        self.ensure_client_in_realm(realm.id, input.client_id)
+            .await?;
+
         let mut scopes = self
             .scope_mapping_repository
             .get_default_scopes(input.client_id)
@@ -183,6 +227,317 @@ where
 
         scopes.extend(optional_scopes);
 
+        // Defence in depth: a mapping created before this realm binding existed
+        // may still point at a scope of another tenant — never echo it back.
+        scopes.retain(|scope| scope.realm_id == realm.id);
+
         Ok(scopes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ferriskey_domain::client::entities::Client;
+    use ferriskey_domain::client::ports::MockClientRepository;
+    use ferriskey_domain::realm::Realm;
+    use ferriskey_domain::realm::ports::MockRealmRepository;
+    use ferriskey_domain::role::entities::Role;
+    use ferriskey_domain::user::ports::{MockUserRepository, MockUserRoleRepository};
+    use uuid::Uuid;
+
+    use crate::entities::ScopeType;
+    use crate::ports::{MockClientScopeMappingRepository, MockClientScopeRepository};
+    use crate::services::test_support::{
+        make_admin_role, make_client, make_realm, make_scope, make_user, mock_client_repository,
+        mock_policy, mock_realm_repository, row_in_realm,
+    };
+
+    type TestService = ScopeMappingServiceImpl<
+        MockRealmRepository,
+        MockUserRepository,
+        MockClientRepository,
+        MockUserRoleRepository,
+        MockClientScopeRepository,
+        MockClientScopeMappingRepository,
+    >;
+
+    fn build_service(
+        realms: Vec<Realm>,
+        roles: Vec<Role>,
+        clients: Vec<Client>,
+        scope_repository: MockClientScopeRepository,
+        mapping_repository: MockClientScopeMappingRepository,
+    ) -> TestService {
+        let client_repository = Arc::new(mock_client_repository(clients));
+
+        ScopeMappingServiceImpl::new(
+            Arc::new(mock_realm_repository(realms)),
+            client_repository.clone(),
+            Arc::new(scope_repository),
+            Arc::new(mapping_repository),
+            mock_policy(roles, client_repository),
+        )
+    }
+
+    /// FK-005, the claim-forgery half: a tenant admin must not be able to attach
+    /// one of *his* scopes — mappers included — to a client of another tenant.
+    #[tokio::test]
+    async fn assign_scope_to_client_rejects_a_client_from_another_realm() {
+        let realm_a = make_realm("tenant-a");
+        let realm_b = make_realm("tenant-b");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+        let foreign_client = make_client(Uuid::new_v4(), realm_b.id);
+        let client_id = foreign_client.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapping_repository = MockClientScopeMappingRepository::new();
+        mapping_repository
+            .expect_assign_scope_to_client()
+            .returning(move |client_id, scope_id, _, _| {
+                Box::pin(async move {
+                    Ok(ClientScopeMapping {
+                        client_id,
+                        scope_id,
+                        default_scope_type: ScopeType::Default,
+                    })
+                })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            vec![foreign_client],
+            scope_repository,
+            mapping_repository,
+        );
+
+        let result = service
+            .assign_scope_to_client(
+                Identity::User(user),
+                AssignClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    client_id,
+                    scope_id,
+                    is_default: true,
+                    is_optional: false,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    /// The other end of the same call: the client is local, the scope is not.
+    #[tokio::test]
+    async fn assign_scope_to_client_rejects_a_scope_from_another_realm() {
+        let realm_a = make_realm("tenant-a");
+        let realm_b = make_realm("tenant-b");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let foreign_scope = make_scope(realm_b.id);
+        let scope_id = foreign_scope.id;
+        let client = make_client(Uuid::new_v4(), realm_a.id);
+        let client_id = client.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&foreign_scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapping_repository = MockClientScopeMappingRepository::new();
+        mapping_repository
+            .expect_assign_scope_to_client()
+            .returning(move |client_id, scope_id, _, _| {
+                Box::pin(async move {
+                    Ok(ClientScopeMapping {
+                        client_id,
+                        scope_id,
+                        default_scope_type: ScopeType::Default,
+                    })
+                })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            vec![client],
+            scope_repository,
+            mapping_repository,
+        );
+
+        let result = service
+            .assign_scope_to_client(
+                Identity::User(user),
+                AssignClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    client_id,
+                    scope_id,
+                    is_default: true,
+                    is_optional: false,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn assign_scope_to_client_accepts_a_client_and_a_scope_of_the_path_realm() {
+        let realm_a = make_realm("tenant-a");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+        let client = make_client(Uuid::new_v4(), realm_a.id);
+        let client_id = client.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapping_repository = MockClientScopeMappingRepository::new();
+        mapping_repository
+            .expect_assign_scope_to_client()
+            .returning(move |client_id, scope_id, _, _| {
+                Box::pin(async move {
+                    Ok(ClientScopeMapping {
+                        client_id,
+                        scope_id,
+                        default_scope_type: ScopeType::Default,
+                    })
+                })
+            });
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            vec![client],
+            scope_repository,
+            mapping_repository,
+        );
+
+        let result = service
+            .assign_scope_to_client(
+                Identity::User(user),
+                AssignClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    client_id,
+                    scope_id,
+                    is_default: true,
+                    is_optional: false,
+                },
+            )
+            .await;
+
+        let mapping = result.expect("a local client accepts a local scope");
+        assert_eq!(mapping.client_id, client_id);
+        assert_eq!(mapping.scope_id, scope_id);
+    }
+
+    #[tokio::test]
+    async fn unassign_scope_from_client_rejects_a_client_from_another_realm() {
+        let realm_a = make_realm("tenant-a");
+        let realm_b = make_realm("tenant-b");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let scope = make_scope(realm_a.id);
+        let scope_id = scope.id;
+        let foreign_client = make_client(Uuid::new_v4(), realm_b.id);
+        let client_id = foreign_client.id;
+
+        let mut scope_repository = MockClientScopeRepository::new();
+        scope_repository
+            .expect_get_by_id()
+            .returning(move |realm_id, id| {
+                let found = row_in_realm(&scope, realm_id, id);
+                Box::pin(async move { Ok(found) })
+            });
+
+        let mut mapping_repository = MockClientScopeMappingRepository::new();
+        mapping_repository
+            .expect_remove_scope_from_client()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            vec![foreign_client],
+            scope_repository,
+            mapping_repository,
+        );
+
+        let result = service
+            .unassign_scope_from_client(
+                Identity::User(user),
+                UnassignClientScopeInput {
+                    realm_name: "tenant-a".to_string(),
+                    client_id,
+                    scope_id,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn get_client_scopes_rejects_a_client_from_another_realm() {
+        let realm_a = make_realm("tenant-a");
+        let realm_b = make_realm("tenant-b");
+        let user = make_user(&realm_a);
+        let role = make_admin_role(realm_a.id);
+        let foreign_client = make_client(Uuid::new_v4(), realm_b.id);
+        let client_id = foreign_client.id;
+        let foreign_scope = make_scope(realm_b.id);
+
+        let mut mapping_repository = MockClientScopeMappingRepository::new();
+        mapping_repository
+            .expect_get_default_scopes()
+            .returning(move |_| {
+                let scope = foreign_scope.clone();
+                Box::pin(async move { Ok(vec![scope]) })
+            });
+        mapping_repository
+            .expect_get_optional_scopes()
+            .returning(|_| Box::pin(async { Ok(vec![]) }));
+
+        let service = build_service(
+            vec![realm_a],
+            vec![role],
+            vec![foreign_client],
+            MockClientScopeRepository::new(),
+            mapping_repository,
+        );
+
+        let result = service
+            .get_client_scopes(
+                Identity::User(user),
+                GetClientClientScopesInput {
+                    realm_name: "tenant-a".to_string(),
+                    client_id,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CoreError::NotFound)));
     }
 }

--- a/libs/ferriskey-aegis/src/services/scope_mapping_service.rs
+++ b/libs/ferriskey-aegis/src/services/scope_mapping_service.rs
@@ -61,13 +61,6 @@ where
         }
     }
 
-    /// Both ends of a scope mapping must belong to the realm named in the URL
-    /// (FK-005). Without this, a tenant administrator could graft one of his own
-    /// client scopes — mappers included — onto a client of another tenant, and
-    /// forge the claims of every token that client issues afterwards.
-    ///
-    /// Both lookups are realm-bound in the query, and a foreign id is reported as
-    /// [`CoreError::NotFound`] so the endpoint never becomes an existence oracle.
     async fn ensure_client_in_realm(
         &self,
         realm_id: RealmId,
@@ -227,8 +220,6 @@ where
 
         scopes.extend(optional_scopes);
 
-        // Defence in depth: a mapping created before this realm binding existed
-        // may still point at a scope of another tenant — never echo it back.
         scopes.retain(|scope| scope.realm_id == realm.id);
 
         Ok(scopes)

--- a/libs/ferriskey-aegis/src/services/test_support.rs
+++ b/libs/ferriskey-aegis/src/services/test_support.rs
@@ -1,0 +1,209 @@
+//! Fixtures and mock builders shared by the aegis service unit tests.
+//!
+//! Both the aegis ports and the foreign domain ports are mocked with
+//! `mockall::automock`, so nothing here duplicates a trait definition. The
+//! builders only pre-program the handful of calls the authorization policy makes
+//! on the way to the code under test.
+//!
+//! [`row_in_realm`] and [`row_in_scope`] are the load-bearing pieces: they
+//! reproduce the `WHERE realm_id = $1` / `WHERE client_scope_id = $1` of the SQL
+//! adapters, so a service that hands the repository the wrong realm — or reaches
+//! a mapper through the wrong scope — fails the test instead of silently
+//! returning another tenant's row.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use ferriskey_domain::client::entities::{Client, ClientType, MaintenanceSessionStrategy};
+use ferriskey_domain::client::ports::MockClientRepository;
+use ferriskey_domain::common::app_errors::CoreError;
+use ferriskey_domain::common::policies::FerriskeyPolicy;
+use ferriskey_domain::realm::ports::MockRealmRepository;
+use ferriskey_domain::realm::{Realm, RealmId};
+use ferriskey_domain::role::entities::Role;
+use ferriskey_domain::user::entities::User;
+use ferriskey_domain::user::ports::{MockUserRepository, MockUserRoleRepository};
+
+use crate::entities::{ClientScope, ProtocolMapper, ScopeType};
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+pub(crate) fn make_realm(name: &str) -> Realm {
+    Realm {
+        id: RealmId::new(Uuid::new_v4()),
+        name: name.to_string(),
+        display_name: None,
+        settings: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+/// A user of `realm`, holding a role that grants `manage_client_scopes` — so the
+/// authorization policy passes and the tests observe the realm binding itself.
+pub(crate) fn make_user(realm: &Realm) -> User {
+    User {
+        id: Uuid::new_v4(),
+        realm_id: realm.id,
+        client_id: None,
+        username: "admin".to_string(),
+        firstname: None,
+        lastname: None,
+        email: None,
+        email_verified: true,
+        enabled: true,
+        roles: None,
+        realm: Some(realm.clone()),
+        required_actions: vec![],
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        failed_login_attempts: 0,
+        locked_until: None,
+    }
+}
+
+pub(crate) fn make_admin_role(realm_id: RealmId) -> Role {
+    Role {
+        id: Uuid::new_v4(),
+        name: "scope-admin".to_string(),
+        description: None,
+        permissions: vec!["manage_client_scopes".to_string()],
+        realm_id,
+        client_id: None,
+        client: None,
+        require_mfa: false,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+pub(crate) fn make_client(id: Uuid, realm_id: RealmId) -> Client {
+    Client {
+        id,
+        enabled: true,
+        client_id: "app".to_string(),
+        secret: None,
+        realm_id,
+        protocol: "openid-connect".to_string(),
+        public_client: false,
+        service_account_enabled: false,
+        direct_access_grants_enabled: false,
+        oauth_device_code_grant_enabled: false,
+        require_pkce: false,
+        client_type: ClientType::Confidential,
+        name: "app".to_string(),
+        redirect_uris: None,
+        access_token_lifetime: None,
+        refresh_token_lifetime: None,
+        id_token_lifetime: None,
+        temporary_token_lifetime: None,
+        maintenance_enabled: false,
+        maintenance_reason: None,
+        maintenance_session_strategy: MaintenanceSessionStrategy::Expire,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+pub(crate) fn make_scope(realm_id: RealmId) -> ClientScope {
+    ClientScope {
+        id: Uuid::new_v4(),
+        realm_id,
+        name: "profile".to_string(),
+        description: None,
+        protocol: "openid-connect".to_string(),
+        default_scope_type: ScopeType::Default,
+        attributes: None,
+        protocol_mappers: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+pub(crate) fn make_mapper(client_scope_id: Uuid) -> ProtocolMapper {
+    ProtocolMapper {
+        id: Uuid::new_v4(),
+        client_scope_id,
+        name: "forged-roles".to_string(),
+        mapper_type: "oidc-hardcoded-claim-mapper".to_string(),
+        config: serde_json::json!({ "claim.name": "realm_access.roles" }),
+        created_at: Utc::now(),
+    }
+}
+
+/// Emulates the realm-bound `SELECT … WHERE realm_id = $1 AND id = $2` of the
+/// SQL adapter: a scope of another realm matches no row.
+pub(crate) fn row_in_realm(
+    scope: &ClientScope,
+    realm_id: RealmId,
+    id: Uuid,
+) -> Option<ClientScope> {
+    (scope.realm_id == realm_id && scope.id == id).then(|| scope.clone())
+}
+
+/// Same thing one level down: a mapper is only reachable through its own scope.
+pub(crate) fn row_in_scope(
+    mapper: &ProtocolMapper,
+    client_scope_id: Uuid,
+    id: Uuid,
+) -> Option<ProtocolMapper> {
+    (mapper.client_scope_id == client_scope_id && mapper.id == id).then(|| mapper.clone())
+}
+
+// ─── mocks of the foreign domain ports ───────────────────────────────────────
+
+/// Resolves realms by name, the way the HTTP path realm is resolved.
+pub(crate) fn mock_realm_repository(realms: Vec<Realm>) -> MockRealmRepository {
+    let mut repository = MockRealmRepository::new();
+    repository.expect_get_by_name().returning(move |name| {
+        let found = realms.iter().find(|realm| realm.name == name).cloned();
+        Box::pin(async move { Ok(found) })
+    });
+    repository
+}
+
+/// Hands the policy the roles that grant the scope permissions.
+pub(crate) fn mock_user_role_repository(roles: Vec<Role>) -> MockUserRoleRepository {
+    let mut repository = MockUserRoleRepository::new();
+    repository.expect_get_user_roles().returning(move |_| {
+        let roles = roles.clone();
+        Box::pin(async move { Ok(roles) })
+    });
+    repository
+}
+
+/// Emulates the realm-bound client lookup of `ClientRepository::get_by_id`:
+/// an id that belongs to another realm matches no row, exactly like the
+/// `WHERE realm_id = $1` in the SQL adapter.
+pub(crate) fn mock_client_repository(clients: Vec<Client>) -> MockClientRepository {
+    let mut repository = MockClientRepository::new();
+    repository
+        .expect_get_by_id()
+        .returning(move |realm_id, id| {
+            let found = clients
+                .iter()
+                .find(|client| client.id == id && client.realm_id == realm_id)
+                .cloned();
+            Box::pin(async move { found.ok_or(CoreError::NotFound) })
+        });
+    repository
+}
+
+pub(crate) type TestPolicy =
+    FerriskeyPolicy<MockUserRepository, MockClientRepository, MockUserRoleRepository>;
+
+/// The tests authenticate as `Identity::User`, which the policy resolves from
+/// the identity itself — the user repository is never called, so it carries no
+/// expectation and any call would fail the test.
+pub(crate) fn mock_policy(
+    roles: Vec<Role>,
+    client_repository: Arc<MockClientRepository>,
+) -> Arc<TestPolicy> {
+    Arc::new(FerriskeyPolicy::new(
+        Arc::new(MockUserRepository::new()),
+        client_repository,
+        Arc::new(mock_user_role_repository(roles)),
+    ))
+}

--- a/libs/ferriskey-domain/src/client/ports.rs
+++ b/libs/ferriskey-domain/src/client/ports.rs
@@ -10,7 +10,7 @@ use crate::client::{
         UpdatePostLogoutRedirectUriInput, UpdateRedirectUriInput,
     },
     entities::{Client, redirect_uri::RedirectUri},
-    value_objects::{CreateClientRequest, CreateRedirectUriRequest, UpdateClientRequest},
+    value_objects::{CreateClientRequest, UpdateClientRequest},
 };
 use crate::common::app_errors::CoreError;
 use crate::realm::{Realm, RealmId};
@@ -131,7 +131,19 @@ pub trait ClientRepository: Send + Sync {
         realm_id: RealmId,
     ) -> impl Future<Output = Result<Client, CoreError>> + Send;
 
-    fn get_by_id(&self, id: Uuid) -> impl Future<Output = Result<Client, CoreError>> + Send;
+    /// Load a client **within `realm_id` only** (FK-005).
+    ///
+    /// Authorization is decided against the realm named in the URL; fetching the
+    /// client by bare UUID afterwards let a tenant administrator read, rewrite or
+    /// delete the clients of any other realm — secret included. The realm belongs in
+    /// the query rather than in a caller-side check, so an id from another tenant
+    /// matches no row and no future caller can forget it.
+    fn get_by_id(
+        &self,
+        realm_id: RealmId,
+        id: Uuid,
+    ) -> impl Future<Output = Result<Client, CoreError>> + Send;
+
     fn get_by_realm_id(
         &self,
         realm_id: RealmId,
@@ -139,38 +151,16 @@ pub trait ClientRepository: Send + Sync {
 
     fn update_client(
         &self,
+        realm_id: RealmId,
         client_id: Uuid,
         data: UpdateClientRequest,
     ) -> impl Future<Output = Result<Client, CoreError>> + Send;
 
-    fn delete_by_id(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
-}
-
-pub trait RedirectUriService: Send + Sync {
-    fn add_redirect_uri(
+    fn delete_by_id(
         &self,
-        payload: CreateRedirectUriRequest,
-        realm_name: String,
-        client_id: Uuid,
-    ) -> impl Future<Output = Result<RedirectUri, CoreError>> + Send;
-
-    fn get_by_client_id(
-        &self,
-        client_id: Uuid,
-    ) -> impl Future<Output = Result<Vec<RedirectUri>, CoreError>> + Send;
-
-    fn get_enabled_by_client_id(
-        &self,
-        client_id: Uuid,
-    ) -> impl Future<Output = Result<Vec<RedirectUri>, CoreError>> + Send;
-
-    fn update_enabled(
-        &self,
+        realm_id: RealmId,
         id: Uuid,
-        enabled: bool,
-    ) -> impl Future<Output = Result<RedirectUri, CoreError>> + Send;
-
-    fn delete(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }
 
 #[cfg_attr(any(test, feature = "mock"), mockall::automock)]
@@ -192,11 +182,21 @@ pub trait RedirectUriRepository: Send + Sync {
         client_id: Uuid,
     ) -> impl Future<Output = Result<Vec<RedirectUri>, CoreError>> + Send;
 
+    /// Update a redirect URI, **within `client_id` only**.
+    ///
+    /// The parent is a parameter rather than a caller-side check: without it a bare
+    /// `uri_id` reaches any client of any realm (FK-005).
     fn update_enabled(
         &self,
+        client_id: Uuid,
         id: Uuid,
         enabled: bool,
     ) -> impl Future<Output = Result<RedirectUri, CoreError>> + Send;
 
-    fn delete(&self, id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
+    /// Delete a redirect URI, **within `client_id` only**. Same reason as above.
+    fn delete(
+        &self,
+        client_id: Uuid,
+        id: Uuid,
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }

--- a/libs/ferriskey-domain/src/client/ports.rs
+++ b/libs/ferriskey-domain/src/client/ports.rs
@@ -131,13 +131,6 @@ pub trait ClientRepository: Send + Sync {
         realm_id: RealmId,
     ) -> impl Future<Output = Result<Client, CoreError>> + Send;
 
-    /// Load a client **within `realm_id` only** (FK-005).
-    ///
-    /// Authorization is decided against the realm named in the URL; fetching the
-    /// client by bare UUID afterwards let a tenant administrator read, rewrite or
-    /// delete the clients of any other realm — secret included. The realm belongs in
-    /// the query rather than in a caller-side check, so an id from another tenant
-    /// matches no row and no future caller can forget it.
     fn get_by_id(
         &self,
         realm_id: RealmId,
@@ -182,10 +175,6 @@ pub trait RedirectUriRepository: Send + Sync {
         client_id: Uuid,
     ) -> impl Future<Output = Result<Vec<RedirectUri>, CoreError>> + Send;
 
-    /// Update a redirect URI, **within `client_id` only**.
-    ///
-    /// The parent is a parameter rather than a caller-side check: without it a bare
-    /// `uri_id` reaches any client of any realm (FK-005).
     fn update_enabled(
         &self,
         client_id: Uuid,
@@ -193,7 +182,6 @@ pub trait RedirectUriRepository: Send + Sync {
         enabled: bool,
     ) -> impl Future<Output = Result<RedirectUri, CoreError>> + Send;
 
-    /// Delete a redirect URI, **within `client_id` only**. Same reason as above.
     fn delete(
         &self,
         client_id: Uuid,

--- a/libs/ferriskey-mail/src/email_template/ports.rs
+++ b/libs/ferriskey-mail/src/email_template/ports.rs
@@ -45,9 +45,6 @@ pub trait EmailTemplateService: Send + Sync {
     ) -> impl Future<Output = Result<String, CoreError>> + Send;
 }
 
-/// Every accessor is scoped by `realm_id`: a template id belonging to another realm
-/// must not match any row, so cross-realm access is indistinguishable from a template
-/// that does not exist (no existence oracle). Never add an unscoped accessor here.
 #[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait EmailTemplateRepository: Send + Sync {
     fn fetch_by_realm(

--- a/libs/ferriskey-mail/src/email_template/ports.rs
+++ b/libs/ferriskey-mail/src/email_template/ports.rs
@@ -40,10 +40,14 @@ pub trait EmailTemplateService: Send + Sync {
 
     fn render_template_html(
         &self,
-        template_id: Uuid,
+        identity: Identity,
+        input: RenderEmailTemplateInput,
     ) -> impl Future<Output = Result<String, CoreError>> + Send;
 }
 
+/// Every accessor is scoped by `realm_id`: a template id belonging to another realm
+/// must not match any row, so cross-realm access is indistinguishable from a template
+/// that does not exist (no existence oracle). Never add an unscoped accessor here.
 #[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait EmailTemplateRepository: Send + Sync {
     fn fetch_by_realm(
@@ -53,6 +57,7 @@ pub trait EmailTemplateRepository: Send + Sync {
 
     fn get_by_id(
         &self,
+        realm_id: Uuid,
         template_id: Uuid,
     ) -> impl Future<Output = Result<Option<EmailTemplate>, CoreError>> + Send;
 
@@ -67,13 +72,18 @@ pub trait EmailTemplateRepository: Send + Sync {
 
     fn update(
         &self,
+        realm_id: Uuid,
         template_id: Uuid,
         name: String,
         structure: serde_json::Value,
         mjml: String,
     ) -> impl Future<Output = Result<EmailTemplate, CoreError>> + Send;
 
-    fn delete(&self, template_id: Uuid) -> impl Future<Output = Result<(), CoreError>> + Send;
+    fn delete(
+        &self,
+        realm_id: Uuid,
+        template_id: Uuid,
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
 }
 
 /// Trait for rendering a builder structure JSON into an intermediate format (e.g. MJML)
@@ -125,6 +135,11 @@ pub struct UpdateEmailTemplateInput {
 }
 
 pub struct DeleteEmailTemplateInput {
+    pub realm_name: String,
+    pub template_id: Uuid,
+}
+
+pub struct RenderEmailTemplateInput {
     pub realm_name: String,
     pub template_id: Uuid,
 }

--- a/libs/ferriskey-mail/src/email_template/services.rs
+++ b/libs/ferriskey-mail/src/email_template/services.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 
-use uuid::Uuid;
-
 use crate::email_template::entities::EmailTemplate;
 use crate::email_template::ports::{
     CreateEmailTemplateInput, DeleteEmailTemplateInput, EmailTemplatePolicy,
     EmailTemplateRepository, EmailTemplateService, GetEmailTemplateInput, GetEmailTemplatesInput,
-    TemplateRenderer, UpdateEmailTemplateInput,
+    RenderEmailTemplateInput, TemplateRenderer, UpdateEmailTemplateInput,
 };
 use ferriskey_domain::auth::Identity;
 use ferriskey_domain::client::ports::ClientRepository;
@@ -102,7 +100,7 @@ where
         )?;
 
         self.email_template_repository
-            .get_by_id(input.template_id)
+            .get_by_id(realm.id.into(), input.template_id)
             .await?
             .ok_or(CoreError::EmailTemplateNotFound)
     }
@@ -161,9 +159,10 @@ where
             "insufficient permissions",
         )?;
 
-        // Verify the template exists
+        // Verify the template exists *within this realm* — a template id belonging to
+        // another realm must not match, and is reported as not found (no oracle).
         self.email_template_repository
-            .get_by_id(input.template_id)
+            .get_by_id(realm.id.into(), input.template_id)
             .await?
             .ok_or(CoreError::EmailTemplateNotFound)?;
 
@@ -175,7 +174,13 @@ where
         self.template_renderer.render_to_html(&mjml)?;
 
         self.email_template_repository
-            .update(input.template_id, input.name, input.structure, mjml)
+            .update(
+                realm.id.into(),
+                input.template_id,
+                input.name,
+                input.structure,
+                mjml,
+            )
             .await
     }
 
@@ -197,21 +202,37 @@ where
             "insufficient permissions",
         )?;
 
-        // Verify the template exists
+        // Verify the template exists *within this realm* — a template id belonging to
+        // another realm must not match, and is reported as not found (no oracle).
         self.email_template_repository
-            .get_by_id(input.template_id)
+            .get_by_id(realm.id.into(), input.template_id)
             .await?
             .ok_or(CoreError::EmailTemplateNotFound)?;
 
         self.email_template_repository
-            .delete(input.template_id)
+            .delete(realm.id.into(), input.template_id)
             .await
     }
 
-    async fn render_template_html(&self, template_id: Uuid) -> Result<String, CoreError> {
+    async fn render_template_html(
+        &self,
+        identity: Identity,
+        input: RenderEmailTemplateInput,
+    ) -> Result<String, CoreError> {
+        let realm = self
+            .realm_repository
+            .get_by_name(&input.realm_name)
+            .await?
+            .ok_or(CoreError::InvalidRealm)?;
+
+        ensure_policy(
+            self.policy.can_view_email_template(&identity, &realm).await,
+            "insufficient permissions",
+        )?;
+
         let template = self
             .email_template_repository
-            .get_by_id(template_id)
+            .get_by_id(realm.id.into(), input.template_id)
             .await?
             .ok_or(CoreError::EmailTemplateNotFound)?;
 
@@ -375,69 +396,327 @@ mod tests {
 
     #[tokio::test]
     async fn test_render_template_html() {
-        let realm = test_realm();
+        let realm = named_realm("test-realm");
+        let user = test_user(&realm);
         let template = test_template(&realm);
         let template_id = template.id;
-        let template_clone = template.clone();
-
-        let realm_repo = MockRealmRepository::new();
-        let user_repo = MockUserRepository::new();
-        let user_role_repo = MockUserRoleRepository::new();
-        let client_repo = MockClientRepository::new();
 
         let mut et_repo = MockEmailTemplateRepository::new();
-        et_repo.expect_get_by_id().returning(move |_| {
-            let t = template_clone.clone();
-            Box::pin(async move { Ok(Some(t)) })
+        et_repo.expect_get_by_id().returning(move |realm_id, _| {
+            let t = template.clone();
+            Box::pin(async move {
+                Ok(if realm_id == t.realm_id {
+                    Some(t)
+                } else {
+                    None
+                })
+            })
         });
 
-        let policy = Arc::new(FerriskeyPolicy::new(
-            Arc::new(user_repo),
-            Arc::new(client_repo),
-            Arc::new(user_role_repo),
-        ));
-
         let service = EmailTemplateServiceImpl::new(
-            Arc::new(realm_repo),
+            Arc::new(realm_repo_for(&realm)),
             Arc::new(et_repo),
             Arc::new(TestRenderer),
-            policy,
+            admin_policy_for(&realm, &user),
         );
 
-        let result = service.render_template_html(template_id).await;
+        let result = service
+            .render_template_html(
+                Identity::User(user),
+                RenderEmailTemplateInput {
+                    realm_name: "test-realm".to_string(),
+                    template_id,
+                },
+            )
+            .await;
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "<html><body>Test</body></html>");
     }
 
+    // ---------------------------------------------------------------------
+    // Cross-realm isolation (FK-005)
+    // ---------------------------------------------------------------------
+
+    type TestPolicy =
+        FerriskeyPolicy<MockUserRepository, MockClientRepository, MockUserRoleRepository>;
+
+    fn named_realm(name: &str) -> Realm {
+        Realm {
+            id: uuid::Uuid::new_v4().into(),
+            name: name.to_string(),
+            display_name: None,
+            settings: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    /// Realm repository that resolves the attacker's own realm (the one in the URL).
+    fn realm_repo_for(realm: &Realm) -> MockRealmRepository {
+        let realm = realm.clone();
+        let mut repo = MockRealmRepository::new();
+        repo.expect_get_by_name().returning(move |_| {
+            let realm = realm.clone();
+            Box::pin(async move { Ok(Some(realm)) })
+        });
+        repo
+    }
+
+    /// Policy granting `manage_realm` on `realm` to `user` — the attacker is a
+    /// legitimate admin *of their own realm*, so `ensure_policy` passes.
+    fn admin_policy_for(realm: &Realm, user: &User) -> Arc<TestPolicy> {
+        let mut user_repo = MockUserRepository::new();
+        let u = user.clone();
+        user_repo.expect_get_by_id().returning(move |_| {
+            let u = u.clone();
+            Box::pin(async move { Ok(u) })
+        });
+
+        let mut user_role_repo = MockUserRoleRepository::new();
+        let rid = realm.id;
+        user_role_repo.expect_get_user_roles().returning(move |_| {
+            let rid = rid;
+            Box::pin(async move {
+                Ok(vec![Role {
+                    id: uuid::Uuid::new_v4(),
+                    name: "admin".to_string(),
+                    description: None,
+                    permissions: vec!["manage_realm".to_string()],
+                    realm_id: rid,
+                    client_id: None,
+                    client: None,
+                    require_mfa: false,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                }])
+            })
+        });
+
+        Arc::new(FerriskeyPolicy::new(
+            Arc::new(user_repo),
+            Arc::new(MockClientRepository::new()),
+            Arc::new(user_role_repo),
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_get_template_rejects_foreign_realm_template() {
+        let attacker_realm = named_realm("attacker-realm");
+        let victim_realm = named_realm("victim-realm");
+        let attacker = test_user(&attacker_realm);
+        let victim_template = test_template(&victim_realm);
+        let victim_template_id = victim_template.id;
+
+        // Simulates the realm-scoped SQL: the row only matches for its owning realm.
+        let mut et_repo = MockEmailTemplateRepository::new();
+        et_repo.expect_get_by_id().returning(move |realm_id, _| {
+            let t = victim_template.clone();
+            Box::pin(async move {
+                Ok(if realm_id == t.realm_id {
+                    Some(t)
+                } else {
+                    None
+                })
+            })
+        });
+
+        let service = EmailTemplateServiceImpl::new(
+            Arc::new(realm_repo_for(&attacker_realm)),
+            Arc::new(et_repo),
+            Arc::new(TestRenderer),
+            admin_policy_for(&attacker_realm, &attacker),
+        );
+
+        let result = service
+            .get_template(
+                Identity::User(attacker),
+                GetEmailTemplateInput {
+                    realm_name: "attacker-realm".to_string(),
+                    template_id: victim_template_id,
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "reading another realm's email template must be refused"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_template_rejects_foreign_realm_template() {
+        let attacker_realm = named_realm("attacker-realm");
+        let victim_realm = named_realm("victim-realm");
+        let attacker = test_user(&attacker_realm);
+        let victim_template = test_template(&victim_realm);
+        let victim_template_id = victim_template.id;
+        let updated = victim_template.clone();
+
+        // Simulates the realm-scoped SQL: the row only matches for its owning realm.
+        let mut et_repo = MockEmailTemplateRepository::new();
+        et_repo.expect_get_by_id().returning(move |realm_id, _| {
+            let t = victim_template.clone();
+            Box::pin(async move {
+                Ok(if realm_id == t.realm_id {
+                    Some(t)
+                } else {
+                    None
+                })
+            })
+        });
+        et_repo.expect_update().returning(move |_, _, _, _, _| {
+            let t = updated.clone();
+            Box::pin(async move { Ok(t) })
+        });
+
+        let service = EmailTemplateServiceImpl::new(
+            Arc::new(realm_repo_for(&attacker_realm)),
+            Arc::new(et_repo),
+            Arc::new(TestRenderer),
+            admin_policy_for(&attacker_realm, &attacker),
+        );
+
+        let result = service
+            .update_template(
+                Identity::User(attacker),
+                UpdateEmailTemplateInput {
+                    realm_name: "attacker-realm".to_string(),
+                    template_id: victim_template_id,
+                    name: "pwned".to_string(),
+                    structure: json!({"type": "root", "children": []}),
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "overwriting another realm's email template must be refused"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_template_rejects_foreign_realm_template() {
+        let attacker_realm = named_realm("attacker-realm");
+        let victim_realm = named_realm("victim-realm");
+        let attacker = test_user(&attacker_realm);
+        let victim_template = test_template(&victim_realm);
+        let victim_template_id = victim_template.id;
+
+        // Simulates the realm-scoped SQL: the row only matches for its owning realm.
+        let mut et_repo = MockEmailTemplateRepository::new();
+        et_repo.expect_get_by_id().returning(move |realm_id, _| {
+            let t = victim_template.clone();
+            Box::pin(async move {
+                Ok(if realm_id == t.realm_id {
+                    Some(t)
+                } else {
+                    None
+                })
+            })
+        });
+        et_repo
+            .expect_delete()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+
+        let service = EmailTemplateServiceImpl::new(
+            Arc::new(realm_repo_for(&attacker_realm)),
+            Arc::new(et_repo),
+            Arc::new(TestRenderer),
+            admin_policy_for(&attacker_realm, &attacker),
+        );
+
+        let result = service
+            .delete_template(
+                Identity::User(attacker),
+                DeleteEmailTemplateInput {
+                    realm_name: "attacker-realm".to_string(),
+                    template_id: victim_template_id,
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "deleting another realm's email template must be refused"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_template_html_rejects_foreign_realm_template() {
+        let attacker_realm = named_realm("attacker-realm");
+        let victim_realm = named_realm("victim-realm");
+        let attacker = test_user(&attacker_realm);
+        let victim_template = test_template(&victim_realm);
+        let victim_template_id = victim_template.id;
+
+        // Simulates the realm-scoped SQL: the row only matches for its owning realm.
+        let mut et_repo = MockEmailTemplateRepository::new();
+        et_repo.expect_get_by_id().returning(move |realm_id, _| {
+            let t = victim_template.clone();
+            Box::pin(async move {
+                Ok(if realm_id == t.realm_id {
+                    Some(t)
+                } else {
+                    None
+                })
+            })
+        });
+
+        let service = EmailTemplateServiceImpl::new(
+            Arc::new(realm_repo_for(&attacker_realm)),
+            Arc::new(et_repo),
+            Arc::new(TestRenderer),
+            admin_policy_for(&attacker_realm, &attacker),
+        );
+
+        let result = service
+            .render_template_html(
+                Identity::User(attacker),
+                RenderEmailTemplateInput {
+                    realm_name: "attacker-realm".to_string(),
+                    template_id: victim_template_id,
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "rendering another realm's email template must be refused"
+        );
+    }
+
     #[tokio::test]
     async fn test_render_template_html_not_found() {
-        let realm_repo = MockRealmRepository::new();
-        let user_repo = MockUserRepository::new();
-        let user_role_repo = MockUserRoleRepository::new();
-        let client_repo = MockClientRepository::new();
+        let realm = named_realm("test-realm");
+        let user = test_user(&realm);
 
         let mut et_repo = MockEmailTemplateRepository::new();
         et_repo
             .expect_get_by_id()
-            .returning(|_| Box::pin(async { Ok(None) }));
-
-        let policy = Arc::new(FerriskeyPolicy::new(
-            Arc::new(user_repo),
-            Arc::new(client_repo),
-            Arc::new(user_role_repo),
-        ));
+            .returning(|_, _| Box::pin(async { Ok(None) }));
 
         let service = EmailTemplateServiceImpl::new(
-            Arc::new(realm_repo),
+            Arc::new(realm_repo_for(&realm)),
             Arc::new(et_repo),
             Arc::new(TestRenderer),
-            policy,
+            admin_policy_for(&realm, &user),
         );
 
-        let result = service.render_template_html(uuid::Uuid::new_v4()).await;
+        let result = service
+            .render_template_html(
+                Identity::User(user),
+                RenderEmailTemplateInput {
+                    realm_name: "test-realm".to_string(),
+                    template_id: uuid::Uuid::new_v4(),
+                },
+            )
+            .await;
 
         assert!(result.is_err());
-        matches!(result.unwrap_err(), CoreError::EmailTemplateNotFound);
+        assert!(matches!(
+            result.unwrap_err(),
+            CoreError::EmailTemplateNotFound
+        ));
     }
 }

--- a/libs/ferriskey-mail/src/email_template/services.rs
+++ b/libs/ferriskey-mail/src/email_template/services.rs
@@ -159,8 +159,6 @@ where
             "insufficient permissions",
         )?;
 
-        // Verify the template exists *within this realm* — a template id belonging to
-        // another realm must not match, and is reported as not found (no oracle).
         self.email_template_repository
             .get_by_id(realm.id.into(), input.template_id)
             .await?
@@ -202,8 +200,6 @@ where
             "insufficient permissions",
         )?;
 
-        // Verify the template exists *within this realm* — a template id belonging to
-        // another realm must not match, and is reported as not found (no oracle).
         self.email_template_repository
             .get_by_id(realm.id.into(), input.template_id)
             .await?

--- a/libs/ferriskey-mail/src/email_verification/services.rs
+++ b/libs/ferriskey-mail/src/email_verification/services.rs
@@ -132,13 +132,14 @@ where
 
     async fn render_email_template(
         &self,
+        realm_id: Uuid,
         template_id: Uuid,
         user: &ferriskey_domain::user::entities::User,
         extra_vars: &[(&str, &str)],
     ) -> Result<String, CoreError> {
         let template = self
             .email_template_repository
-            .get_by_id(template_id)
+            .get_by_id(realm_id, template_id)
             .await?
             .ok_or(CoreError::EmailTemplateNotFound)?;
 
@@ -249,6 +250,7 @@ where
 
         let html_body = self
             .render_email_template(
+                realm.id.into(),
                 template_id,
                 &user,
                 &[
@@ -848,7 +850,7 @@ mod tests {
         });
 
         let mut et_repo = MockEmailTemplateRepository::new();
-        et_repo.expect_get_by_id().returning(move |_| {
+        et_repo.expect_get_by_id().returning(move |_, _| {
             let t = template_clone.clone();
             Box::pin(async move { Ok(Some(t)) })
         });
@@ -1036,7 +1038,7 @@ mod tests {
             });
 
         let mut et_repo = MockEmailTemplateRepository::new();
-        et_repo.expect_get_by_id().returning(move |_| {
+        et_repo.expect_get_by_id().returning(move |_, _| {
             let t = template_clone.clone();
             Box::pin(async move { Ok(Some(t)) })
         });
@@ -1130,7 +1132,7 @@ mod tests {
         });
 
         let mut et_repo = MockEmailTemplateRepository::new();
-        et_repo.expect_get_by_id().returning(move |_| {
+        et_repo.expect_get_by_id().returning(move |_, _| {
             let t = template_clone.clone();
             Box::pin(async move { Ok(Some(t)) })
         });
@@ -1212,7 +1214,7 @@ mod tests {
         });
 
         let mut et_repo = MockEmailTemplateRepository::new();
-        et_repo.expect_get_by_id().returning(move |_| {
+        et_repo.expect_get_by_id().returning(move |_, _| {
             let t = template_clone.clone();
             Box::pin(async move { Ok(Some(t)) })
         });


### PR DESCRIPTION
Authorization was decided against the realm named in the URL, then the object fetched by **bare UUID**. Thirteen of `ClientService`'s fifteen methods had no realm binding, and the same omission ran through client scopes, protocol mappers, scope mappings, email templates and maintenance.

## Proof, before the fix

The integration test in this PR was run against the unpatched tree. A `tenant-a` administrator, holding only `manage_clients` and `view_clients` **on their own realm**, reached `tenant-b`:

**Secret theft** — `GET /realms/tenant-a/clients/{client_of_tenant_b}` returned 200 with the secret in clear:
```json
{"data":{"client_id":"victim-fb59…","secret":"RV1DA42jBIgeF2Iy",
         "realm_id":"01a00126-7260-…","client_type":"confidential", …}}
```
The secret is stored unhashed, so it is directly replayable against the victim tenant's token endpoint.

**Weakening** — one `PATCH` flipped `require_pkce: true → false` and `direct_access_grants_enabled: false → true` on another tenant's client.

**Destruction** — `DELETE` returned `{"message":"Client with ID … in realm tenant-a deleted successfully"}`. The client belonged to `tenant-b`; the API confirmed the deletion in `tenant-a`'s name.

**Redirect URI injection** — `POST .../redirects` planted `https://attacker.tenant-a.example/steal` on the victim's client, which combined with the authorization-code flow hands over that tenant's codes.

The attacker is a *tenant* administrator. Cross-realm access from `master` is intentional and untouched.

## What changed

**The bound lives in the query, not in the caller.** `ClientRepository::{get_by_id, update_client, delete_by_id}`, `ClientScopeRepository::{get_by_id, update_by_id, delete_by_id}` and `EmailTemplateRepository::{get_by_id, update, delete}` all take the realm and carry it into `WHERE`. A pre-check in each service would have worked once; a `WHERE` clause cannot be forgotten by the next caller. Changing those signatures surfaced **nine call sites** the compiler pointed at immediately — that noise is the point.

**Sub-resources are bound to their parent as well.** `RedirectUriRepository::{update_enabled, delete}` and `ProtocolMapperRepository::{get_by_id, update_by_id, delete_by_id}` take the parent id, so a bare `uri_id` or `mapper_id` can no longer reach across clients or scopes. `ClientServiceImpl::load_client_in_realm` binds the parent before any child is touched.

**Claim forgery closed.** `assign_scope_to_client` checked neither `client.realm_id` nor `scope.realm_id`. An attacker could attach a scope of their own realm — carrying an `oidc-hardcoded-claim-mapper` of their choosing — as a default scope of another tenant's client, and every token that client issued would then carry the forged claims. Both ends are now checked separately, and `get_client_scopes` filters out cross-realm scopes so mappings already in the database stop taking effect.

**Email templates.** Rewriting another tenant's password-reset template lets `{{reset_link}}` point at an attacker domain, with the mail sent through the victim's own SMTP. The template path is bound, and so is the render path used by `trident` for password-reset and magic-link mails.

**`render_template_html` had no authentication at all** — no `Identity`, no policy, no realm, on a public service trait. It also has zero callers today. Rather than leave an unauthenticated render method one `#[utoipa::path]` away from being exposed, it now takes `(Identity, RenderEmailTemplateInput)` like every sibling method.

**Maintenance.** `toggle_maintenance` could disable authentication on another tenant's client.

## Verification

- `api/tests/client_cross_realm_test.rs` — 4 attack tests plus one non-regression test proving the tenant admin still fully manages their own clients. All 5 confirmed red on the unpatched tree (`0 passed; 5 failed`), green here.
- 17 unit tests in `ferriskey-aegis`, 4 in `ferriskey-mail`, all red before the fix. The aegis suite was additionally validated by **mutation**: production code was deliberately broken (dropping a realm check, passing a wrong realm to the repository) and the tests were confirmed to catch it. That exercise exposed a blind spot — write paths were only covered negatively — and four mirror tests were added.
- `cargo fmt --check` clean, `cargo clippy --workspace --all-targets` 0 errors.

`cargo test --workspace` shows 5 failures, all pre-existing on `main` and verified by stashing: 4 in `ferriskey-mail` (`email_verification::services::tests::*`) and 1 in `ferriskey-portal-theme`.

## Debt removed along the way

These are not incidental tidying: they are what let the vulnerabilities go unnoticed.

- **`RedirectUriService` deleted** — zero implementations anywhere. Like `UserRoleService` in #1226, it advertised coverage the live path did not have.
- **Hand-written `mockall::mock!` blocks removed** for the aegis ports and `PostLogoutRedirectUriRepository`. The traits already carried `automock`; `core` re-declared them by hand, so every port signature change cost six compile errors and a manual re-copy, and a stale copy could drift from the real trait. `ferriskey-aegis` now has a `mock` feature like the rest of the workspace. This also unblocks service-level unit tests across `ferriskey-core`, which were impossible before.
- **Hand-written test doubles in `ferriskey-aegis` replaced by generated mocks** — 407 → 209 lines, with detection power verified by mutation rather than asserted.

## API impact

- Client, scope, mapper, template and maintenance routes now answer **404** for an id outside the URL realm, never 403 — an id that exists elsewhere must not be distinguishable from one that does not exist.
- **`GET /realms/{realm}/clients/{id}` returns 404 instead of 401 for an absent client.** `get_client_by_id` mapped its error to `InvalidClient`; it now returns `NotFound`. Correct on the merits — absent and foreign must be indistinguishable — but it is a public status-code change and will break any consumer testing for 401.
- `get_client_scopes` no longer returns scopes belonging to another realm. A tenant carrying a pre-existing cross-realm mapping will see that scope disappear from the list. Intended; a cleanup migration for those rows is not included.

## Found on the way — not fixed here

- **JWT key generation has a race.** `KeystoreRepository::get_or_generate_key` (`core/src/infrastructure/repositories/keystore_repository.rs:40-71`) is a read-then-insert with no lock, and `core/migrations/20250601180719_create_jwt_keys.up.sql` puts **no unique index on `jwt_keys.realm_id`** (verified). Concurrent first requests against a cold realm each insert a key pair; `find().one()` then returns an arbitrary one and tokens signed with the other fail with a bodiless 401. Found because it made four integration tests flaky, and reproduced independently of this PR. A `UNIQUE(realm_id)` plus dedup of existing rows would close it — needs its own migration.
- `Client.secret` is still serialized in clear on every client response and still stored unhashed. This PR closes cross-realm access to it; masking it and moving it behind a dedicated `GET /clients/{id}/client-secret` is the separate workstream we agreed to defer.
- `libs/ferriskey-api-core/src/auth.rs:153` — the middleware returns a bare `UNAUTHORIZED` with no body and no logging, which is what made the key race hard to diagnose.
- `ensure_client_in_realm` maps *every* repository error to `NotFound`, including a database failure. No oracle is created, but an outage surfacing as 404 is poor for operability.
- `create_client` hardcodes `require_pkce: false` (`core/src/domain/client/services.rs:190`) and the validator does not expose the field at creation time.
- `ClientScopeAttributeRepository` is still unbound. It has no callers today, so binding it would have added a signature break with no attack surface removed — a latent IDOR the moment anything uses it.

## Base

Stacked on `fix/mfa-test-webapp-url` (#1225), which restores compilation of `main`. Merge #1225 first, then #1226, then this.

## Note for the reviewer

`render_template_html` has no callers at all. It has been secured rather than deleted, on the assumption that it is an unwired preview feature. If that is not the plan, deleting it is the better answer and I am happy to do it.
