### PR TITLE
fix: scope device session approval to the caller realm

### DIFF
--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -318,6 +318,26 @@ mod tests {
             .await
     }
 
+    async fn verify_in_realm(
+        server: &TestServer,
+        realm_name: &str,
+        admin_token: &str,
+        user_code: &str,
+        action: &str,
+    ) -> TestResponse {
+        server
+            .post(&format!("/realms/{}/device/verify", realm_name))
+            .add_header(
+                "Cookie",
+                HeaderValue::from_str(&format!("FERRISKEY_IDENTITY={admin_token}")).unwrap(),
+            )
+            .json(&json!({
+                "user_code": user_code,
+                "action": action
+            }))
+            .await
+    }
+
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
@@ -357,6 +377,44 @@ mod tests {
                 .as_str()
                 .expect("access_token in poll response");
             assert!(!access_token.is_empty(), "access_token must not be empty");
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn approval_through_another_realm_path_is_refused() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let client_id = create_device_client(&server, &admin_token).await;
+
+            let init_body = initiate(&server, &client_id, Some("openid")).await;
+            let device_code = init_body["device_code"].as_str().expect("device_code");
+            let user_code = init_body["user_code"].as_str().expect("user_code");
+
+            let other_realm = format!("other-{}", Uuid::new_v4().simple());
+
+            let resp =
+                verify_in_realm(&server, &other_realm, &admin_token, user_code, "approve").await;
+            assert_eq!(
+                resp.status_code(),
+                403,
+                "approval must be refused when the caller does not belong to the realm in the path: {}",
+                resp.text()
+            );
+
+            let poll_resp = poll(&server, &client_id, device_code).await;
+            assert_eq!(
+                poll_resp.status_code(),
+                400,
+                "the session must still be pending: {}",
+                poll_resp.text()
+            );
+            let body: Value = poll_resp.json();
+            assert_eq!(
+                body["error"], "authorization_pending",
+                "the refused approval must not have advanced the session: {body:?}"
+            );
         });
     }
 

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -4,6 +4,8 @@ use ferriskey_compass::recorder::FlowRecorder;
 use ferriskey_migrate::{entities::MigrationReport, error::MigrationError};
 use sea_orm::DatabaseConnection;
 
+use crate::domain::realm::entities::RealmId;
+
 use crate::{
     application::migrate::{build_runner, context::MigrationContext},
     domain::{
@@ -697,22 +699,56 @@ impl ApplicationService {
     /// identified by `user_code` and mark it approved (RFC 8628 §3.3).
     pub async fn verify_device_user_code(
         &self,
+        realm_name: String,
         user_code: String,
         user_id: uuid::Uuid,
+        user_realm_id: RealmId,
     ) -> Result<(), DeviceFlowError> {
+        let realm_id = self
+            .device_realm_for_actor(&realm_name, user_realm_id)
+            .await?;
+
         self.device_flow_service
-            .verify_user_code(user_code, user_id)
+            .verify_user_code(user_code, user_id, realm_id)
             .await
+    }
+
+    async fn device_realm_for_actor(
+        &self,
+        realm_name: &str,
+        user_realm_id: RealmId,
+    ) -> Result<RealmId, DeviceFlowError> {
+        let realm = self
+            .realm_service
+            .realm_repository
+            .get_by_name(realm_name)
+            .await
+            .map_err(|_| DeviceFlowError::Forbidden)?
+            .ok_or(DeviceFlowError::Forbidden)?;
+
+        if user_realm_id != realm.id {
+            return Err(DeviceFlowError::Forbidden);
+        }
+
+        Ok(realm.id)
     }
 
     /// Verification page: mark the device session identified by `user_code`
     /// as denied.
     pub async fn deny_device_user_code(
         &self,
+        realm_name: String,
         user_code: String,
         user_id: uuid::Uuid,
+        user_realm_id: RealmId,
     ) -> Result<(), DeviceFlowError> {
-        self.device_flow_service.deny(user_code, user_id).await
+        let realm_id = self
+            .device_realm_for_actor(&realm_name, user_realm_id)
+            .await?;
+
+        self.device_flow_service
+            .deny(user_code, user_id, realm_id)
+            .await
     }
 
     pub async fn list_user_sessions(

--- a/core/src/domain/authentication/device_flow/error.rs
+++ b/core/src/domain/authentication/device_flow/error.rs
@@ -50,6 +50,9 @@ pub enum DeviceFlowError {
     #[error("unauthorized_client")]
     UnauthorizedClient,
 
+    #[error("forbidden")]
+    Forbidden,
+
     /// Could not generate a collision-free user code within the retry budget.
     #[error("failed to generate a unique user code")]
     UserCodeGenerationExhausted,
@@ -74,6 +77,9 @@ impl From<DeviceFlowError> for CoreError {
             DeviceFlowError::InvalidUserCode => CoreError::InvalidToken,
             DeviceFlowError::InvalidClient => CoreError::InvalidClient,
             DeviceFlowError::UnauthorizedClient => CoreError::InvalidClient,
+            DeviceFlowError::Forbidden => {
+                CoreError::Forbidden("device session belongs to another realm".to_string())
+            }
             DeviceFlowError::UserCodeGenerationExhausted => CoreError::InternalServerError,
             DeviceFlowError::TokenIssuance(msg) => CoreError::TokenGenerationError(msg),
             DeviceFlowError::Repository(err) => err.into(),

--- a/core/src/domain/authentication/device_flow/ports.rs
+++ b/core/src/domain/authentication/device_flow/ports.rs
@@ -8,6 +8,7 @@ use crate::domain::authentication::device_flow::value_objects::{
 use crate::domain::authentication::entities::{AuthenticationError, JwtToken};
 use crate::domain::authentication::value_objects::GenerateTokensForUserInput;
 use crate::domain::common::entities::app_errors::CoreError;
+use crate::domain::realm::entities::RealmId;
 
 /// Persistence contract for device authorization sessions (RFC 8628).
 #[cfg_attr(test, mockall::automock)]
@@ -28,7 +29,13 @@ pub trait DeviceAuthRepository: Send + Sync {
     fn find_by_user_code(
         &self,
         user_code: String,
+        realm_id: RealmId,
     ) -> impl Future<Output = Result<Option<DeviceAuthSession>, AuthenticationError>> + Send;
+
+    fn user_code_exists(
+        &self,
+        user_code: String,
+    ) -> impl Future<Output = Result<bool, AuthenticationError>> + Send;
 
     /// Transition a session to a new status, optionally binding the approving
     /// user.
@@ -76,6 +83,7 @@ pub trait DeviceFlowService: Send + Sync {
         &self,
         user_code: String,
         user_id: Uuid,
+        realm_id: RealmId,
     ) -> impl Future<Output = Result<(), DeviceFlowError>> + Send;
 
     /// Verification page: mark the session denied and fire
@@ -84,6 +92,7 @@ pub trait DeviceFlowService: Send + Sync {
         &self,
         user_code: String,
         user_id: Uuid,
+        realm_id: RealmId,
     ) -> impl Future<Output = Result<(), DeviceFlowError>> + Send;
 
     /// Token endpoint: advance the polling state machine, returning a

--- a/core/src/domain/authentication/device_flow/services.rs
+++ b/core/src/domain/authentication/device_flow/services.rs
@@ -15,6 +15,7 @@ use crate::domain::authentication::device_flow::value_objects::{
 };
 use crate::domain::authentication::entities::JwtToken;
 use crate::domain::authentication::value_objects::GenerateTokensForUserInput;
+use crate::domain::realm::entities::RealmId;
 use crate::domain::webhook::entities::webhook_payload::WebhookPayload;
 use crate::domain::webhook::entities::webhook_trigger::WebhookTrigger;
 use crate::domain::webhook::ports::WebhookRepository;
@@ -79,12 +80,12 @@ where
     async fn generate_unique_user_code(&self) -> Result<UserCode, DeviceFlowError> {
         for _ in 0..MAX_USER_CODE_ATTEMPTS {
             let candidate = UserCode::generate();
-            let existing = self
+            let exists = self
                 .device_auth_repository
-                .find_by_user_code(candidate.as_str().to_string())
+                .user_code_exists(candidate.as_str().to_string())
                 .await?;
 
-            if existing.is_none() {
+            if !exists {
                 return Ok(candidate);
             }
         }
@@ -159,10 +160,11 @@ where
         &self,
         user_code: String,
         user_id: uuid::Uuid,
+        realm_id: RealmId,
     ) -> Result<(), DeviceFlowError> {
         let session = self
             .device_auth_repository
-            .find_by_user_code(user_code)
+            .find_by_user_code(user_code, realm_id)
             .await?
             .ok_or(DeviceFlowError::InvalidUserCode)?;
 
@@ -191,10 +193,15 @@ where
         Ok(())
     }
 
-    async fn deny(&self, user_code: String, user_id: uuid::Uuid) -> Result<(), DeviceFlowError> {
+    async fn deny(
+        &self,
+        user_code: String,
+        user_id: uuid::Uuid,
+        realm_id: RealmId,
+    ) -> Result<(), DeviceFlowError> {
         let session = self
             .device_auth_repository
-            .find_by_user_code(user_code)
+            .find_by_user_code(user_code, realm_id)
             .await?
             .ok_or(DeviceFlowError::InvalidUserCode)?;
 
@@ -372,9 +379,9 @@ mod tests {
         let issuer = MockDeviceTokenIssuer::new();
 
         device_repo
-            .expect_find_by_user_code()
+            .expect_user_code_exists()
             .times(1)
-            .returning(|_| Box::pin(async move { Ok(None) }));
+            .returning(|_| Box::pin(async move { Ok(false) }));
         device_repo
             .expect_create()
             .times(1)
@@ -418,18 +425,12 @@ mod tests {
         // First candidate collides, second is free.
         let mut calls = 0;
         device_repo
-            .expect_find_by_user_code()
+            .expect_user_code_exists()
             .times(2)
             .returning(move |_| {
                 calls += 1;
                 let collide = calls == 1;
-                Box::pin(async move {
-                    if collide {
-                        Ok(Some(pending_session(Uuid::new_v4())))
-                    } else {
-                        Ok(None)
-                    }
-                })
+                Box::pin(async move { Ok(collide) })
             });
         device_repo
             .expect_create()
@@ -493,7 +494,7 @@ mod tests {
         device_repo
             .expect_find_by_user_code()
             .times(1)
-            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+            .return_once(move |_, _| Box::pin(async move { Ok(Some(session)) }));
         device_repo
             .expect_update_status()
             .withf(move |dc, expected, status, uid| {
@@ -512,7 +513,11 @@ mod tests {
 
         let service = build(device_repo, webhook_repo, issuer);
         service
-            .verify_user_code("BCDF-GHJK".to_string(), user_id)
+            .verify_user_code(
+                "BCDF-GHJK".to_string(),
+                user_id,
+                RealmId::from(Uuid::new_v4()),
+            )
             .await
             .expect("verify should succeed");
     }
@@ -523,7 +528,7 @@ mod tests {
         device_repo
             .expect_find_by_user_code()
             .times(1)
-            .returning(|_| Box::pin(async move { Ok(None) }));
+            .returning(|_, _| Box::pin(async move { Ok(None) }));
 
         let service = build(
             device_repo,
@@ -531,7 +536,11 @@ mod tests {
             MockDeviceTokenIssuer::new(),
         );
         let err = service
-            .verify_user_code("ZZZZ-ZZZZ".to_string(), Uuid::new_v4())
+            .verify_user_code(
+                "ZZZZ-ZZZZ".to_string(),
+                Uuid::new_v4(),
+                RealmId::from(Uuid::new_v4()),
+            )
             .await
             .unwrap_err();
 
@@ -551,7 +560,7 @@ mod tests {
         device_repo
             .expect_find_by_user_code()
             .times(1)
-            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+            .return_once(move |_, _| Box::pin(async move { Ok(Some(session)) }));
         device_repo
             .expect_update_status()
             .withf(move |dc, expected, status, _| {
@@ -574,7 +583,11 @@ mod tests {
 
         let service = build(device_repo, webhook_repo, issuer);
         service
-            .deny("BCDF-GHJK".to_string(), user_id)
+            .deny(
+                "BCDF-GHJK".to_string(),
+                user_id,
+                RealmId::from(Uuid::new_v4()),
+            )
             .await
             .expect("deny should succeed");
     }
@@ -858,6 +871,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn approval_only_looks_inside_the_caller_realm() {
+        let realm_id = RealmId::from(Uuid::new_v4());
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_user_code()
+            .withf(move |_, r| *r == realm_id)
+            .times(1)
+            .returning(|_, _| Box::pin(async move { Ok(None) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .verify_user_code("BCDF-GHJK".to_string(), Uuid::new_v4(), realm_id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::InvalidUserCode));
+    }
+
+    #[tokio::test]
+    async fn denial_only_looks_inside_the_caller_realm() {
+        let realm_id = RealmId::from(Uuid::new_v4());
+        let mut device_repo = MockDeviceAuthRepository::new();
+        device_repo
+            .expect_find_by_user_code()
+            .withf(move |_, r| *r == realm_id)
+            .times(1)
+            .returning(|_, _| Box::pin(async move { Ok(None) }));
+
+        let service = build(
+            device_repo,
+            MockWebhookRepository::new(),
+            MockDeviceTokenIssuer::new(),
+        );
+        let err = service
+            .deny("BCDF-GHJK".to_string(), Uuid::new_v4(), realm_id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, DeviceFlowError::InvalidUserCode));
+    }
+
+    #[tokio::test]
     async fn a_consumed_session_no_longer_yields_a_token() {
         let client_id = Uuid::new_v4();
         let mut session = pending_session(client_id);
@@ -969,7 +1028,7 @@ mod tests {
         device_repo
             .expect_find_by_user_code()
             .times(1)
-            .return_once(move |_| Box::pin(async move { Ok(Some(session)) }));
+            .return_once(move |_, _| Box::pin(async move { Ok(Some(session)) }));
 
         let service = build(
             device_repo,
@@ -977,7 +1036,11 @@ mod tests {
             MockDeviceTokenIssuer::new(),
         );
         let err = service
-            .deny(user_code.into_inner(), Uuid::new_v4())
+            .deny(
+                user_code.into_inner(),
+                Uuid::new_v4(),
+                RealmId::from(Uuid::new_v4()),
+            )
             .await
             .unwrap_err();
 

--- a/core/src/infrastructure/repositories/device_auth_repository.rs
+++ b/core/src/infrastructure/repositories/device_auth_repository.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
-    prelude::Expr,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait,
+    PaginatorTrait, QueryFilter, prelude::Expr,
 };
 use tracing::error;
 use uuid::Uuid;
@@ -11,6 +11,7 @@ use crate::domain::authentication::device_flow::entities::{
 };
 use crate::domain::authentication::device_flow::ports::DeviceAuthRepository;
 use crate::domain::authentication::entities::AuthenticationError;
+use crate::domain::realm::entities::RealmId;
 use crate::entity::device_auth_sessions::{
     ActiveModel as DasActiveModel, Column as DasColumn, Entity as DasEntity, Model as DasModel,
 };
@@ -114,9 +115,11 @@ impl DeviceAuthRepository for PostgresDeviceAuthRepository {
     async fn find_by_user_code(
         &self,
         user_code: String,
+        realm_id: RealmId,
     ) -> Result<Option<DeviceAuthSession>, AuthenticationError> {
         let model = DasEntity::find()
             .filter(DasColumn::UserCode.eq(user_code))
+            .filter(DasColumn::RealmId.eq(Uuid::from(realm_id)))
             .one(&self.db)
             .await
             .map_err(|e| {
@@ -125,6 +128,19 @@ impl DeviceAuthRepository for PostgresDeviceAuthRepository {
             })?;
 
         Ok(model.map(Into::into))
+    }
+
+    async fn user_code_exists(&self, user_code: String) -> Result<bool, AuthenticationError> {
+        let count = DasEntity::find()
+            .filter(DasColumn::UserCode.eq(user_code))
+            .count(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error checking device auth user_code uniqueness: {e:?}");
+                AuthenticationError::InternalServerError
+            })?;
+
+        Ok(count > 0)
     }
 
     async fn update_status(

--- a/libs/ferriskey-api-authentication/src/handlers/device_verify.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/device_verify.rs
@@ -152,14 +152,24 @@ pub async fn device_verify(
         DeviceVerifyAction::Approve => {
             state
                 .service
-                .verify_device_user_code(payload.user_code, user_id)
+                .verify_device_user_code(
+                    realm_name.clone(),
+                    payload.user_code,
+                    user_id,
+                    user.realm_id,
+                )
                 .await?;
             "approved"
         }
         DeviceVerifyAction::Deny => {
             state
                 .service
-                .deny_device_user_code(payload.user_code, user_id)
+                .deny_device_user_code(
+                    realm_name.clone(),
+                    payload.user_code,
+                    user_id,
+                    user.realm_id,
+                )
                 .await?;
             "denied"
         }

--- a/libs/ferriskey-api-core/src/error.rs
+++ b/libs/ferriskey-api-core/src/error.rs
@@ -351,6 +351,9 @@ impl From<DeviceFlowError> for ApiError {
                 "unauthorized_client",
                 "The client is not authorized to use the device authorization grant.",
             ),
+            DeviceFlowError::Forbidden => {
+                Self::Forbidden("You cannot act on a device session of another realm".into())
+            }
             DeviceFlowError::UserCodeGenerationExhausted => {
                 Self::InternalServerError("Failed to generate a unique user code".into())
             }


### PR DESCRIPTION
## Context

FK-010, second of five parts. The device verification endpoint bound `realm_name` from the path and used it only to build a redirect URL — it never reached the domain. `find_by_user_code` filtered on the user code alone, so approval and denial were global operations: any authenticated user, from any realm, could approve or deny any device session in the deployment.

The attack needs no phishing. An attacker initiates a device flow in the victim realm using a public `client_id`, then approves it with their own foreign identity cookie. Tokens are then minted and signed with the victim realm's key.

Reproduced against the unpatched build: approving through a realm path that **does not exist at all** returns `200 {"status":"approved"}`. The realm segment was decorative.

## Change

Two independent guards, because either alone leaves the attack open.

**The caller must belong to the realm in the path.** `verify_device_user_code` and `deny_device_user_code` now resolve the realm by name and compare it to the authenticated user's `realm_id`, refusing with `403` otherwise. Without this, scoping the query would not help: the attacker's session genuinely lives in the victim realm, so a realm-scoped lookup would still find it.

**The lookup is scoped to that realm.** `find_by_user_code` takes a `RealmId` and filters on it. Without this, a caller legitimately inside realm A could still reach a session in realm B by its code. A cross-realm code now simply is not found, and returns the same `invalid_grant` as an unknown one — no signal that the code exists elsewhere.

**Uniqueness and lookup are separated.** `generate_unique_user_code` used `find_by_user_code` to detect collisions. `user_code` carries a **global** `UNIQUE` constraint in the schema, so scoping that call to one realm would let two realms draw the same code and fail on insert. Collision detection is now a dedicated `user_code_exists`, which stays global; `find_by_user_code` is realm-scoped and used only for lookups. One method was answering two different questions with the same query — that conflation is what made the missing filter easy to miss.

`DeviceFlowError::Forbidden` is added and maps to `403`.

## Verification

Added, 2 unit + 1 integration:

| Test | Asserts |
|---|---|
| `approval_only_looks_inside_the_caller_realm` | the lookup receives the caller's realm |
| `denial_only_looks_inside_the_caller_realm` | same for denial |
| `approval_through_another_realm_path_is_refused` | 403, and the session is still `authorization_pending` afterwards |

The integration test asserts the session's state after the refusal, not just the status code — a 403 that still flipped the session would otherwise pass. It was run against the unpatched domain and returns `200 {"status":"approved"}` there.

Its coverage is partial and worth stating: it uses a realm path that does not resolve, which exercises the guard and the regression (the path realm now reaches the domain at all). The two-realm variant — a real user of realm B approving in realm A — is covered at the domain layer by the unit tests above. A full two-realm HTTP scenario needs a harness bootstrapped on the literal `master` realm, as `organization_cross_realm_test.rs` does, since realm creation is restricted to it; this suite bootstraps on a random realm name.

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
cargo test -p ferriskey-api --test device_flow_test -- --ignored              # 9 passed
cargo test -p ferriskey-core device_flow                                      # 28 passed
```

## Not in this PR

Parts 3 to 5: client authentication on the device endpoints, scope propagation and consent display, scheduled `purge_expired`. `find_by_device_code` and `mark_polled` remain keyed on the device code alone; that code is an unguessable UUIDv7 and part 1 made it single-use, so realm-scoping them is hygiene rather than a hole.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Device approval and denial actions are now restricted to the correct realm.
  * Attempts to access a device session from another realm return a forbidden error.
  * Cross-realm approval attempts leave the session pending, and polling continues to report authorization pending.

* **Bug Fixes**
  * Improved validation prevents device-code conflicts while preserving realm isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->