### PR TITLE
ci: lint test targets and fix the lints they were hiding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         pass_filenames: false
       - id: rust-clippy
         name: rust-clippy
-        entry: cargo clippy --all --exclude ferriskey-client -- -D warnings
+        entry: cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings
         language: system
         files: ^(.*)\.rs|Cargo\.(toml|lock)$
         exclude: ^client/

--- a/api/tests/pkce_test.rs
+++ b/api/tests/pkce_test.rs
@@ -292,7 +292,7 @@ mod tests {
                 .add_query_param("client_id", &ctx.plain_client_id)
                 .add_query_param("redirect_uri", "http://localhost/callback")
                 .add_query_param("scope", "openid")
-                .add_query_param("code_challenge", &challenge)
+                .add_query_param("code_challenge", challenge)
                 .add_query_param("code_challenge_method", "S256")
                 .await;
 
@@ -348,7 +348,7 @@ mod tests {
             let token_resp = server
                 .post(&token_url(realm()))
                 .content_type("application/x-www-form-urlencoded")
-                .text(&format!(
+                .text(format!(
                     "grant_type=authorization_code&client_id={}&code={}&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&code_verifier={}",
                     ctx.plain_client_id, code, verifier
                 ))
@@ -378,7 +378,7 @@ mod tests {
                 .add_query_param("client_id", &ctx.plain_client_id)
                 .add_query_param("redirect_uri", "http://localhost/callback")
                 .add_query_param("scope", "openid")
-                .add_query_param("code_challenge", &challenge)
+                .add_query_param("code_challenge", challenge)
                 .add_query_param("code_challenge_method", "S256")
                 .await;
 
@@ -409,7 +409,7 @@ mod tests {
             let token_resp = server
                 .post(&token_url(realm()))
                 .content_type("application/x-www-form-urlencoded")
-                .text(&format!(
+                .text(format!(
                     "grant_type=authorization_code&client_id={}&code={}&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&code_verifier={}",
                     ctx.plain_client_id, code, wrong_verifier
                 ))

--- a/api/tests/refresh_token_rotation_test.rs
+++ b/api/tests/refresh_token_rotation_test.rs
@@ -18,7 +18,6 @@ mod tests {
     use std::{env, sync::Arc};
 
     use axum::Router;
-    use axum::http::HeaderValue;
     use axum_test::{TestResponse, TestServer};
     use ferriskey_api::{
         application::http::server::{app_state::AppState, http_server::router},
@@ -30,7 +29,7 @@ mod tests {
             DatabaseConfig, FerriskeyConfig, entities::StartupConfig, ports::CoreService,
         },
     };
-    use serde_json::{Value, json};
+    use serde_json::Value;
     use sqlx::Executor;
     use uuid::Uuid;
 
@@ -48,7 +47,7 @@ mod tests {
     struct SharedContext {
         app: std::sync::Mutex<Router>,
         realm_name: String,
-        pool: sqlx::PgPool,
+        _pool: sqlx::PgPool,
     }
 
     static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
@@ -147,7 +146,7 @@ mod tests {
         SharedContext {
             app: std::sync::Mutex::new(app),
             realm_name,
-            pool,
+            _pool: pool,
         }
     }
 

--- a/core/src/application/token_revocation.rs
+++ b/core/src/application/token_revocation.rs
@@ -160,7 +160,7 @@ mod tests {
     async fn revoke_all_user_access_revokes_tokens_and_drops_sessions() {
         let user_id = Uuid::new_v4();
         let realm_id = Uuid::new_v4();
-        let sessions = vec![
+        let sessions = [
             make_session(user_id, realm_id),
             make_session(user_id, realm_id),
         ];

--- a/libs/ferriskey-mail/src/email_verification/services.rs
+++ b/libs/ferriskey-mail/src/email_verification/services.rs
@@ -871,7 +871,7 @@ mod tests {
             let token = EmailVerificationToken {
                 id: Uuid::new_v4(),
                 user_id: Uuid::new_v4(),
-                realm_id: Uuid::new_v4().into(),
+                realm_id: Uuid::new_v4(),
                 token_hash: "hash".to_string(),
                 expires_at: Utc::now() + Duration::hours(24),
                 created_at: Utc::now(),
@@ -1153,7 +1153,7 @@ mod tests {
                 Ok(EmailVerificationToken {
                     id: Uuid::new_v4(),
                     user_id: Uuid::new_v4(),
-                    realm_id: Uuid::new_v4().into(),
+                    realm_id: Uuid::new_v4(),
                     token_hash: "hash".to_string(),
                     expires_at: Utc::now() + Duration::hours(24),
                     created_at: Utc::now(),
@@ -1235,7 +1235,7 @@ mod tests {
                 Ok(EmailVerificationToken {
                     id: Uuid::new_v4(),
                     user_id: Uuid::new_v4(),
-                    realm_id: Uuid::new_v4().into(),
+                    realm_id: Uuid::new_v4(),
                     token_hash: "hash".to_string(),
                     expires_at: Utc::now() + Duration::hours(24),
                     created_at: Utc::now(),

--- a/libs/ferriskey-seawatch/src/hashing.rs
+++ b/libs/ferriskey-seawatch/src/hashing.rs
@@ -199,7 +199,7 @@ mod tests {
         let mut prev = GENESIS_PREV_HASH;
         let mut events = Vec::with_capacity(count);
         for _ in 0..count {
-            let mut e = make_event(realm_id.clone());
+            let mut e = make_event(realm_id);
             let hash = compute_event_hash(&e, &prev);
             e.prev_hash = Some(prev);
             e.event_hash = Some(hash);


### PR DESCRIPTION
## Context

The clippy hook runs `cargo clippy --all --exclude ferriskey-client -- -D warnings` — **without `--all-targets`**. Test targets are therefore never linted, and no CI job compiles them either. A pull request can be entirely green while `cargo check --all-targets` fails.

This is not hypothetical. It has cost the repository twice in the last two days:

- **#1225** — #1223 added `webapp_url` to `FerriskeyConfig`/`StartupConfig` while #1224 added a test file written against the previous shape. Git merged cleanly, CI stayed green, and `main` no longer compiled its test targets.
- **#1233** — a `collapsible_if` slipped through local verification because clippy without `-D warnings` reports it as a warning. CI caught that one only because the lint was in a lib target.

## Change

`--all-targets` is added to the hook, and the 12 lints it surfaces are fixed:

| Crate | Lint | Count |
|---|---|---|
| `ferriskey-mail` | `useless_conversion` on `Uuid` | 3 |
| `ferriskey-api` (`pkce_test`) | `needless_borrow` | 4 |
| `ferriskey-api` (`refresh_token_rotation_test`) | unused imports, unread field | 3 |
| `ferriskey-seawatch` | `clone_on_copy` on `RealmId` | 1 |
| `ferriskey-core` | `useless_vec` | 1 |

All are in test code, and none change behaviour. `refresh_token_rotation_test`'s unread `pool` field is renamed `_pool` rather than removed, so the `PgPool` keeps its lifetime rather than being dropped early.

Each fix uncovered the next one — clippy stops at the first failing crate — so the lints were spread across four crates that had never been checked.

## Verification

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded automated lint checks to cover all build targets.
  - Cleaned up test fixtures and request setup for clearer, more consistent validation.

- **Tests**
  - Updated authentication, token, email verification, and revocation test data handling.
  - Removed unnecessary conversions, clones, imports, and unused fixture fields without changing expected behavior.
  - Maintained existing test coverage and assertions while improving test reliability and code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->