### PR TITLE
fix: enforce pending authentication steps on all token issuance paths

### DIFF
--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -387,6 +387,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             mjml_renderer.clone(),
             password_policy.clone(),
             otp_enrollment.clone(),
+            user_role.clone(),
             token_revocation.clone(),
         ),
         user_service: UserServiceImpl::new(

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -241,6 +241,7 @@ type ApplicationTridentService = TridentServiceImpl<
     MjmlRenderer,
     PasswordPolicyRepo,
     OtpEnrollmentRepo,
+    UserRoleRepo,
     ApplicationTokenRevocation,
 >;
 

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -240,6 +240,49 @@ fn resolve_refresh_required_actions(
     actions
 }
 
+fn pending_step_message(step: &mfa_policy::PendingAuthStep) -> String {
+    match step {
+        mfa_policy::PendingAuthStep::RequiredActions(actions) => format!(
+            "the required action(s) {} are still owed",
+            actions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        mfa_policy::PendingAuthStep::OtpChallenge => {
+            "a second authentication factor is still owed".to_string()
+        }
+    }
+}
+
+fn pending_step_refusal(step: &mfa_policy::PendingAuthStep) -> CoreError {
+    CoreError::Forbidden(format!(
+        "Tokens cannot be issued for this account because {}. Sign in through the browser-based authorization_code flow to complete the remaining step.",
+        pending_step_message(step)
+    ))
+}
+
+fn refuse_token_issuance_when_step_pending(
+    step: Option<&mfa_policy::PendingAuthStep>,
+) -> Result<(), CoreError> {
+    match step {
+        Some(step) => Err(pending_step_refusal(step)),
+        None => Ok(()),
+    }
+}
+
+fn refuse_token_issuance_when_actions_pending(
+    step: Option<&mfa_policy::PendingAuthStep>,
+) -> Result<(), CoreError> {
+    match step {
+        Some(step @ mfa_policy::PendingAuthStep::RequiredActions(_)) => {
+            Err(pending_step_refusal(step))
+        }
+        _ => Ok(()),
+    }
+}
+
 /// Lifetime, in seconds, of a `Temporary` step token.
 ///
 /// A step token only has to survive one hop of the login flow (OTP challenge,
@@ -1639,6 +1682,48 @@ where
         Ok(is_valid)
     }
 
+    async fn resolve_pending_auth_step(
+        &self,
+        user_id: Uuid,
+        realm_id: RealmId,
+    ) -> Result<Option<mfa_policy::PendingAuthStep>, CoreError> {
+        let persisted_actions = self
+            .user_required_action_repository
+            .get_required_actions(user_id)
+            .await
+            .map_err(|e| {
+                warn!(user_id = %user_id, error = ?e, "Failed to load required actions");
+                CoreError::InternalServerError
+            })?;
+
+        let credentials = self
+            .credential_repository
+            .get_credentials_by_user_id(user_id)
+            .await
+            .map_err(|_| CoreError::GetUserCredentialsError)?;
+
+        let has_otp_credential = credentials
+            .iter()
+            .any(|credential| matches!(credential.credential_type, CredentialType::Otp));
+        let has_temporary_password = credentials.iter().any(|credential| credential.temporary);
+
+        let user_roles = self
+            .user_role_repository
+            .get_user_roles(user_id)
+            .await
+            .map_err(|_| CoreError::InternalServerError)?;
+
+        let realm_settings = self.realm_repository.get_realm_settings(realm_id).await?;
+
+        Ok(mfa_policy::pending_auth_step(
+            &persisted_actions,
+            realm_settings.as_ref(),
+            &user_roles,
+            has_otp_credential,
+            has_temporary_password,
+        ))
+    }
+
     async fn verify_refresh_token(
         &self,
         token: String,
@@ -1821,6 +1906,20 @@ where
         let flow_id = auth_session.compass_flow_id.map(FlowId);
         let user_id = auth_session.user_id.ok_or(CoreError::NotFound)?;
         let user = self.user_repository.get_by_id(user_id).await?;
+
+        let pending_step = self
+            .resolve_pending_auth_step(user_id, params.realm_id)
+            .await?;
+
+        if let Err(error) = refuse_token_issuance_when_actions_pending(pending_step.as_ref()) {
+            warn!(
+                user_id = %user_id,
+                client_id = %params.client_id,
+                step = ?pending_step,
+                "Refusing an authorization code: the account still owes a required action"
+            );
+            return Err(error);
+        }
 
         let final_scope = self
             .resolve_scopes_for_client(auth_session.client_id, Some(auth_session.scope.clone()))
@@ -2119,6 +2218,21 @@ where
             .user_repository
             .reset_failed_login_attempts(user.id)
             .await;
+
+        let pending_step = self
+            .resolve_pending_auth_step(user.id, params.realm_id)
+            .instrument(info_span!("auth.password.pending_step"))
+            .await?;
+
+        if let Err(error) = refuse_token_issuance_when_step_pending(pending_step.as_ref()) {
+            warn!(
+                user_id = %user.id,
+                client_id = %params.client_id,
+                step = ?pending_step,
+                "Refusing a direct grant: the account still owes an authentication step"
+            );
+            return Err(error);
+        }
 
         let final_scope = self
             .resolve_scopes_for_client(client.id, params.scope)
@@ -3485,7 +3599,7 @@ where
                 .map_err(|err| warn!("Failed to notify UserCreated webhook: {}", err))
                 .ok();
 
-            return Ok(RegisterUserOutput::PendingVerification {
+            return Ok(RegisterUserOutput::PendingAction {
                 message: "Please check your email to verify your account.".to_string(),
                 user_id: user.id,
             });
@@ -3534,6 +3648,13 @@ where
                 .await?;
             let redirect_url = output.redirect_url.ok_or(CoreError::InternalServerError)?;
             return Ok(RegisterUserOutput::Redirect { url: redirect_url });
+        }
+
+        if let Some(step) = self.resolve_pending_auth_step(user.id, realm.id).await? {
+            return Ok(RegisterUserOutput::PendingAction {
+                message: pending_step_message(&step),
+                user_id: user.id,
+            });
         }
 
         let token = self
@@ -3847,6 +3968,17 @@ where
         };
 
         let user = self.user_repository.get_by_id(input.user_id).await?;
+
+        let pending_step = self.resolve_pending_auth_step(user.id, realm.id).await?;
+
+        if let Err(error) = refuse_token_issuance_when_step_pending(pending_step.as_ref()) {
+            warn!(
+                user_id = %user.id,
+                step = ?pending_step,
+                "Refusing to mint tokens: the account still owes an authentication step"
+            );
+            return Err(error);
+        }
 
         let user_session = self
             .create_user_session(user.id, realm.id, lifetimes.refresh_token)
@@ -4783,5 +4915,149 @@ mod tests {
         let session = user_session(now);
 
         assert!(validate_session_binding(Some(session.id), Some(&session), now).is_ok());
+    }
+
+    use super::{
+        refuse_token_issuance_when_actions_pending, refuse_token_issuance_when_step_pending,
+    };
+    use crate::domain::trident::mfa_policy::{PendingAuthStep, pending_auth_step};
+
+    fn step(
+        persisted: &[RequiredAction],
+        require_mfa: bool,
+        has_otp_credential: bool,
+        has_temporary_password: bool,
+    ) -> Option<PendingAuthStep> {
+        let settings = realm_setting(require_mfa);
+        pending_auth_step(
+            persisted,
+            Some(&settings),
+            &[role(false)],
+            has_otp_credential,
+            has_temporary_password,
+        )
+    }
+
+    #[test]
+    fn an_admin_owing_nothing_still_gets_a_direct_grant() {
+        let pending = step(&[], false, false, false);
+
+        assert_eq!(pending, None);
+        assert!(refuse_token_issuance_when_step_pending(pending.as_ref()).is_ok());
+    }
+
+    #[test]
+    fn a_direct_grant_is_refused_for_a_temporary_password() {
+        assert!(matches!(
+            refuse_token_issuance_when_step_pending(step(&[], false, false, true).as_ref()),
+            Err(CoreError::Forbidden(_))
+        ));
+    }
+
+    #[test]
+    fn a_direct_grant_is_refused_for_an_enrolled_authenticator() {
+        assert!(matches!(
+            refuse_token_issuance_when_step_pending(step(&[], false, true, false).as_ref()),
+            Err(CoreError::Forbidden(_))
+        ));
+    }
+
+    #[test]
+    fn a_direct_grant_is_refused_when_the_realm_mandates_mfa_enrolment() {
+        assert!(matches!(
+            refuse_token_issuance_when_step_pending(step(&[], true, false, false).as_ref()),
+            Err(CoreError::Forbidden(_))
+        ));
+    }
+
+    #[test]
+    fn a_direct_grant_is_refused_when_a_role_mandates_mfa_enrolment() {
+        let pending = pending_auth_step(&[], None, &[role(true)], false, false);
+
+        assert!(matches!(
+            refuse_token_issuance_when_step_pending(pending.as_ref()),
+            Err(CoreError::Forbidden(_))
+        ));
+    }
+
+    #[test]
+    fn a_direct_grant_is_refused_for_a_persisted_action() {
+        assert!(matches!(
+            refuse_token_issuance_when_step_pending(
+                step(&[RequiredAction::VerifyEmail], false, false, false).as_ref()
+            ),
+            Err(CoreError::Forbidden(_))
+        ));
+    }
+
+    #[test]
+    fn a_refusal_names_the_step_and_sends_the_client_to_the_browser() {
+        let Err(CoreError::Forbidden(message)) =
+            refuse_token_issuance_when_step_pending(step(&[], false, false, true).as_ref())
+        else {
+            panic!("a temporary password must be refused");
+        };
+
+        assert!(
+            message.contains("update_password"),
+            "the client must learn which step is owed: {message}"
+        );
+        assert!(
+            message.contains("authorization_code"),
+            "the client must be told where to continue: {message}"
+        );
+
+        let Err(CoreError::Forbidden(otp_message)) =
+            refuse_token_issuance_when_step_pending(step(&[], false, true, false).as_ref())
+        else {
+            panic!("an enrolled authenticator must be refused");
+        };
+
+        assert!(
+            otp_message.contains("authorization_code"),
+            "the client must be told where to continue: {otp_message}"
+        );
+    }
+
+    #[test]
+    fn auto_login_survives_a_reset_that_leaves_nothing_pending() {
+        assert!(
+            refuse_token_issuance_when_step_pending(step(&[], false, false, false).as_ref())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn auto_login_is_refused_when_a_second_factor_is_enrolled() {
+        assert!(matches!(
+            refuse_token_issuance_when_step_pending(step(&[], false, true, false).as_ref()),
+            Err(CoreError::Forbidden(_))
+        ));
+    }
+
+    #[test]
+    fn a_code_grant_survives_an_otp_challenge() {
+        assert!(
+            refuse_token_issuance_when_actions_pending(step(&[], false, true, false).as_ref())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn a_code_grant_is_refused_while_actions_are_owed() {
+        assert!(matches!(
+            refuse_token_issuance_when_actions_pending(
+                step(&[RequiredAction::VerifyEmail], false, false, false).as_ref()
+            ),
+            Err(CoreError::Forbidden(_))
+        ));
+    }
+
+    #[test]
+    fn a_code_grant_survives_an_empty_slate() {
+        assert!(
+            refuse_token_issuance_when_actions_pending(step(&[], false, false, false).as_ref())
+                .is_ok()
+        );
     }
 }

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -48,6 +48,7 @@ use crate::{
         session::ports::TokenRevocationPort,
         trident::{
             entities::{MfaRecoveryCode, PasswordResetToken, TotpSecret},
+            mfa_policy::{PendingAuthStep, pending_auth_step},
             ports::{
                 BurnRecoveryCodeInput, BurnRecoveryCodeOutput, ChallengeOtpInput,
                 ChallengeOtpOutput, CompletePasswordResetInput, CompletePasswordResetOutput,
@@ -66,7 +67,7 @@ use crate::{
         },
         user::{
             entities::RequiredAction,
-            ports::{UserRepository, UserRequiredActionRepository},
+            ports::{UserRepository, UserRequiredActionRepository, UserRoleRepository},
         },
         webhook::{
             entities::{webhook_payload::WebhookPayload, webhook_trigger::WebhookTrigger},
@@ -195,31 +196,6 @@ fn build_webauthn_client(rp_info: WebAuthnRpInfo) -> Result<Webauthn, CoreError>
         })
 }
 
-/// Generates a random authorization code, stores it in the user auth session
-/// and returns it in a formated URL ready to be sent to the user
-async fn store_auth_code_and_generate_login_url<AS: AuthSessionRepository>(
-    auth_session_repository: &AS,
-    auth_session: &AuthSession,
-    user_id: Uuid,
-) -> Result<String, CoreError> {
-    let authorization_code = generate_random_string();
-
-    auth_session_repository
-        .update_code_and_user_id(auth_session.id, authorization_code.clone(), user_id)
-        .await
-        .map_err(|_| CoreError::AuthorizationCodeStorageFailed)?;
-
-    let current_state = auth_session
-        .state
-        .as_ref()
-        .ok_or(CoreError::AuthSessionExpectedState)?;
-
-    Ok(format!(
-        "{}?code={}&state={}",
-        auth_session.redirect_uri, authorization_code, current_state
-    ))
-}
-
 #[derive(Clone, Debug)]
 pub struct TridentServiceImpl<
     CR,
@@ -239,6 +215,7 @@ pub struct TridentServiceImpl<
     TR,
     PPR,
     OER,
+    URR,
     TRV,
 > where
     CR: CredentialRepository,
@@ -258,6 +235,7 @@ pub struct TridentServiceImpl<
     TR: TemplateRenderer,
     PPR: PasswordPolicyRepository,
     OER: OtpEnrollmentRepository,
+    URR: UserRoleRepository,
     TRV: TokenRevocationPort,
 {
     pub(crate) credential_repository: Arc<CR>,
@@ -277,11 +255,32 @@ pub struct TridentServiceImpl<
     pub(crate) template_renderer: Arc<TR>,
     pub(crate) password_policy_repository: Arc<PPR>,
     pub(crate) otp_enrollment_repository: Arc<OER>,
+    pub(crate) user_role_repository: Arc<URR>,
     pub(crate) token_revocation: Arc<TRV>,
 }
 
-impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR, OER, TRV>
-    TridentServiceImpl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR, OER, TRV>
+impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR, OER, URR, TRV>
+    TridentServiceImpl<
+        CR,
+        RC,
+        AS,
+        H,
+        URA,
+        ML,
+        UR,
+        RR,
+        ES,
+        SC,
+        PRT,
+        SE,
+        WH,
+        ETR,
+        TR,
+        PPR,
+        OER,
+        URR,
+        TRV,
+    >
 where
     CR: CredentialRepository,
     RC: RecoveryCodeRepository,
@@ -300,6 +299,7 @@ where
     TR: TemplateRenderer,
     PPR: PasswordPolicyRepository,
     OER: OtpEnrollmentRepository,
+    URR: UserRoleRepository,
     TRV: TokenRevocationPort,
 {
     #[allow(clippy::too_many_arguments)]
@@ -321,6 +321,7 @@ where
         template_renderer: Arc<TR>,
         password_policy_repository: Arc<PPR>,
         otp_enrollment_repository: Arc<OER>,
+        user_role_repository: Arc<URR>,
         token_revocation: Arc<TRV>,
     ) -> Self {
         Self {
@@ -341,8 +342,88 @@ where
             template_renderer,
             password_policy_repository,
             otp_enrollment_repository,
+            user_role_repository,
             token_revocation,
         }
+    }
+
+    async fn pending_auth_step_for(
+        &self,
+        user_id: Uuid,
+        actions_satisfied_by_path: &[RequiredAction],
+    ) -> Result<Option<PendingAuthStep>, CoreError> {
+        let user = self.user_repository.get_by_id(user_id).await?;
+
+        let credentials = self
+            .credential_repository
+            .get_credentials_by_user_id(user_id)
+            .await
+            .map_err(|_| CoreError::GetUserCredentialsError)?;
+
+        let has_otp_credential = credentials
+            .iter()
+            .any(|credential| credential.credential_type == CredentialType::Otp);
+        let has_temporary_password = credentials.iter().any(|credential| credential.temporary);
+
+        let roles = self.user_role_repository.get_user_roles(user_id).await?;
+
+        let settings = self
+            .realm_repository
+            .get_realm_settings(user.realm_id)
+            .await?;
+
+        let persisted_actions = user
+            .required_actions
+            .into_iter()
+            .filter(|action| !actions_satisfied_by_path.contains(action))
+            .collect::<Vec<RequiredAction>>();
+
+        Ok(pending_auth_step(
+            &persisted_actions,
+            settings.as_ref(),
+            &roles,
+            has_otp_credential,
+            has_temporary_password,
+        ))
+    }
+
+    async fn store_auth_code_and_generate_login_url(
+        &self,
+        auth_session: &AuthSession,
+        user_id: Uuid,
+        actions_satisfied_by_path: &[RequiredAction],
+    ) -> Result<String, CoreError> {
+        if let Some(step) = self
+            .pending_auth_step_for(user_id, actions_satisfied_by_path)
+            .await?
+        {
+            warn!(
+                user_id = %user_id,
+                ?step,
+                "refusing to issue an authorization code while an authentication step is due"
+            );
+
+            return Err(CoreError::Forbidden(
+                "an authentication step is still due for this user".to_string(),
+            ));
+        }
+
+        let authorization_code = generate_random_string();
+
+        self.auth_session_repository
+            .update_code_and_user_id(auth_session.id, authorization_code.clone(), user_id)
+            .await
+            .map_err(|_| CoreError::AuthorizationCodeStorageFailed)?;
+
+        let current_state = auth_session
+            .state
+            .as_ref()
+            .ok_or(CoreError::AuthSessionExpectedState)?;
+
+        Ok(format!(
+            "{}?code={}&state={}",
+            auth_session.redirect_uri, authorization_code, current_state
+        ))
     }
 
     async fn render_email_template(
@@ -381,7 +462,8 @@ where
     }
 }
 
-impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR, OER, TRV> TridentService
+impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR, OER, URR, TRV>
+    TridentService
     for TridentServiceImpl<
         CR,
         RC,
@@ -400,6 +482,7 @@ impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR, OER, TRV
         TR,
         PPR,
         OER,
+        URR,
         TRV,
     >
 where
@@ -420,6 +503,7 @@ where
     TR: TemplateRenderer,
     PPR: PasswordPolicyRepository,
     OER: OtpEnrollmentRepository,
+    URR: UserRoleRepository,
     TRV: TokenRevocationPort,
 {
     async fn generate_recovery_code(
@@ -831,12 +915,9 @@ where
             return Err(CoreError::WebAuthnChallengeFailed);
         }
 
-        let login_url = store_auth_code_and_generate_login_url::<AS>(
-            &self.auth_session_repository,
-            &auth_session,
-            user.id,
-        )
-        .await?;
+        let login_url = self
+            .store_auth_code_and_generate_login_url(&auth_session, user.id, &[])
+            .await?;
 
         Ok(WebAuthnPublicKeyAuthenticateOutput { login_url })
     }
@@ -1016,12 +1097,9 @@ where
             return Err(CoreError::WebAuthnChallengeFailed);
         }
 
-        let login_url = store_auth_code_and_generate_login_url::<AS>(
-            &self.auth_session_repository,
-            &auth_session,
-            user.id,
-        )
-        .await?;
+        let login_url = self
+            .store_auth_code_and_generate_login_url(&auth_session, user.id, &[])
+            .await?;
 
         Ok(PasskeyAuthenticateOutput { login_url })
     }
@@ -1595,13 +1673,14 @@ where
         }
 
         // Generate authorization code and login URL
-        let login_url = store_auth_code_and_generate_login_url::<AS>(
-            &self.auth_session_repository,
-            &auth_session,
-            magic_link.user_id,
-        )
-        .await
-        .inspect_err(|e| error!("Failed to generate login URL: {}", e))?;
+        let login_url = self
+            .store_auth_code_and_generate_login_url(
+                &auth_session,
+                magic_link.user_id,
+                &[RequiredAction::VerifyEmail],
+            )
+            .await
+            .inspect_err(|e| error!("Failed to generate login URL: {}", e))?;
 
         // TODO: here an email should be sent to the user instead of logging it
         debug!("Magic link verified for user_id: {}", magic_link.user_id);
@@ -1994,12 +2073,9 @@ where
                 .await
             {
                 Ok(auth_session) if Uuid::from(auth_session.realm_id) == realm_id => {
-                    match store_auth_code_and_generate_login_url::<AS>(
-                        &self.auth_session_repository,
-                        &auth_session,
-                        user_id,
-                    )
-                    .await
+                    match self
+                        .store_auth_code_and_generate_login_url(&auth_session, user_id, &[])
+                        .await
                     {
                         Ok(url) => Some(url),
                         Err(e) => {
@@ -2066,11 +2142,16 @@ mod tests {
         realm::ports::{MockRealmRepository, MockSmtpConfigRepository},
         seawatch::ports::MockSecurityEventRepository,
         session::ports::MockTokenRevocationPort,
-        trident::ports::{
-            MockMagicLinkRepository, MockOtpEnrollmentRepository, MockPasswordResetTokenRepository,
-            MockRecoveryCodeRepository, OtpEnrollment,
+        trident::{
+            entities::MagicLink,
+            ports::{
+                MockMagicLinkRepository, MockOtpEnrollmentRepository,
+                MockPasswordResetTokenRepository, MockRecoveryCodeRepository, OtpEnrollment,
+            },
         },
-        user::ports::{MockUserRepository, MockUserRequiredActionRepository},
+        user::ports::{
+            MockUserRepository, MockUserRequiredActionRepository, MockUserRoleRepository,
+        },
         webhook::ports::MockWebhookRepository,
     };
     use chrono::DateTime;
@@ -2112,6 +2193,7 @@ mod tests {
         NoopTemplateRenderer,
         MockPasswordPolicyRepository,
         MockOtpEnrollmentRepository,
+        MockUserRoleRepository,
         MockTokenRevocationPort,
     >;
 
@@ -2136,6 +2218,7 @@ mod tests {
         template_renderer: Arc<NoopTemplateRenderer>,
         password_policy_repo: Arc<MockPasswordPolicyRepository>,
         otp_enrollment_repo: Arc<MockOtpEnrollmentRepository>,
+        user_role_repo: Arc<MockUserRoleRepository>,
         token_revocation: Arc<MockTokenRevocationPort>,
     }
 
@@ -2159,6 +2242,7 @@ mod tests {
                 template_renderer: Arc::new(NoopTemplateRenderer),
                 password_policy_repo: Arc::new(MockPasswordPolicyRepository::new()),
                 otp_enrollment_repo: Arc::new(MockOtpEnrollmentRepository::new()),
+                user_role_repo: Arc::new(MockUserRoleRepository::new()),
                 token_revocation: Arc::new(MockTokenRevocationPort::new()),
             }
         }
@@ -2191,6 +2275,7 @@ mod tests {
                 self.template_renderer,
                 self.password_policy_repo,
                 self.otp_enrollment_repo,
+                self.user_role_repo,
                 self.token_revocation,
             )
         }
@@ -3350,6 +3435,522 @@ mod tests {
         assert!(
             matches!(result, Err(CoreError::WebAuthnChallengeFailed)),
             "a challenge older than its TTL must be refused"
+        );
+    }
+
+    fn password_credential(user_id: Uuid) -> Credential {
+        Credential {
+            id: Uuid::new_v4(),
+            salt: Some("salt".to_string()),
+            credential_type: CredentialType::Password,
+            user_id,
+            user_label: None,
+            secret_data: "new_hash".to_string(),
+            credential_data: CredentialData::new_hash(1, "argon2".to_string()),
+            temporary: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            webauthn_credential_id: None,
+        }
+    }
+
+    fn magic_link_for(user_id: Uuid, realm_id: Uuid, session_code: Uuid) -> MagicLink {
+        MagicLink {
+            id: Uuid::new_v4(),
+            user_id,
+            realm_id,
+            magic_token_id: Uuid::new_v4(),
+            magic_token_hash: "hashed".to_string(),
+            created_at: Utc::now(),
+            expires_at: Utc::now() + Duration::minutes(10),
+            auth_session_code: Some(session_code),
+        }
+    }
+
+    fn expect_pending_step_lookups(
+        builder: &mut TridentTestBuilder,
+        user: crate::domain::user::entities::User,
+        credentials: Vec<Credential>,
+        settings: RealmSetting,
+    ) {
+        Arc::get_mut(&mut builder.user_repo)
+            .unwrap()
+            .expect_get_by_id()
+            .returning(move |_| {
+                let u = user.clone();
+                Box::pin(async move { Ok(u) })
+            });
+
+        Arc::get_mut(&mut builder.credential_repo)
+            .unwrap()
+            .expect_get_credentials_by_user_id()
+            .returning(move |_| {
+                let c = credentials.clone();
+                Box::pin(async move { Ok(c) })
+            });
+
+        Arc::get_mut(&mut builder.user_role_repo)
+            .unwrap()
+            .expect_get_user_roles()
+            .returning(|_| Box::pin(async { Ok(Vec::new()) }));
+
+        Arc::get_mut(&mut builder.realm_repo)
+            .unwrap()
+            .expect_get_realm_settings()
+            .returning(move |_| {
+                let s = settings.clone();
+                Box::pin(async move { Ok(Some(s)) })
+            });
+    }
+
+    fn expect_no_authorization_code(builder: &mut TridentTestBuilder) {
+        Arc::get_mut(&mut builder.auth_session_repo)
+            .unwrap()
+            .expect_update_code_and_user_id()
+            .never()
+            .returning(|_, _, _| Box::pin(async { Err(AuthenticationError::NotFound) }));
+    }
+
+    fn expect_authorization_code(builder: &mut TridentTestBuilder, session: AuthSession) {
+        Arc::get_mut(&mut builder.auth_session_repo)
+            .unwrap()
+            .expect_update_code_and_user_id()
+            .times(1)
+            .returning(move |_, _, _| {
+                let s = session.clone();
+                Box::pin(async move { Ok(s) })
+            });
+    }
+
+    struct MagicLinkFixture {
+        builder: TridentTestBuilder,
+        token_id: Uuid,
+        session: AuthSession,
+    }
+
+    fn magic_link_fixture(
+        realm: &crate::domain::realm::entities::Realm,
+        user: &crate::domain::user::entities::User,
+    ) -> MagicLinkFixture {
+        let mut builder = TridentTestBuilder::new();
+        let session_code = Uuid::new_v4();
+        let session = auth_session_with_challenge_issued_at(realm, session_code, None);
+
+        let magic_link = magic_link_for(user.id, Uuid::from(realm.id), session_code);
+        let token_id = magic_link.magic_token_id;
+
+        Arc::get_mut(&mut builder.magic_link_repo)
+            .unwrap()
+            .expect_get_by_token_id()
+            .returning(move |_| {
+                let ml = magic_link.clone();
+                Box::pin(async move { Ok(Some(ml)) })
+            });
+
+        let session_clone = session.clone();
+        Arc::get_mut(&mut builder.auth_session_repo)
+            .unwrap()
+            .expect_get_by_session_code()
+            .returning(move |_| {
+                let s = session_clone.clone();
+                Box::pin(async move { Ok(s) })
+            });
+
+        Arc::get_mut(&mut builder.hasher_repo)
+            .unwrap()
+            .expect_verify_magic_token()
+            .returning(|_, _| Box::pin(async { Ok(true) }));
+
+        MagicLinkFixture {
+            builder,
+            token_id,
+            session,
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_magic_link_withholds_the_code_while_otp_enrolment_is_pending() {
+        let realm = create_test_realm_with_name("test-realm");
+        let mut user = create_test_user_with_email(&realm, "user@example.com");
+        user.required_actions = vec![RequiredAction::ConfigureOtp];
+
+        let MagicLinkFixture {
+            mut builder,
+            token_id,
+            ..
+        } = magic_link_fixture(&realm, &user);
+
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            Vec::new(),
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_no_authorization_code(&mut builder);
+
+        let service = builder.build();
+        let result = service
+            .verify_magic_link(VerifyMagicLinkInput {
+                magic_token_id: token_id,
+                magic_token: "raw_token".to_string(),
+            })
+            .await;
+
+        assert!(
+            matches!(result, Err(CoreError::Forbidden(_))),
+            "a magic link must not log in a user who still owes ConfigureOtp: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_magic_link_withholds_the_code_from_an_otp_credential_holder() {
+        let realm = create_test_realm_with_name("test-realm");
+        let user = create_test_user_with_email(&realm, "user@example.com");
+
+        let MagicLinkFixture {
+            mut builder,
+            token_id,
+            ..
+        } = magic_link_fixture(&realm, &user);
+
+        let credentials = vec![otp_credential(user.id)];
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            credentials,
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_no_authorization_code(&mut builder);
+
+        let service = builder.build();
+        let result = service
+            .verify_magic_link(VerifyMagicLinkInput {
+                magic_token_id: token_id,
+                magic_token: "raw_token".to_string(),
+            })
+            .await;
+
+        assert!(
+            matches!(result, Err(CoreError::Forbidden(_))),
+            "an OTP credential still demands a challenge before any code is minted: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_magic_link_does_not_stall_on_a_pending_email_verification() {
+        let realm = create_test_realm_with_name("test-realm");
+        let mut user = create_test_user_with_email(&realm, "user@example.com");
+        user.required_actions = vec![RequiredAction::VerifyEmail];
+
+        let MagicLinkFixture {
+            mut builder,
+            token_id,
+            session,
+        } = magic_link_fixture(&realm, &user);
+
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            Vec::new(),
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_authorization_code(&mut builder, session);
+
+        Arc::get_mut(&mut builder.magic_link_repo)
+            .unwrap()
+            .expect_delete_by_token_id()
+            .returning(|_| Box::pin(async { Ok(()) }));
+
+        let service = builder.build();
+        let result = service
+            .verify_magic_link(VerifyMagicLinkInput {
+                magic_token_id: token_id,
+                magic_token: "raw_token".to_string(),
+            })
+            .await;
+
+        let url = result.expect("clicking the link already proves mailbox control");
+        assert!(
+            url.contains("code="),
+            "expected an authorization code in {url}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_magic_link_still_logs_in_a_user_owing_nothing() {
+        let realm = create_test_realm_with_name("test-realm");
+        let user = create_test_user_with_email(&realm, "user@example.com");
+
+        let MagicLinkFixture {
+            mut builder,
+            token_id,
+            session,
+        } = magic_link_fixture(&realm, &user);
+
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            Vec::new(),
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_authorization_code(&mut builder, session);
+
+        Arc::get_mut(&mut builder.magic_link_repo)
+            .unwrap()
+            .expect_delete_by_token_id()
+            .returning(|_| Box::pin(async { Ok(()) }));
+
+        let service = builder.build();
+        let result = service
+            .verify_magic_link(VerifyMagicLinkInput {
+                magic_token_id: token_id,
+                magic_token: "raw_token".to_string(),
+            })
+            .await;
+
+        let url = result.expect("a user owing no step must still be logged in");
+        assert!(
+            url.contains("code="),
+            "expected an authorization code in {url}"
+        );
+    }
+
+    struct PasswordResetFixture {
+        builder: TridentTestBuilder,
+        token_id: Uuid,
+        session: AuthSession,
+    }
+
+    fn password_reset_fixture(
+        realm: &crate::domain::realm::entities::Realm,
+        user: &crate::domain::user::entities::User,
+    ) -> PasswordResetFixture {
+        let mut builder = TridentTestBuilder::new();
+        let token_id = Uuid::new_v4();
+        let session_code = Uuid::new_v4();
+        let session = auth_session_with_challenge_issued_at(realm, session_code, None);
+        let user_id = user.id;
+
+        let prt = PasswordResetToken {
+            id: Uuid::new_v4(),
+            user_id,
+            realm_id: Uuid::from(realm.id),
+            token_id,
+            token_hash: "hashed_token".to_string(),
+            created_at: Utc::now(),
+            expires_at: Utc::now() + Duration::minutes(30),
+            auth_session_code: Some(session_code),
+        };
+
+        Arc::get_mut(&mut builder.prt_repo)
+            .unwrap()
+            .expect_get_by_token_id()
+            .returning(move |_| {
+                let t = prt.clone();
+                Box::pin(async move { Ok(Some(t)) })
+            });
+
+        Arc::get_mut(&mut builder.hasher_repo)
+            .unwrap()
+            .expect_verify_magic_token()
+            .returning(|_, _| Box::pin(async { Ok(true) }));
+
+        Arc::get_mut(&mut builder.password_policy_repo)
+            .unwrap()
+            .expect_find_by_realm_id()
+            .returning(|_| Box::pin(async { Ok(None) }));
+
+        Arc::get_mut(&mut builder.credential_repo)
+            .unwrap()
+            .expect_delete_password_credential()
+            .returning(|_| Box::pin(async { Ok(()) }));
+
+        Arc::get_mut(&mut builder.hasher_repo)
+            .unwrap()
+            .expect_hash_password()
+            .returning(|_| {
+                Box::pin(async {
+                    Ok(HashResult::new(
+                        "new_hash".to_string(),
+                        "salt".to_string(),
+                        1,
+                        "argon2".to_string(),
+                    ))
+                })
+            });
+
+        Arc::get_mut(&mut builder.credential_repo)
+            .unwrap()
+            .expect_create_credential()
+            .times(1)
+            .returning(move |_, _, _, _, _| {
+                let cred = password_credential(user_id);
+                Box::pin(async move { Ok(cred) })
+            });
+
+        Arc::get_mut(&mut builder.prt_repo)
+            .unwrap()
+            .expect_delete_all_by_user_id()
+            .returning(|_| Box::pin(async { Ok(()) }));
+
+        Arc::get_mut(&mut builder.user_required_action_repo)
+            .unwrap()
+            .expect_remove_required_action()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+
+        Arc::get_mut(&mut builder.security_event_repo)
+            .unwrap()
+            .expect_store_event()
+            .returning(|_| Box::pin(async { Ok(()) }));
+
+        Arc::get_mut(&mut builder.webhook_repo)
+            .unwrap()
+            .expect_notify()
+            .returning(|_, _: WebhookPayload<()>| Box::pin(async { Ok(()) }));
+
+        let session_clone = session.clone();
+        Arc::get_mut(&mut builder.auth_session_repo)
+            .unwrap()
+            .expect_get_by_session_code()
+            .returning(move |_| {
+                let s = session_clone.clone();
+                Box::pin(async move { Ok(s) })
+            });
+
+        PasswordResetFixture {
+            builder,
+            token_id,
+            session,
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_password_reset_withholds_auto_login_while_an_action_is_pending() {
+        let realm = create_test_realm_with_name("test-realm");
+        let mut user = create_test_user_with_email(&realm, "user@example.com");
+        user.required_actions = vec![RequiredAction::ConfigureOtp];
+
+        let PasswordResetFixture {
+            mut builder,
+            token_id,
+            ..
+        } = password_reset_fixture(&realm, &user);
+
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            Vec::new(),
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_no_authorization_code(&mut builder);
+
+        let service = builder.with_user_access_revoked(1).build();
+        let output = service
+            .complete_password_reset(CompletePasswordResetInput {
+                token_id,
+                token: "raw_token".to_string(),
+                new_password: "Str0ng!P@ssword#2024".to_string(),
+            })
+            .await
+            .expect("the password change itself must still go through");
+
+        assert!(
+            output.login_url.is_none(),
+            "a residual required action must not be skipped by the reset auto-login"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_password_reset_still_logs_in_a_user_owing_nothing() {
+        let realm = create_test_realm_with_name("test-realm");
+        let user = create_test_user_with_email(&realm, "user@example.com");
+
+        let PasswordResetFixture {
+            mut builder,
+            token_id,
+            session,
+        } = password_reset_fixture(&realm, &user);
+
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            Vec::new(),
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_authorization_code(&mut builder, session);
+
+        let service = builder.with_user_access_revoked(1).build();
+        let output = service
+            .complete_password_reset(CompletePasswordResetInput {
+                token_id,
+                token: "raw_token".to_string(),
+                new_password: "Str0ng!P@ssword#2024".to_string(),
+            })
+            .await
+            .expect("password reset must succeed");
+
+        let url = output
+            .login_url
+            .expect("a user owing no step keeps the auto-login");
+        assert!(
+            url.contains("code="),
+            "expected an authorization code in {url}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_shared_gate_refuses_an_otp_holder_for_passkey_and_webauthn_callers() {
+        let mut builder = TridentTestBuilder::new();
+        let realm = create_test_realm_with_name("test-realm");
+        let user = create_test_user_with_email(&realm, "user@example.com");
+        let session = auth_session_with_challenge_issued_at(&realm, Uuid::new_v4(), None);
+
+        let credentials = vec![otp_credential(user.id)];
+        let user_id = user.id;
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            credentials,
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_no_authorization_code(&mut builder);
+
+        let service = builder.build();
+        let result = service
+            .store_auth_code_and_generate_login_url(&session, user_id, &[])
+            .await;
+
+        assert!(
+            matches!(result, Err(CoreError::Forbidden(_))),
+            "passkey and webauthn waive nothing, so an OTP credential must block: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn only_the_magic_link_path_waives_the_email_verification_step() {
+        let mut builder = TridentTestBuilder::new();
+        let realm = create_test_realm_with_name("test-realm");
+        let mut user = create_test_user_with_email(&realm, "user@example.com");
+        user.required_actions = vec![RequiredAction::VerifyEmail];
+        let session = auth_session_with_challenge_issued_at(&realm, Uuid::new_v4(), None);
+
+        let user_id = user.id;
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            Vec::new(),
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_no_authorization_code(&mut builder);
+
+        let service = builder.build();
+        let result = service
+            .store_auth_code_and_generate_login_url(&session, user_id, &[])
+            .await;
+
+        assert!(
+            matches!(result, Err(CoreError::Forbidden(_))),
+            "the VerifyEmail waiver belongs to the magic link path only: {result:?}"
         );
     }
 }

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -756,7 +756,7 @@ export namespace Schemas {
     require_uppercase: boolean;
     updated_at: string;
   };
-  export type PendingVerificationResponse = { message: string; user_id: string };
+  export type PendingActionResponse = { message: string; user_id: string };
   export type Permissions =
     | "create_client"
     | "manage_authorization"
@@ -836,7 +836,7 @@ export namespace Schemas {
   export type RegistrationResponse =
     | { data: JwtToken; status: "authenticated" }
     | { data: RedirectRegistrationResponse; status: "redirect" }
-    | { data: PendingVerificationResponse; status: "pending_verification" };
+    | { data: PendingActionResponse; status: "pending_action" };
   export type RemoveClientWhitelistEntryResponse = { message: string };
   export type RemoveRealmWhitelistEntryResponse = { message: string };
   export type ResendVerificationEmailResponse = { message: string };

--- a/libs/ferriskey-api-authentication/src/handlers/registration.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/registration.rs
@@ -37,7 +37,7 @@ pub struct RegistrationRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct PendingVerificationResponse {
+pub struct PendingActionResponse {
     pub message: String,
     pub user_id: Uuid,
 }
@@ -52,7 +52,7 @@ pub struct RedirectRegistrationResponse {
 pub enum RegistrationResponse {
     Authenticated(JwtToken),
     Redirect(RedirectRegistrationResponse),
-    PendingVerification(PendingVerificationResponse),
+    PendingAction(PendingActionResponse),
 }
 
 fn registration_verification_base_url(webapp_url: &str) -> String {
@@ -138,11 +138,8 @@ pub async fn registration_handler(
         RegisterUserOutput::Redirect { url } => Ok(Response::Created(
             RegistrationResponse::Redirect(RedirectRegistrationResponse { url }),
         )),
-        RegisterUserOutput::PendingVerification { message, user_id } => Ok(Response::Created(
-            RegistrationResponse::PendingVerification(PendingVerificationResponse {
-                message,
-                user_id,
-            }),
+        RegisterUserOutput::PendingAction { message, user_id } => Ok(Response::Created(
+            RegistrationResponse::PendingAction(PendingActionResponse { message, user_id }),
         )),
     }
 }
@@ -186,7 +183,7 @@ mod tests {
     #[test]
     fn test_pending_verification_response_serialization() {
         let user_id = Uuid::new_v4();
-        let response = PendingVerificationResponse {
+        let response = PendingActionResponse {
             message: "Please check your email".to_string(),
             user_id,
         };
@@ -197,9 +194,9 @@ mod tests {
     }
 
     #[test]
-    fn test_registration_response_pending_verification_serialization() {
+    fn test_registration_response_pending_action_serialization() {
         let user_id = Uuid::new_v4();
-        let response = RegistrationResponse::PendingVerification(PendingVerificationResponse {
+        let response = RegistrationResponse::PendingAction(PendingActionResponse {
             message: "Please verify your email".to_string(),
             user_id,
         });
@@ -208,7 +205,7 @@ mod tests {
         assert_eq!(
             json,
             serde_json::json!({
-                "status": "pending_verification",
+                "status": "pending_action",
                 "data": {
                     "message": "Please verify your email",
                     "user_id": user_id,

--- a/libs/ferriskey-domain/src/authentication/value_objects.rs
+++ b/libs/ferriskey-domain/src/authentication/value_objects.rs
@@ -106,9 +106,13 @@ pub enum RegisterUserOutput {
     /// Normal registration - returns JWT tokens
     Authenticated(JwtToken),
     /// Registration completed inside an OIDC flow - redirect to the original client
-    Redirect { url: String },
-    /// Email verification required - no tokens
-    PendingVerification { message: String, user_id: Uuid },
+    Redirect {
+        url: String,
+    },
+    PendingAction {
+        message: String,
+        user_id: Uuid,
+    },
 }
 
 pub struct GenerateTokensForUserInput {

--- a/libs/ferriskey-trident/src/mfa_policy.rs
+++ b/libs/ferriskey-trident/src/mfa_policy.rs
@@ -24,6 +24,44 @@ pub fn required_action_for_mfa(has_mfa_credential: bool) -> Option<RequiredActio
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingAuthStep {
+    RequiredActions(Vec<RequiredAction>),
+    OtpChallenge,
+}
+
+pub fn pending_auth_step(
+    persisted_actions: &[RequiredAction],
+    settings: Option<&RealmSetting>,
+    roles: &[Role],
+    has_otp_credential: bool,
+    has_temporary_password: bool,
+) -> Option<PendingAuthStep> {
+    let mut effective = persisted_actions.to_vec();
+
+    if has_temporary_password && !effective.contains(&RequiredAction::UpdatePassword) {
+        effective.push(RequiredAction::UpdatePassword);
+    }
+
+    if !has_temporary_password && user_requires_mfa(settings, roles) {
+        if let Some(action) = required_action_for_mfa(has_otp_credential)
+            && !effective.contains(&action)
+        {
+            effective.push(action);
+        }
+    }
+
+    if !effective.is_empty() {
+        return Some(PendingAuthStep::RequiredActions(effective));
+    }
+
+    if has_otp_credential {
+        return Some(PendingAuthStep::OtpChallenge);
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,5 +136,144 @@ mod tests {
     fn has_mfa_credential_returns_none() {
         let action = required_action_for_mfa(true);
         assert_eq!(action, None);
+    }
+
+    #[test]
+    fn no_pending_step_for_a_plain_user() {
+        let settings = make_realm_setting(false);
+        let role = make_role(false);
+        assert_eq!(
+            pending_auth_step(&[], Some(&settings), &[role], false, false),
+            None
+        );
+    }
+
+    #[test]
+    fn an_otp_credential_alone_demands_a_challenge() {
+        let settings = make_realm_setting(false);
+        let role = make_role(false);
+        assert_eq!(
+            pending_auth_step(&[], Some(&settings), &[role], true, false),
+            Some(PendingAuthStep::OtpChallenge)
+        );
+    }
+
+    #[test]
+    fn a_persisted_action_outranks_the_otp_challenge() {
+        let settings = make_realm_setting(false);
+        let role = make_role(false);
+        assert_eq!(
+            pending_auth_step(
+                &[RequiredAction::UpdatePassword],
+                Some(&settings),
+                &[role],
+                true,
+                false
+            ),
+            Some(PendingAuthStep::RequiredActions(vec![
+                RequiredAction::UpdatePassword
+            ]))
+        );
+    }
+
+    #[test]
+    fn realm_level_mfa_without_a_credential_demands_enrolment() {
+        let settings = make_realm_setting(true);
+        let role = make_role(false);
+        assert_eq!(
+            pending_auth_step(&[], Some(&settings), &[role], false, false),
+            Some(PendingAuthStep::RequiredActions(vec![
+                RequiredAction::ConfigureOtp
+            ]))
+        );
+    }
+
+    #[test]
+    fn role_level_mfa_without_a_credential_demands_enrolment() {
+        let settings = make_realm_setting(false);
+        let role = make_role(true);
+        assert_eq!(
+            pending_auth_step(&[], Some(&settings), &[role], false, false),
+            Some(PendingAuthStep::RequiredActions(vec![
+                RequiredAction::ConfigureOtp
+            ]))
+        );
+    }
+
+    #[test]
+    fn a_temporary_password_is_settled_before_mfa_enrolment() {
+        let settings = make_realm_setting(true);
+        let role = make_role(false);
+        assert_eq!(
+            pending_auth_step(
+                &[RequiredAction::UpdatePassword],
+                Some(&settings),
+                &[role],
+                false,
+                true
+            ),
+            Some(PendingAuthStep::RequiredActions(vec![
+                RequiredAction::UpdatePassword
+            ]))
+        );
+    }
+
+    #[test]
+    fn enrolment_is_not_demanded_twice() {
+        let settings = make_realm_setting(true);
+        let role = make_role(false);
+        assert_eq!(
+            pending_auth_step(
+                &[RequiredAction::ConfigureOtp],
+                Some(&settings),
+                &[role],
+                false,
+                false
+            ),
+            Some(PendingAuthStep::RequiredActions(vec![
+                RequiredAction::ConfigureOtp
+            ]))
+        );
+    }
+
+    #[test]
+    fn a_realm_without_settings_still_honours_role_level_mfa() {
+        let role = make_role(true);
+        assert_eq!(
+            pending_auth_step(&[], None, &[role], false, false),
+            Some(PendingAuthStep::RequiredActions(vec![
+                RequiredAction::ConfigureOtp
+            ]))
+        );
+    }
+
+    #[test]
+    fn a_temporary_password_is_owed_even_when_nothing_was_persisted() {
+        let settings = make_realm_setting(false);
+        let role = make_role(false);
+        assert_eq!(
+            pending_auth_step(&[], Some(&settings), &[role], false, true),
+            Some(PendingAuthStep::RequiredActions(vec![
+                RequiredAction::UpdatePassword
+            ]))
+        );
+    }
+
+    #[test]
+    fn a_temporary_password_is_not_owed_twice() {
+        let settings = make_realm_setting(false);
+        let role = make_role(false);
+        assert_eq!(
+            pending_auth_step(
+                &[RequiredAction::UpdatePassword],
+                Some(&settings),
+                &[role],
+                false,
+                true
+            ),
+            Some(PendingAuthStep::RequiredActions(vec![
+                RequiredAction::UpdatePassword
+            ]))
+        );
     }
 }

--- a/libs/ferriskey-trident/src/mfa_policy.rs
+++ b/libs/ferriskey-trident/src/mfa_policy.rs
@@ -43,12 +43,12 @@ pub fn pending_auth_step(
         effective.push(RequiredAction::UpdatePassword);
     }
 
-    if !has_temporary_password && user_requires_mfa(settings, roles) {
-        if let Some(action) = required_action_for_mfa(has_otp_credential)
-            && !effective.contains(&action)
-        {
-            effective.push(action);
-        }
+    if !has_temporary_password
+        && user_requires_mfa(settings, roles)
+        && let Some(action) = required_action_for_mfa(has_otp_credential)
+        && !effective.contains(&action)
+    {
+        effective.push(action);
     }
 
     if !effective.is_empty() {


### PR DESCRIPTION
## Context

FK-008 — the `authorization_code` browser flow enforced MFA and required actions, but every alternate authentication path issued full tokens without consulting them. An account owing a second factor, a password change or an email verification could obtain a complete token pair through:

- the `password` grant (ROPC),
- the magic-link callback,
- the password-reset completion,
- passkey / WebAuthn authentication.

The enforcement lived inside one flow rather than behind the token issuance itself, so each new authentication path silently re-opened the hole.

## Approach

A single predicate now answers "does this account still owe an authentication step", and every path consults it.

`libs/ferriskey-trident/src/mfa_policy.rs` gains `pending_auth_step`, returning `Option<PendingAuthStep>`:

- `RequiredActions(Vec<RequiredAction>)` — persisted actions, plus MFA enrolment when the realm or a role mandates it, plus `UpdatePassword` when the password is temporary;
- `OtpChallenge` — an enrolled authenticator whose challenge has not been answered.

It is a pure function over `(persisted_actions, realm_settings, roles, has_otp_credential, has_temporary_password)`, locked by 17 unit tests.

Both `AuthServiceImpl` and `TridentServiceImpl` resolve their inputs from the repositories and delegate to it. Persisted actions are read through `user_required_action_repository` rather than `user.required_actions`, which is not authoritative.

## Behaviour changes

**`password` grant / auto-login** — refused with `403` when a step is pending, naming the step and directing the caller to the browser flow. The admin path is unaffected and guarded by `an_admin_owing_nothing_still_gets_a_direct_grant`; ROPC via `admin-cli` remains the bootstrap and integration-test login.

**`authorization_code`** — refuses on `RequiredActions` only, never on `OtpChallenge`. A user holding an OTP credential produces `OtpChallenge` permanently, since the credential does not disappear once the challenge is answered; refusing there would have locked out every MFA user after an otherwise complete browser flow.

**Magic link / passkey / WebAuthn / password reset** — the free function `store_auth_code_and_generate_login_url` was deleted and replaced by a method on `TridentServiceImpl`, so no new caller can reach `update_code_and_user_id` without passing the guard. All four callers are covered; only the magic link waives `VerifyEmail`, which it has by definition just satisfied.

**Registration** — returns `PendingAction { message, user_id }` instead of tokens when the realm mandates MFA. Returning an error would have failed the request *after* the account was created and the webhook had fired.

## Public API change

The registration response serde tag changes from `pending_verification` to `pending_action`, with `PendingVerificationResponse` renamed to `PendingActionResponse`. `front/src/api/api.client.ts` is updated by hand (full OpenAPI→TS regeneration is broken on this repository). No front-end code branches on the tag today; an external consumer would.

## Known limitations

- Magic link and passkey **fail closed with `403`** rather than returning a proper "action required" status. Doing it properly needs a change to `core/src/domain/trident/ports.rs` plus a JWT service inside `TridentServiceImpl` — a 20th generic parameter. Acknowledged debt.
- `TridentServiceImpl` now carries 19 generic parameters. The signature is at the point where it should become a struct of collaborators; out of scope here.

## Found, not fixed

- `core/src/domain/trident/services.rs:830` — `webauthn_public_key_authenticate` never checks `auth_session.realm_id == user.realm_id`, whereas `passkey_authenticate:1046` does. The new guard derives its realm from `user.realm_id` and so is not affected, but the underlying IDOR remains.
- `core/src/domain/user/services.rs:335-341` — `reset_password` sets `temporary: true` without persisting `RequiredAction::UpdatePassword`. The browser flow infers it at runtime and `pending_auth_step` now does the same, but any direct read of the required-actions table sees an account owing nothing. Fixing it at the source would make that inference unnecessary everywhere.

## Verification

```
cargo fmt --all -- --check          # clean
cargo clippy --workspace --all-targets   # 0 errors
cargo test --workspace              # 0 failures
tsc --noEmit (front)                # clean
```

30 tests added: 10 on `pending_auth_step`, 12 on the authentication service, 8 on the trident paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified handling for required authentication steps, including MFA enrollment, OTP challenges, temporary passwords, and pending actions.
  * Authentication flows now identify and resolve the next required step based on account, realm, and role settings.
  * Added options to explicitly bypass selected actions where supported.

* **Bug Fixes**
  * Prevented token issuance when required authentication steps remain incomplete.
  * Improved registration, password reset, magic-link, and authorization-code flows.

* **API Changes**
  * Renamed the pending registration status from `pending_verification` to `pending_action`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->