### PR TITLE
test: realign stale expectations in mail and portal theme suites

### DIFF
--- a/libs/ferriskey-mail/src/email_verification/services.rs
+++ b/libs/ferriskey-mail/src/email_verification/services.rs
@@ -618,6 +618,18 @@ mod tests {
             Box::pin(async move { Ok(Some(r)) })
         });
 
+        let mut security_event_repo = MockSecurityEventRepository::new();
+        security_event_repo
+            .expect_store_event()
+            .times(1)
+            .returning(|_| Box::pin(async move { Ok(()) }));
+
+        let mut webhook_repo = MockWebhookRepository::new();
+        webhook_repo
+            .expect_notify::<User>()
+            .times(1)
+            .returning(|_, _: WebhookPayload<User>| Box::pin(async move { Ok(()) }));
+
         let service = build_service(
             evrt,
             user_repo,
@@ -626,8 +638,8 @@ mod tests {
             MockEmailPort::new(),
             MockSmtpConfigRepository::new(),
             MockEmailTemplateRepository::new(),
-            MockWebhookRepository::new(),
-            MockSecurityEventRepository::new(),
+            webhook_repo,
+            security_event_repo,
         );
 
         let result = service
@@ -644,6 +656,8 @@ mod tests {
         let realm = test_realm();
         let mut evrt = MockEmailVerificationTokenRepository::new();
         evrt.expect_find_valid_by_hash()
+            .return_once(|_, _| Box::pin(async move { Ok(None) }));
+        evrt.expect_find_by_hash()
             .return_once(|_, _| Box::pin(async move { Ok(None) }));
 
         let mut realm_repo = MockRealmRepository::new();
@@ -681,7 +695,7 @@ mod tests {
         let raw_token = "expired-token";
         let token_hash = generate_token_hash(raw_token);
 
-        let _expired_token = EmailVerificationToken {
+        let expired_token = EmailVerificationToken {
             id: Uuid::new_v4(),
             user_id: user.id,
             realm_id: realm.id.into(),
@@ -694,6 +708,15 @@ mod tests {
         let mut evrt = MockEmailVerificationTokenRepository::new();
         evrt.expect_find_valid_by_hash()
             .return_once(move |_, _| Box::pin(async move { Ok(None) }));
+        let et = expired_token.clone();
+        evrt.expect_find_by_hash()
+            .return_once(move |_, _| Box::pin(async move { Ok(Some(et)) }));
+
+        let unverified = user.clone();
+        let mut user_repo = MockUserRepository::new();
+        user_repo
+            .expect_get_by_id()
+            .return_once(move |_| Box::pin(async move { Ok(unverified) }));
 
         let mut realm_repo = MockRealmRepository::new();
         let r = realm.clone();
@@ -704,7 +727,7 @@ mod tests {
 
         let service = build_service(
             evrt,
-            MockUserRepository::new(),
+            user_repo,
             realm_repo,
             MockUserRequiredActionRepository::new(),
             MockEmailPort::new(),
@@ -731,7 +754,7 @@ mod tests {
         let raw_token = "used-token";
         let token_hash = generate_token_hash(raw_token);
 
-        let _used_token = EmailVerificationToken {
+        let used_token = EmailVerificationToken {
             id: Uuid::new_v4(),
             user_id: user.id,
             realm_id: realm.id.into(),
@@ -744,6 +767,16 @@ mod tests {
         let mut evrt = MockEmailVerificationTokenRepository::new();
         evrt.expect_find_valid_by_hash()
             .return_once(move |_, _| Box::pin(async move { Ok(None) }));
+        let ut = used_token.clone();
+        evrt.expect_find_by_hash()
+            .return_once(move |_, _| Box::pin(async move { Ok(Some(ut)) }));
+
+        let mut verified_user = user.clone();
+        verified_user.email_verified = true;
+        let mut user_repo = MockUserRepository::new();
+        user_repo
+            .expect_get_by_id()
+            .return_once(move |_| Box::pin(async move { Ok(verified_user) }));
 
         let mut realm_repo = MockRealmRepository::new();
         let r = realm.clone();
@@ -754,7 +787,7 @@ mod tests {
 
         let service = build_service(
             evrt,
-            MockUserRepository::new(),
+            user_repo,
             realm_repo,
             MockUserRequiredActionRepository::new(),
             MockEmailPort::new(),
@@ -767,11 +800,9 @@ mod tests {
         let result = service
             .verify_email("test-realm".to_string(), raw_token.to_string())
             .await;
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            CoreError::InvalidOrExpiredToken
-        ));
+        let res = result.expect("replaying a spent token on a verified account is idempotent");
+        assert_eq!(res.user_id, user.id);
+        assert!(res.verified);
     }
 
     #[tokio::test]

--- a/libs/ferriskey-portal-theme/src/validation.rs
+++ b/libs/ferriskey-portal-theme/src/validation.rs
@@ -168,7 +168,8 @@ mod tests {
     fn login_missing_password_input_fails() {
         let tree = json!([
             { "type": "email_input" },
-            { "type": "submit_button" }
+            { "type": "submit_button" },
+            { "type": "identity_providers" }
         ]);
         let err = validate_tree(PortalPageType::Login, &tree).unwrap_err();
         assert_eq!(err.page_type, PortalPageType::Login);


### PR DESCRIPTION
`cargo test --workspace` failed on `main` with five failures, in `ferriskey-mail` (4) and `ferriskey-portal-theme` (1). None of them was a product bug: in every case the production code moved and the assertion did not follow. The suite is green after this.

## `ferriskey-portal-theme`

`identity_providers` became a required block on the login page in #1017. That PR updated two of the three tests that enumerate required blocks and missed `login_missing_password_input_fails`, which then reported `["password_input", "identity_providers"]` against an expectation of `["password_input"]`.

Fixed by adding `identity_providers` to the test's tree rather than by widening the assertion. The test is named after the one block it is meant to find missing; widening it would have made the name a lie and quietly turned it into a duplicate of `empty_tree_reports_all_required_missing_for_login`.

## `ferriskey-mail` — three separate causes

**`test_verify_email_success`** — `verify_email` now records a `UserEmailVerified` security event and fires a `UserEmailVerified` webhook. Both mocks were built bare, so the first call panicked on an unmatched expectation. Both are now expected with `.times(1)`, which also pins the fact that they fire exactly once.

**All three failure-path tests** — when `find_valid_by_hash` returns `None`, `verify_email` now calls `find_by_hash` to tell an already-used token from an unknown one. None of the three stubbed it.

**`test_verify_email_already_used_token` and `test_verify_email_expired_token` were testing neither.** Each built its token — `_used_token`, `_expired_token` — and never wired it into the mock; the leading underscore silenced the compiler. Both therefore exercised the same path as `test_verify_email_invalid_token`: a token that cannot be found at all. Two of the three names promised coverage that did not exist.

They now cover what they claim:

| Test | Path actually exercised |
|---|---|
| `test_verify_email_invalid_token` | `find_valid_by_hash` → `None`, `find_by_hash` → `None` → `InvalidOrExpiredToken` |
| `test_verify_email_expired_token` | token found, past expiry, account not yet verified → `InvalidOrExpiredToken` |
| `test_verify_email_already_used_token` | token found, already consumed, account already verified → **`Ok`** |

The last one is a behaviour change the old assertion predates: replaying a spent token on an already-verified account is now idempotent and returns success (`services.rs`, "Email verification token already used, user email already verified"). That branch had no test at all; the stale one asserted the opposite.

## Verification

- `cargo test --workspace --no-fail-fast` — **0 failures** on this branch, 5 on `main` (checked by stashing, both directions).
- `cargo fmt --check` clean, `cargo clippy --workspace --all-targets` 0 errors.
- No production code touched: the diff is two test modules, +44/−12.

## Worth flagging

An unused `_prefixed` binding in a test is the same signal as an ignored `_realm_id` parameter in a policy: the compiler was told to stop asking, and the test kept its name while losing its meaning. Both of these had been sitting in the suite since before this branch, passing as red noise nobody owned.

There is no CI job that would have caught these either — `cargo test` runs in `pre-commit.yaml` only through the hooks, and the DB-backed job runs four named suites explicitly. A plain `cargo test --workspace` gate would have.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email verification handling so repeated verification succeeds safely for users who are already verified.
  * Updated validation behavior coverage for login forms with identity provider settings.
* **Tests**
  * Expanded verification test coverage for successful, invalid, expired, and previously used tokens.
  * Refined login validation tests to accurately reflect required configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->