### PR TITLE
fix: authenticate confidential clients on both device endpoints

### DIFF
--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -255,6 +255,55 @@ mod tests {
         client_id
     }
 
+    async fn create_confidential_device_client(
+        server: &TestServer,
+        admin_token: &str,
+    ) -> (String, String) {
+        let client_id = format!("device-conf-{}", Uuid::new_v4().simple());
+
+        let response = server
+            .post(&format!("/realms/{}/clients", realm()))
+            .add_header("Authorization", auth_header(admin_token))
+            .json(&json!({
+                "client_id": client_id,
+                "name": "Confidential Device Test Client",
+                "client_type": "confidential",
+                "protocol": "openid-connect",
+                "public_client": false,
+                "service_account_enabled": false,
+                "direct_access_grants_enabled": false,
+                "enabled": true,
+                "oauth_device_code_grant_enabled": true
+            }))
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            201,
+            "confidential client creation failed: {}",
+            response.text()
+        );
+
+        let body: Value = response.json();
+        let secret = body["secret"]
+            .as_str()
+            .unwrap_or_else(|| panic!("a confidential client carries a secret: {body}"))
+            .to_string();
+        assert!(!secret.is_empty(), "the client secret must not be empty");
+
+        (client_id, secret)
+    }
+
+    async fn initiate_raw(server: &TestServer, fields: &[(&str, &str)]) -> TestResponse {
+        server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/auth/device",
+                realm()
+            ))
+            .form(fields)
+            .await
+    }
+
     /// POST to the device authorization endpoint. Returns the parsed JSON body.
     async fn initiate(server: &TestServer, client_id: &str, scope: Option<&str>) -> Value {
         let mut fields = vec![("client_id", client_id)];
@@ -377,6 +426,99 @@ mod tests {
                 .as_str()
                 .expect("access_token in poll response");
             assert!(!access_token.is_empty(), "access_token must not be empty");
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn a_confidential_client_cannot_initiate_without_its_secret() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let (client_id, secret) =
+                create_confidential_device_client(&server, &admin_token).await;
+
+            let resp = initiate_raw(&server, &[("client_id", client_id.as_str())]).await;
+            assert_eq!(
+                resp.status_code(),
+                400,
+                "a confidential client must not initiate without its secret: {}",
+                resp.text()
+            );
+            let body: Value = resp.json();
+            assert_eq!(body["error"], "invalid_client", "body: {body:?}");
+
+            let resp = initiate_raw(
+                &server,
+                &[
+                    ("client_id", client_id.as_str()),
+                    ("client_secret", "not-the-secret"),
+                ],
+            )
+            .await;
+            assert_eq!(
+                resp.status_code(),
+                400,
+                "a wrong secret must not be accepted: {}",
+                resp.text()
+            );
+
+            let resp = initiate_raw(
+                &server,
+                &[
+                    ("client_id", client_id.as_str()),
+                    ("client_secret", secret.as_str()),
+                ],
+            )
+            .await;
+            assert_eq!(
+                resp.status_code(),
+                200,
+                "the correct secret must be accepted: {}",
+                resp.text()
+            );
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn a_confidential_client_cannot_poll_without_its_secret() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let (client_id, secret) =
+                create_confidential_device_client(&server, &admin_token).await;
+
+            let init = initiate_raw(
+                &server,
+                &[
+                    ("client_id", client_id.as_str()),
+                    ("client_secret", secret.as_str()),
+                ],
+            )
+            .await;
+            assert_eq!(init.status_code(), 200, "initiate failed: {}", init.text());
+            let init_body: Value = init.json();
+            let device_code = init_body["device_code"].as_str().expect("device_code");
+            let user_code = init_body["user_code"].as_str().expect("user_code");
+
+            let verify_resp = verify(&server, &admin_token, user_code, "approve").await;
+            assert_eq!(
+                verify_resp.status_code(),
+                200,
+                "approve failed: {}",
+                verify_resp.text()
+            );
+
+            let resp = poll(&server, &client_id, device_code).await;
+            assert_eq!(
+                resp.status_code(),
+                400,
+                "polling without the client secret must be refused: {}",
+                resp.text()
+            );
+            let body: Value = resp.json();
+            assert_eq!(body["error"], "invalid_client", "body: {body:?}");
         });
     }
 

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -4,6 +4,7 @@ use ferriskey_compass::recorder::FlowRecorder;
 use ferriskey_migrate::{entities::MigrationReport, error::MigrationError};
 use sea_orm::DatabaseConnection;
 
+use crate::domain::authentication::services::client_secret_matches;
 use crate::domain::realm::entities::RealmId;
 
 use crate::{
@@ -641,6 +642,12 @@ impl ApplicationService {
             .await
             .map_err(|_| DeviceFlowError::InvalidClient)?;
 
+        if !client.public_client
+            && !client_secret_matches(client.secret.as_deref(), input.client_secret.as_deref())
+        {
+            return Err(DeviceFlowError::InvalidClient);
+        }
+
         let verification_uri = format!("{base_url}/realms/{}/device", realm.name);
 
         self.device_flow_service
@@ -685,6 +692,12 @@ impl ApplicationService {
             .get_by_client_id(input.client_id, realm.id)
             .await
             .map_err(|_| DeviceFlowError::InvalidClient)?;
+
+        if !client.public_client
+            && !client_secret_matches(client.secret.as_deref(), input.client_secret.as_deref())
+        {
+            return Err(DeviceFlowError::InvalidClient);
+        }
 
         self.device_flow_service
             .poll(PollDeviceTokenParams {

--- a/core/src/domain/authentication/device_flow/value_objects.rs
+++ b/core/src/domain/authentication/device_flow/value_objects.rs
@@ -33,6 +33,7 @@ pub struct PollDeviceTokenParams {
 pub struct InitiateDeviceFlowInput {
     pub realm_name: String,
     pub client_id: String,
+    pub client_secret: Option<String>,
     pub scope: Option<String>,
 }
 

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -299,7 +299,7 @@ fn temporary_token_lifetime(realm_settings: Option<&RealmSetting>) -> i64 {
 /// Constant-time comparison of a configured client secret against the one
 /// presented on the token endpoint. `(None, None)` means "no secret configured
 /// and none presented", which is only ever reached for public clients.
-fn client_secret_matches(stored: Option<&str>, provided: Option<&str>) -> bool {
+pub(crate) fn client_secret_matches(stored: Option<&str>, provided: Option<&str>) -> bool {
     match (stored, provided) {
         (Some(s), Some(p)) => {
             let s_hash = Sha256::digest(s.as_bytes());

--- a/libs/ferriskey-api-authentication/src/handlers/device_authorization.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/device_authorization.rs
@@ -22,6 +22,7 @@ pub struct DeviceAuthorizationRequest {
     /// OAuth 2.0 client identifier. Optional in the body when the client
     /// authenticates with HTTP Basic (confidential clients).
     pub client_id: Option<String>,
+    pub client_secret: Option<String>,
     /// Space-delimited list of requested scopes.
     pub scope: Option<String>,
 }
@@ -57,9 +58,12 @@ pub async fn device_authorization(
 ) -> Result<impl IntoResponse, ApiError> {
     // Confidential clients authenticate via HTTP Basic (username = client_id);
     // public clients send `client_id` in the form body.
-    let client_id = match try_parse_basic_client_credentials(&headers) {
-        Some((id, _secret)) => id,
-        None => payload.client_id.clone().unwrap_or_default(),
+    let (client_id, client_secret) = match try_parse_basic_client_credentials(&headers) {
+        Some((id, secret)) => (id, Some(secret)),
+        None => (
+            payload.client_id.clone().unwrap_or_default(),
+            payload.client_secret.clone(),
+        ),
     };
 
     if client_id.is_empty() {
@@ -74,6 +78,7 @@ pub async fn device_authorization(
             InitiateDeviceFlowInput {
                 realm_name,
                 client_id: client_id.clone(),
+                client_secret,
                 scope: payload.scope,
             },
             base_url,


### PR DESCRIPTION
## Context

FK-010, third of five parts. Neither device endpoint authenticated the client.

At the token endpoint, `poll_device_token` resolved the client with `get_by_client_id` and never read `input.client_secret` — the HTTP layer parsed the secret and handed it over, and the application dropped it. At the device authorization endpoint the Basic credential was discarded outright: `Some((id, _secret)) => id`.

A confidential client was therefore protected by nothing but its `client_id`, which is not a secret. Anyone knowing it could start a device flow in its name, and — combined with a disclosed `device_code` — redeem tokens as that client.

Reproduced against the unpatched build: a confidential client initiates with **no secret at all** and receives `200` with a `device_code`, then polls through to a token.

## Change

Both endpoints now verify the secret whenever `!client.public_client`, refusing with `invalid_client` otherwise. `InitiateDeviceFlowInput` gains a `client_secret`, and the authorization handler forwards the Basic credential it was already parsing, falling back to `client_secret` in the form body for `client_secret_post` clients.

Verification reuses the existing `client_secret_matches` — SHA-256 digests compared with `ct_eq` — rather than introducing a second comparison. It was private to the authentication module and is now `pub(crate)`. This is the same guard `authorization_code` applies at `services.rs:339`; the device endpoints were the ones missing it, not a case needing new logic.

Public clients are unaffected: they have no secret and skip the check.

## Verification

Added, both integration:

| Test | Asserts |
|---|---|
| `a_confidential_client_cannot_initiate_without_its_secret` | no secret → `invalid_client`; wrong secret → refused; correct secret → `200` |
| `a_confidential_client_cannot_poll_without_its_secret` | an approved session still yields no token without the secret |

Both assert the positive case too, so they fail if the endpoint is simply broken rather than correctly guarded. Run against the unpatched application layer, both return `200` — initiation succeeds with no credential whatsoever.

The nine pre-existing device flow tests use a public client and are unaffected, which is the intended shape: this change must not alter the public-client path.

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
cargo test -p ferriskey-api --test device_flow_test -- --ignored              # 11 passed
cargo test -p ferriskey-core device_flow                                      # 28 passed
```

## Noted while testing

`POST /realms/{realm}/clients` returns the generated `secret` in plaintext in the creation response — the test helper reads it straight from there. That is the deferred client-secret masking workstream, not something this PR changes.

## Not in this PR

Parts 4 and 5: scope propagation with consent display, and scheduling `purge_expired`.

`PollDeviceTokenInput` and `VerifyUserCodeInput` remain dead code. They carry `client_secret` and `realm_name` — precisely the fields the live path lacked before parts 2 and 3. Now that both are threaded through the real types, these two should simply be deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Confidential clients must provide the correct client secret when starting a device authorization flow.
  - Device token polling now rejects missing or incorrect secrets for confidential clients.
  - Public clients continue to work without client-secret validation.
  - Client secrets can be supplied through HTTP Basic authentication or the request form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->