### PR TITLE
fix: make an approved device code single-use and subject to expiry

### DIFF
--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -362,6 +362,49 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn second_poll_after_token_issuance_returns_invalid_grant() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let client_id = create_device_client(&server, &admin_token).await;
+
+            let init_body = initiate(&server, &client_id, Some("openid")).await;
+            let device_code = init_body["device_code"].as_str().expect("device_code");
+            let user_code = init_body["user_code"].as_str().expect("user_code");
+
+            let verify_resp = verify(&server, &admin_token, user_code, "approve").await;
+            assert_eq!(
+                verify_resp.status_code(),
+                200,
+                "approve failed: {}",
+                verify_resp.text()
+            );
+
+            let first = poll(&server, &client_id, device_code).await;
+            assert_eq!(
+                first.status_code(),
+                200,
+                "first poll must issue a token: {}",
+                first.text()
+            );
+
+            let second = poll(&server, &client_id, device_code).await;
+            assert_eq!(
+                second.status_code(),
+                400,
+                "a device_code must not be replayable: {}",
+                second.text()
+            );
+            let body: Value = second.json();
+            assert_eq!(
+                body["error"], "invalid_grant",
+                "replay must be refused as invalid_grant: {body:?}"
+            );
+        });
+    }
+
+    #[test]
+    #[ignore]
     fn poll_before_verify_returns_authorization_pending() {
         let server = make_server();
         rt().block_on(async {

--- a/core/src/domain/authentication/device_flow/entities.rs
+++ b/core/src/domain/authentication/device_flow/entities.rs
@@ -84,6 +84,9 @@ pub enum DeviceAuthStatus {
     /// returns `expired_token`.
     #[serde(rename = "expired")]
     Expired,
+
+    #[serde(rename = "consumed")]
+    Consumed,
 }
 
 impl DeviceAuthStatus {
@@ -94,6 +97,7 @@ impl DeviceAuthStatus {
             DeviceAuthStatus::Approved => "approved",
             DeviceAuthStatus::Denied => "denied",
             DeviceAuthStatus::Expired => "expired",
+            DeviceAuthStatus::Consumed => "consumed",
         }
     }
 
@@ -104,6 +108,7 @@ impl DeviceAuthStatus {
             "approved" => Some(DeviceAuthStatus::Approved),
             "denied" => Some(DeviceAuthStatus::Denied),
             "expired" => Some(DeviceAuthStatus::Expired),
+            "consumed" => Some(DeviceAuthStatus::Consumed),
             _ => None,
         }
     }

--- a/core/src/domain/authentication/device_flow/ports.rs
+++ b/core/src/domain/authentication/device_flow/ports.rs
@@ -35,6 +35,7 @@ pub trait DeviceAuthRepository: Send + Sync {
     fn update_status(
         &self,
         device_code: Uuid,
+        expected: DeviceAuthStatus,
         status: DeviceAuthStatus,
         user_id: Option<Uuid>,
     ) -> impl Future<Output = Result<DeviceAuthSession, AuthenticationError>> + Send;

--- a/core/src/domain/authentication/device_flow/services.rs
+++ b/core/src/domain/authentication/device_flow/services.rs
@@ -169,6 +169,7 @@ where
         match session.status {
             DeviceAuthStatus::Denied => return Err(DeviceFlowError::AccessDenied),
             DeviceAuthStatus::Expired => return Err(DeviceFlowError::ExpiredToken),
+            DeviceAuthStatus::Consumed => return Err(DeviceFlowError::InvalidUserCode),
             // Idempotent: re-approving an already approved session is a no-op.
             DeviceAuthStatus::Approved => return Ok(()),
             DeviceAuthStatus::Pending => {}
@@ -181,6 +182,7 @@ where
         self.device_auth_repository
             .update_status(
                 session.device_code,
+                DeviceAuthStatus::Pending,
                 DeviceAuthStatus::Approved,
                 Some(user_id),
             )
@@ -196,9 +198,26 @@ where
             .await?
             .ok_or(DeviceFlowError::InvalidUserCode)?;
 
+        match session.status {
+            DeviceAuthStatus::Denied => return Ok(()),
+            DeviceAuthStatus::Approved => return Err(DeviceFlowError::InvalidUserCode),
+            DeviceAuthStatus::Expired => return Err(DeviceFlowError::ExpiredToken),
+            DeviceAuthStatus::Consumed => return Err(DeviceFlowError::InvalidUserCode),
+            DeviceAuthStatus::Pending => {}
+        }
+
+        if session.is_expired() {
+            return Err(DeviceFlowError::ExpiredToken);
+        }
+
         let session = self
             .device_auth_repository
-            .update_status(session.device_code, DeviceAuthStatus::Denied, Some(user_id))
+            .update_status(
+                session.device_code,
+                DeviceAuthStatus::Pending,
+                DeviceAuthStatus::Denied,
+                Some(user_id),
+            )
             .await?;
 
         self.fire_event(&session, WebhookTrigger::AuthDeviceFlowDenied)
@@ -219,6 +238,25 @@ where
             return Err(DeviceFlowError::InvalidClient);
         }
 
+        if session.is_expired() {
+            if session.status == DeviceAuthStatus::Pending
+                && let Ok(expired) = self
+                    .device_auth_repository
+                    .update_status(
+                        session.device_code,
+                        DeviceAuthStatus::Pending,
+                        DeviceAuthStatus::Expired,
+                        None,
+                    )
+                    .await
+            {
+                self.fire_event(&expired, WebhookTrigger::AuthDeviceFlowExpired)
+                    .await;
+            }
+
+            return Err(DeviceFlowError::ExpiredToken);
+        }
+
         match session.status {
             DeviceAuthStatus::Approved => {
                 let user_id = session.user_id.ok_or_else(|| {
@@ -226,6 +264,16 @@ where
                         "approved session has no associated user".to_string(),
                     )
                 })?;
+
+                self.device_auth_repository
+                    .update_status(
+                        session.device_code,
+                        DeviceAuthStatus::Approved,
+                        DeviceAuthStatus::Consumed,
+                        None,
+                    )
+                    .await
+                    .map_err(|_| DeviceFlowError::InvalidDeviceCode)?;
 
                 self.token_issuer
                     .issue_tokens_for_user(GenerateTokensForUserInput {
@@ -237,22 +285,10 @@ where
                     .await
                     .map_err(|err| DeviceFlowError::TokenIssuance(err.to_string()))
             }
+            DeviceAuthStatus::Consumed => Err(DeviceFlowError::InvalidDeviceCode),
             DeviceAuthStatus::Denied => Err(DeviceFlowError::AccessDenied),
             DeviceAuthStatus::Expired => Err(DeviceFlowError::ExpiredToken),
             DeviceAuthStatus::Pending => {
-                // Time-based expiry takes precedence: terminate the session.
-                if session.is_expired() {
-                    let session = self
-                        .device_auth_repository
-                        .update_status(session.device_code, DeviceAuthStatus::Expired, None)
-                        .await?;
-
-                    self.fire_event(&session, WebhookTrigger::AuthDeviceFlowExpired)
-                        .await;
-
-                    return Err(DeviceFlowError::ExpiredToken);
-                }
-
                 // Anti-bruteforce: reject polls arriving faster than `interval`.
                 if let Some(last_polled_at) = session.last_polled_at {
                     let next_allowed = last_polled_at + Duration::seconds(session.interval);
@@ -287,6 +323,7 @@ mod tests {
     use crate::domain::authentication::device_flow::value_objects::{
         InitiateDeviceFlowParams, PollDeviceTokenParams,
     };
+    use crate::domain::authentication::entities::AuthenticationError;
     use crate::domain::common::entities::app_errors::CoreError;
     use crate::domain::realm::entities::RealmId;
     use crate::domain::webhook::entities::webhook_payload::WebhookPayload;
@@ -459,11 +496,14 @@ mod tests {
             .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
         device_repo
             .expect_update_status()
-            .withf(move |dc, status, uid| {
-                *dc == device_code && *status == DeviceAuthStatus::Approved && *uid == Some(user_id)
+            .withf(move |dc, expected, status, uid| {
+                *dc == device_code
+                    && *expected == DeviceAuthStatus::Pending
+                    && *status == DeviceAuthStatus::Approved
+                    && *uid == Some(user_id)
             })
             .times(1)
-            .return_once(move |_, _, _| {
+            .return_once(move |_, _, _, _| {
                 let mut s = pending_session(Uuid::new_v4());
                 s.status = DeviceAuthStatus::Approved;
                 s.user_id = Some(user_id);
@@ -514,9 +554,13 @@ mod tests {
             .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
         device_repo
             .expect_update_status()
-            .withf(move |dc, status, _| *dc == device_code && *status == DeviceAuthStatus::Denied)
+            .withf(move |dc, expected, status, _| {
+                *dc == device_code
+                    && *expected == DeviceAuthStatus::Pending
+                    && *status == DeviceAuthStatus::Denied
+            })
             .times(1)
-            .return_once(move |_, _, _| {
+            .return_once(move |_, _, _, _| {
                 let mut s = pending_session(Uuid::new_v4());
                 s.status = DeviceAuthStatus::Denied;
                 Box::pin(async move { Ok(s) })
@@ -551,6 +595,19 @@ mod tests {
             .expect_find_by_device_code()
             .times(1)
             .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        device_repo
+            .expect_update_status()
+            .withf(move |dc, expected, status, _| {
+                *dc == device_code
+                    && *expected == DeviceAuthStatus::Approved
+                    && *status == DeviceAuthStatus::Consumed
+            })
+            .times(1)
+            .return_once(move |_, _, _, _| {
+                let mut s = pending_session(client_id);
+                s.status = DeviceAuthStatus::Consumed;
+                Box::pin(async move { Ok(s) })
+            });
         issuer
             .expect_issue_tokens_for_user()
             .withf(move |input| input.user_id == user_id && input.client_id == Some(client_id))
@@ -686,9 +743,13 @@ mod tests {
             .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
         device_repo
             .expect_update_status()
-            .withf(move |dc, status, _| *dc == device_code && *status == DeviceAuthStatus::Expired)
+            .withf(move |dc, expected, status, _| {
+                *dc == device_code
+                    && *expected == DeviceAuthStatus::Pending
+                    && *status == DeviceAuthStatus::Expired
+            })
             .times(1)
-            .return_once(move |_, _, _| {
+            .return_once(move |_, _, _, _| {
                 let mut s = pending_session(client_id);
                 s.status = DeviceAuthStatus::Expired;
                 Box::pin(async move { Ok(s) })
@@ -797,6 +858,133 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_consumed_session_no_longer_yields_a_token() {
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        session.status = DeviceAuthStatus::Consumed;
+        session.user_id = Some(Uuid::new_v4());
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::InvalidDeviceCode));
+    }
+
+    #[tokio::test]
+    async fn a_lost_consumption_race_issues_no_token() {
+        let user_id = Uuid::new_v4();
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        session.status = DeviceAuthStatus::Approved;
+        session.user_id = Some(user_id);
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        device_repo
+            .expect_update_status()
+            .times(1)
+            .return_once(move |_, _, _, _| {
+                Box::pin(async move { Err(AuthenticationError::NotFound) })
+            });
+
+        let issuer = MockDeviceTokenIssuer::new();
+
+        let service = build(device_repo, MockWebhookRepository::new(), issuer);
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::InvalidDeviceCode));
+    }
+
+    #[tokio::test]
+    async fn an_approved_session_still_expires() {
+        let user_id = Uuid::new_v4();
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        session.status = DeviceAuthStatus::Approved;
+        session.user_id = Some(user_id);
+        session.expires_at = Utc::now() - Duration::seconds(1);
+        let device_code = session.device_code;
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_device_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .poll(PollDeviceTokenParams {
+                device_code,
+                client_id,
+                base_url: "https://auth.example.com".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::ExpiredToken));
+    }
+
+    #[tokio::test]
+    async fn deny_cannot_overturn_an_approved_session() {
+        let client_id = Uuid::new_v4();
+        let mut session = pending_session(client_id);
+        session.status = DeviceAuthStatus::Approved;
+        session.user_id = Some(Uuid::new_v4());
+        let user_code = session.user_code.clone();
+
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_user_code()
+            .times(1)
+            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .deny(user_code.into_inner(), Uuid::new_v4())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::InvalidUserCode));
+    }
+
+    #[tokio::test]
     async fn poll_token_issuance_failure_is_surfaced() {
         let user_id = Uuid::new_v4();
         let client_id = Uuid::new_v4();
@@ -812,6 +1000,14 @@ mod tests {
             .expect_find_by_device_code()
             .times(1)
             .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+        device_repo
+            .expect_update_status()
+            .times(1)
+            .return_once(move |_, _, _, _| {
+                let mut s = pending_session(client_id);
+                s.status = DeviceAuthStatus::Consumed;
+                Box::pin(async move { Ok(s) })
+            });
         issuer
             .expect_issue_tokens_for_user()
             .times(1)

--- a/core/src/infrastructure/repositories/device_auth_repository.rs
+++ b/core/src/infrastructure/repositories/device_auth_repository.rs
@@ -31,7 +31,7 @@ impl From<DasModel> for DeviceAuthSession {
             user_code: UserCode::new(model.user_code),
             scope: model.scope,
             status: DeviceAuthStatus::from_db_value(&model.status)
-                .unwrap_or(DeviceAuthStatus::Pending),
+                .unwrap_or(DeviceAuthStatus::Expired),
             user_id: model.user_id,
             interval: i64::from(model.interval_seconds),
             created_at,
@@ -130,6 +130,7 @@ impl DeviceAuthRepository for PostgresDeviceAuthRepository {
     async fn update_status(
         &self,
         device_code: Uuid,
+        expected: DeviceAuthStatus,
         status: DeviceAuthStatus,
         user_id: Option<Uuid>,
     ) -> Result<DeviceAuthSession, AuthenticationError> {
@@ -142,6 +143,7 @@ impl DeviceAuthRepository for PostgresDeviceAuthRepository {
 
         let model = update
             .filter(DasColumn::DeviceCode.eq(device_code))
+            .filter(DasColumn::Status.eq(expected.as_str()))
             .exec_with_returning(&self.db)
             .await
             .map_err(|e| {


### PR DESCRIPTION
## Context

FK-010, first of five parts. An approved `device_code` was a permanent bearer secret: the `Approved` branch of `poll` issued a fresh access/refresh pair on every call, and never consumed the session, never checked expiry, never marked the poll. Expiry was only evaluated inside the `Pending` branch, so an approved session outlived its own `expires_at` forever.

Reproduced against the unpatched build: after one approval, a second `poll` with the same `device_code` returns **HTTP 200 with a complete, freshly minted token pair**. The device code is not a one-time grant — it is an unlimited, unrevocable credential.

## Change

**Single use.** A terminal `Consumed` status is set by compare-and-swap immediately before token issuance. The port's `update_status` now takes the expected current status, so the transition is `WHERE device_code = $1 AND status = $2`; if no row comes back, issuance is abandoned and the caller gets `invalid_grant`. This mirrors the existing CAS in `otp_enrollment_repository.rs`, written for FK-003.

Making the port carry the expected status is what turns every transition into a guarded one — the previous signature offered no way to express a precondition, which is why the state machine had none.

**Expiry applies to every state.** `session.is_expired()` moves to the top of `poll`, ahead of the `match`. An expired session is refused whatever its status; only a `Pending` one is additionally transitioned to `Expired` and fires the webhook, so the event still fires exactly once.

**`deny` gains preconditions.** It previously performed no check at all: any session, in any state, could be flipped to `Denied`, re-firing the webhook each time. It now refuses on approved, consumed and expired sessions, and its transition is CAS-guarded from `Pending`.

**Unknown status values fail closed.** `From<DasModel>` mapped unrecognised strings to `Pending`. During a mixed-version rollout that is exactly backwards: a writer emitting `"consumed"` before all readers know the variant would have every consumed session read back as `Pending` — re-issuable. The fallback is now `Expired`.

No migration: `status` is a bare `VARCHAR(32)` with no CHECK constraint and no Postgres enum, so `"consumed"` needs only the variant and its two conversion arms.

## Verification

Two existing unit tests failed on this change — `poll_returns_token_when_approved` and `poll_token_issuance_failure_is_surfaced` — because they asserted issuance with no consumption. They locked in the vulnerable behaviour and were updated to expect the CAS.

Added, 4 unit + 1 integration:

| Test | Asserts |
|---|---|
| `a_consumed_session_no_longer_yields_a_token` | replay is refused |
| `a_lost_consumption_race_issues_no_token` | losing the CAS aborts before the issuer is called |
| `an_approved_session_still_expires` | expiry is not confined to `Pending` |
| `deny_cannot_overturn_an_approved_session` | deny respects state |
| `second_poll_after_token_issuance_returns_invalid_grant` | end-to-end replay refusal |

The integration test was run against the unpatched domain to confirm it fails there — it returned 200 with a full token pair, which is the exploit.

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
cargo test -p ferriskey-api --test device_flow_test -- --ignored              # 8 passed
```

## Not in this PR

Parts 2 to 5 of FK-010, each its own PR off `main`: cross-realm approval, client authentication on the device endpoints, scope propagation and consent display, scheduled `purge_expired`.

Two defects found while verifying, both outside this PR's scope:

- `generate_tokens_for_user` (`core/src/domain/authentication/services.rs:3948-4065`) never checks `user.enabled`, while the password flows do (`:2158`, `:2322`, `:2597`). This affects every caller, not just the device flow.
- `PollDeviceTokenInput` and `VerifyUserCodeInput` are dead code carrying exactly the fields the live path lacks — `client_secret` and `realm_name` respectively.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device authorization codes can no longer be reused after tokens are issued.
  * Prevented invalid transitions, such as denying already approved requests.
  * Expired and consumed device sessions are now handled consistently.
  * Concurrent token requests are safely rejected with an invalid device-code error.
* **Tests**
  * Added coverage for code reuse, expiration, session consumption, and competing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->