### PR TITLE
fix: validate and propagate the device flow scope, and show consent before approval

### DIFF
--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -387,6 +387,15 @@ mod tests {
             .await
     }
 
+    fn decode_jwt_payload(token: &str) -> Value {
+        use base64::Engine;
+        let payload = token.split('.').nth(1).expect("a JWT has three parts");
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(payload)
+            .expect("JWT payload is base64url");
+        serde_json::from_slice(&bytes).expect("JWT payload is JSON")
+    }
+
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
@@ -557,6 +566,83 @@ mod tests {
                 body["error"], "authorization_pending",
                 "the refused approval must not have advanced the session: {body:?}"
             );
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn the_issued_token_carries_the_client_and_the_granted_scope() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let client_id = create_device_client(&server, &admin_token).await;
+
+            let init_body = initiate(&server, &client_id, Some("openid")).await;
+            let device_code = init_body["device_code"].as_str().expect("device_code");
+            let user_code = init_body["user_code"].as_str().expect("user_code");
+
+            let verify_resp = verify(&server, &admin_token, user_code, "approve").await;
+            assert_eq!(
+                verify_resp.status_code(),
+                200,
+                "approve failed: {}",
+                verify_resp.text()
+            );
+
+            let poll_resp = poll(&server, &client_id, device_code).await;
+            assert_eq!(
+                poll_resp.status_code(),
+                200,
+                "poll failed: {}",
+                poll_resp.text()
+            );
+            let body: Value = poll_resp.json();
+
+            let claims = decode_jwt_payload(body["access_token"].as_str().expect("access_token"));
+            assert_eq!(
+                claims["azp"], client_id,
+                "the token must name the client it was issued to: {claims:?}"
+            );
+            let scope = claims["scope"].as_str().unwrap_or("");
+            assert!(
+                scope.contains("openid"),
+                "the granted scope must reach the token: {claims:?}"
+            );
+
+            let refresh =
+                decode_jwt_payload(body["refresh_token"].as_str().expect("refresh_token"));
+            assert_eq!(
+                refresh["azp"], client_id,
+                "the refresh token must carry the same client: {refresh:?}"
+            );
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn a_scope_the_client_does_not_have_is_refused_at_initiation() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let client_id = create_device_client(&server, &admin_token).await;
+
+            let resp = initiate_raw(
+                &server,
+                &[
+                    ("client_id", client_id.as_str()),
+                    ("scope", "openid not-a-scope-of-this-client"),
+                ],
+            )
+            .await;
+
+            assert_eq!(
+                resp.status_code(),
+                400,
+                "an unassigned scope must be refused before any user is prompted: {}",
+                resp.text()
+            );
+            let body: Value = resp.json();
+            assert_eq!(body["error"], "invalid_scope", "body: {body:?}");
         });
     }
 

--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -571,6 +571,70 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn the_consent_preview_names_the_client_and_the_requested_scopes() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let client_id = create_device_client(&server, &admin_token).await;
+
+            let init_body = initiate(&server, &client_id, Some("openid")).await;
+            let user_code = init_body["user_code"].as_str().expect("user_code");
+
+            let resp = server
+                .get(&format!("/realms/{}/device/preview", realm()))
+                .add_query_param("user_code", user_code)
+                .add_header(
+                    "Cookie",
+                    HeaderValue::from_str(&format!("FERRISKEY_IDENTITY={admin_token}")).unwrap(),
+                )
+                .await;
+
+            assert_eq!(resp.status_code(), 200, "preview failed: {}", resp.text());
+            let body: Value = resp.json();
+            assert_eq!(
+                body["client_id"], client_id,
+                "the preview must name the requesting client: {body:?}"
+            );
+            let scopes: Vec<String> = body["scopes"]
+                .as_array()
+                .expect("scopes array")
+                .iter()
+                .map(|v| v.as_str().unwrap_or_default().to_string())
+                .collect();
+            assert!(
+                scopes.iter().any(|s| s == "openid"),
+                "the preview must list what is being granted: {body:?}"
+            );
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn the_consent_preview_requires_an_identity() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let client_id = create_device_client(&server, &admin_token).await;
+
+            let init_body = initiate(&server, &client_id, Some("openid")).await;
+            let user_code = init_body["user_code"].as_str().expect("user_code");
+
+            let resp = server
+                .get(&format!("/realms/{}/device/preview", realm()))
+                .add_query_param("user_code", user_code)
+                .await;
+
+            assert_eq!(
+                resp.status_code(),
+                401,
+                "the preview must not be an anonymous oracle over user codes: {}",
+                resp.text()
+            );
+        });
+    }
+
+    #[test]
+    #[ignore]
     fn the_issued_token_carries_the_client_and_the_granted_scope() {
         let server = make_server();
         rt().block_on(async {

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -648,13 +648,19 @@ impl ApplicationService {
             return Err(DeviceFlowError::InvalidClient);
         }
 
+        let scope = self
+            .auth_service
+            .resolve_scopes_for_client(client.id, input.scope)
+            .await
+            .map_err(|_| DeviceFlowError::InvalidScope)?;
+
         let verification_uri = format!("{base_url}/realms/{}/device", realm.name);
 
         self.device_flow_service
             .initiate(InitiateDeviceFlowParams {
                 realm_id: realm.id,
                 client_id: client.id,
-                scope: input.scope,
+                scope: Some(scope),
                 oauth_device_code_grant_enabled: client.oauth_device_code_grant_enabled,
                 verification_uri,
             })

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -20,8 +20,8 @@ use crate::{
                 ports::{DeviceFlowService, DeviceTokenIssuer},
                 services::DeviceFlowServiceImpl,
                 value_objects::{
-                    InitiateDeviceFlowInput, InitiateDeviceFlowOutput, InitiateDeviceFlowParams,
-                    PollDeviceTokenParams,
+                    DeviceVerificationPreview, InitiateDeviceFlowInput, InitiateDeviceFlowOutput,
+                    InitiateDeviceFlowParams, PollDeviceTokenParams,
                 },
             },
             entities::{ExchangeTokenInput, JwtToken},
@@ -716,6 +716,40 @@ impl ApplicationService {
 
     /// Verification page: bind the authenticated user to the device session
     /// identified by `user_code` and mark it approved (RFC 8628 §3.3).
+    pub async fn describe_device_user_code(
+        &self,
+        realm_name: String,
+        user_code: String,
+        user_realm_id: RealmId,
+    ) -> Result<DeviceVerificationPreview, DeviceFlowError> {
+        let realm_id = self
+            .device_realm_for_actor(&realm_name, user_realm_id)
+            .await?;
+
+        let preview = self
+            .device_flow_service
+            .preview_user_code(user_code, realm_id)
+            .await?;
+
+        let client = self
+            .client_service
+            .client_repository
+            .get_by_id(realm_id, preview.client_id)
+            .await
+            .map_err(|_| DeviceFlowError::InvalidClient)?;
+
+        Ok(DeviceVerificationPreview {
+            client_id: client.client_id,
+            client_name: client.name,
+            scopes: preview
+                .scope
+                .unwrap_or_default()
+                .split_whitespace()
+                .map(str::to_string)
+                .collect(),
+        })
+    }
+
     pub async fn verify_device_user_code(
         &self,
         realm_name: String,

--- a/core/src/domain/authentication/device_flow/error.rs
+++ b/core/src/domain/authentication/device_flow/error.rs
@@ -53,6 +53,9 @@ pub enum DeviceFlowError {
     #[error("forbidden")]
     Forbidden,
 
+    #[error("invalid_scope")]
+    InvalidScope,
+
     /// Could not generate a collision-free user code within the retry budget.
     #[error("failed to generate a unique user code")]
     UserCodeGenerationExhausted,
@@ -79,6 +82,9 @@ impl From<DeviceFlowError> for CoreError {
             DeviceFlowError::UnauthorizedClient => CoreError::InvalidClient,
             DeviceFlowError::Forbidden => {
                 CoreError::Forbidden("device session belongs to another realm".to_string())
+            }
+            DeviceFlowError::InvalidScope => {
+                CoreError::InvalidScope("requested scope is not allowed".to_string())
             }
             DeviceFlowError::UserCodeGenerationExhausted => CoreError::InternalServerError,
             DeviceFlowError::TokenIssuance(msg) => CoreError::TokenGenerationError(msg),

--- a/core/src/domain/authentication/device_flow/mod.rs
+++ b/core/src/domain/authentication/device_flow/mod.rs
@@ -13,6 +13,6 @@ pub use error::DeviceFlowError;
 pub use ports::{DeviceAuthRepository, DeviceFlowService, DeviceTokenIssuer};
 pub use services::{DeviceFlowConfig, DeviceFlowServiceImpl};
 pub use value_objects::{
-    InitiateDeviceFlowInput, InitiateDeviceFlowOutput, InitiateDeviceFlowParams,
-    PollDeviceTokenParams,
+    DeviceSessionPreview, DeviceVerificationPreview, InitiateDeviceFlowInput,
+    InitiateDeviceFlowOutput, InitiateDeviceFlowParams, PollDeviceTokenParams,
 };

--- a/core/src/domain/authentication/device_flow/mod.rs
+++ b/core/src/domain/authentication/device_flow/mod.rs
@@ -14,5 +14,5 @@ pub use ports::{DeviceAuthRepository, DeviceFlowService, DeviceTokenIssuer};
 pub use services::{DeviceFlowConfig, DeviceFlowServiceImpl};
 pub use value_objects::{
     InitiateDeviceFlowInput, InitiateDeviceFlowOutput, InitiateDeviceFlowParams,
-    PollDeviceTokenInput, PollDeviceTokenParams, VerifyUserCodeInput,
+    PollDeviceTokenParams,
 };

--- a/core/src/domain/authentication/device_flow/ports.rs
+++ b/core/src/domain/authentication/device_flow/ports.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 use crate::domain::authentication::device_flow::entities::{DeviceAuthSession, DeviceAuthStatus};
 use crate::domain::authentication::device_flow::error::DeviceFlowError;
 use crate::domain::authentication::device_flow::value_objects::{
-    InitiateDeviceFlowOutput, InitiateDeviceFlowParams, PollDeviceTokenParams,
+    DeviceSessionPreview, InitiateDeviceFlowOutput, InitiateDeviceFlowParams, PollDeviceTokenParams,
 };
 use crate::domain::authentication::entities::{AuthenticationError, JwtToken};
 use crate::domain::authentication::value_objects::GenerateTokensForUserInput;
@@ -79,6 +79,12 @@ pub trait DeviceFlowService: Send + Sync {
 
     /// Verification page: bind the approving user and mark the session
     /// approved.
+    fn preview_user_code(
+        &self,
+        user_code: String,
+        realm_id: RealmId,
+    ) -> impl Future<Output = Result<DeviceSessionPreview, DeviceFlowError>> + Send;
+
     fn verify_user_code(
         &self,
         user_code: String,

--- a/core/src/domain/authentication/device_flow/services.rs
+++ b/core/src/domain/authentication/device_flow/services.rs
@@ -11,7 +11,7 @@ use crate::domain::authentication::device_flow::ports::{
     DeviceAuthRepository, DeviceFlowService, DeviceTokenIssuer,
 };
 use crate::domain::authentication::device_flow::value_objects::{
-    InitiateDeviceFlowOutput, InitiateDeviceFlowParams, PollDeviceTokenParams,
+    DeviceSessionPreview, InitiateDeviceFlowOutput, InitiateDeviceFlowParams, PollDeviceTokenParams,
 };
 use crate::domain::authentication::entities::JwtToken;
 use crate::domain::authentication::value_objects::GenerateTokensForUserInput;
@@ -153,6 +153,34 @@ where
             verification_uri_complete,
             expires_in: self.config.expires_in_seconds,
             interval: self.config.interval_seconds,
+        })
+    }
+
+    async fn preview_user_code(
+        &self,
+        user_code: String,
+        realm_id: RealmId,
+    ) -> Result<DeviceSessionPreview, DeviceFlowError> {
+        let session = self
+            .device_auth_repository
+            .find_by_user_code(user_code, realm_id)
+            .await?
+            .ok_or(DeviceFlowError::InvalidUserCode)?;
+
+        match session.status {
+            DeviceAuthStatus::Denied => return Err(DeviceFlowError::AccessDenied),
+            DeviceAuthStatus::Expired => return Err(DeviceFlowError::ExpiredToken),
+            DeviceAuthStatus::Consumed => return Err(DeviceFlowError::InvalidUserCode),
+            DeviceAuthStatus::Approved | DeviceAuthStatus::Pending => {}
+        }
+
+        if session.is_expired() {
+            return Err(DeviceFlowError::ExpiredToken);
+        }
+
+        Ok(DeviceSessionPreview {
+            client_id: session.client_id,
+            scope: session.scope,
         })
     }
 

--- a/core/src/domain/authentication/device_flow/services.rs
+++ b/core/src/domain/authentication/device_flow/services.rs
@@ -288,6 +288,7 @@ where
                         realm_id: session.realm_id.into(),
                         base_url: params.base_url,
                         client_id: Some(session.client_id),
+                        scope: session.scope.clone(),
                     })
                     .await
                     .map_err(|err| DeviceFlowError::TokenIssuance(err.to_string()))

--- a/core/src/domain/authentication/device_flow/value_objects.rs
+++ b/core/src/domain/authentication/device_flow/value_objects.rs
@@ -37,6 +37,18 @@ pub struct InitiateDeviceFlowInput {
     pub scope: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DeviceVerificationPreview {
+    pub client_id: String,
+    pub client_name: String,
+    pub scopes: Vec<String>,
+}
+
+pub struct DeviceSessionPreview {
+    pub client_id: Uuid,
+    pub scope: Option<String>,
+}
+
 /// Output of the device authorization endpoint (RFC 8628 §3.2).
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct InitiateDeviceFlowOutput {

--- a/core/src/domain/authentication/device_flow/value_objects.rs
+++ b/core/src/domain/authentication/device_flow/value_objects.rs
@@ -52,19 +52,3 @@ pub struct InitiateDeviceFlowOutput {
     #[schema(example = 5)]
     pub interval: i64,
 }
-
-/// Input used when the end user submits a code on the verification page
-/// (RFC 8628 §3.3).
-pub struct VerifyUserCodeInput {
-    pub realm_name: String,
-    pub user_code: String,
-}
-
-/// Input for the token endpoint when polling with the device code
-/// (RFC 8628 §3.4).
-pub struct PollDeviceTokenInput {
-    pub realm_name: String,
-    pub client_id: String,
-    pub client_secret: Option<String>,
-    pub device_code: String,
-}

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -1757,7 +1757,7 @@ where
     /// - Standard OIDC scopes (openid, profile, email, etc.) are always permitted.
     /// - Any requested scope not in the above sets returns `CoreError::InvalidScope`.
     /// - Falls back to `profile email` defaults when the client has no configured scopes.
-    async fn resolve_scopes_for_client(
+    pub(crate) async fn resolve_scopes_for_client(
         &self,
         client_uuid: Uuid,
         requested_scope: Option<String>,
@@ -3663,6 +3663,7 @@ where
                 realm_id: realm.id.into(),
                 base_url: issuer_base_url,
                 client_id: None,
+                scope: None,
             })
             .await?;
 
@@ -3984,6 +3985,20 @@ where
             .create_user_session(user.id, realm.id, lifetimes.refresh_token)
             .await?;
 
+        let (azp, scope) = match input.client_id {
+            Some(client_uuid) => {
+                let client = self
+                    .client_repository
+                    .get_by_id(realm.id, client_uuid)
+                    .await?;
+                let scope = self
+                    .resolve_scopes_for_client(client_uuid, input.scope.clone())
+                    .await?;
+                (client.client_id, Some(scope))
+            }
+            None => ("".to_string(), None),
+        };
+
         let iss = format!("{}/realms/{}", input.base_url, realm.name);
         let mut claims = JwtClaim::new(
             user.id,
@@ -3991,9 +4006,9 @@ where
             iss.clone(),
             vec![format!("{}-realm", realm.name), "account".to_string()],
             ClaimsTyp::Bearer,
-            "".to_string(),
+            azp,
             user.email.clone(),
-            None,
+            scope.clone(),
             lifetimes.access_token,
         );
         claims.sid = Some(user_session.id);
@@ -4005,7 +4020,7 @@ where
             claims.iss.clone(),
             claims.aud.clone(),
             claims.azp.clone(),
-            None,
+            scope,
             lifetimes.refresh_token,
         );
         refresh_claims.sid = Some(user_session.id);

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -489,6 +489,11 @@ export namespace Schemas {
   export type DeviceAuthorizationRequest = Partial<{ client_id: string | null; scope: string | null }>;
   export type DeviceVerifyAction = "approve" | "deny";
   export type DeviceVerifyRequest = { action: DeviceVerifyAction; user_code: string };
+  export type DeviceVerificationPreview = {
+    client_id: string;
+    client_name: string;
+    scopes: Array<string>;
+  };
   export type DeviceVerifyResponse = { status: string };
   export type EvaluatedMapper = { config: unknown; mapper_type: string; name: string };
   export type EvaluatedRoles = { client_roles: Record<string, Array<string>>; realm_roles: Array<string> };
@@ -1772,6 +1777,20 @@ export namespace Endpoints {
       path: { realm_name: string };
     };
     responses: { 302: unknown };
+  };
+  export type get_Device_preview = {
+    method: "GET";
+    path: "/realms/{realm_name}/device/preview";
+    requestFormat: "json";
+    parameters: {
+      query: { user_code: string };
+      path: { realm_name: string };
+    };
+    responses: {
+      200: Schemas.DeviceVerificationPreview;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+    };
   };
   export type post_Device_verify = {
     method: "POST";
@@ -3749,6 +3768,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/compass/v1/flows/{flow_id}": Endpoints.get_Get_flow;
     "/realms/{realm_name}/compass/v1/stats": Endpoints.get_Get_stats;
     "/realms/{realm_name}/device": Endpoints.get_Device_verification_page;
+    "/realms/{realm_name}/device/preview": Endpoints.get_Device_preview;
     "/realms/{realm_name}/email-templates": Endpoints.get_Fetch_templates;
     "/realms/{realm_name}/email-templates/{template_id}": Endpoints.get_Get_template;
     "/realms/{realm_name}/federation/providers": Endpoints.get_List_providers;

--- a/front/src/api/device.api.ts
+++ b/front/src/api/device.api.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { BaseQuery } from '.'
 import type { Schemas } from './api.client'
 
@@ -12,6 +12,25 @@ export const useDeviceVerify = () => {
         path: { realm_name: realm ?? 'master' },
         body: data,
       } as never) as Promise<Schemas.DeviceVerifyResponse>
+    },
+  })
+}
+
+export const useDevicePreview = ({
+  realm,
+  userCode,
+  enabled,
+}: BaseQuery & { userCode: string; enabled: boolean }) => {
+  return useQuery({
+    queryKey: ['device-preview', realm, userCode],
+    enabled,
+    retry: false,
+    staleTime: 0,
+    queryFn: async () => {
+      return window.tanstackApi.client.get('/realms/{realm_name}/device/preview', {
+        path: { realm_name: realm ?? 'master' },
+        query: { user_code: userCode },
+      } as never) as Promise<Schemas.DeviceVerificationPreview>
     },
   })
 }

--- a/front/src/lib/builder-portal/components.tsx
+++ b/front/src/lib/builder-portal/components.tsx
@@ -53,6 +53,7 @@ const ALL_CHILDREN = [
   'password_confirm_input',
   'totp_input',
   'user_code_input',
+  'device_consent',
   'submit_button',
   'device_approve_button',
   'device_deny_button',
@@ -366,6 +367,16 @@ export const portalComponents: ComponentDefinition[] = [
   // segmented control as `totp_input`; submitted as `name="user_code"` and
   // prefilled from the `?user_code=` query at runtime.
   {
+    type: 'device_consent',
+    label: 'Device consent details',
+    icon: <ScanLine size={14} />,
+    defaultProps: {
+      label: 'is asking to sign in as you.',
+      placeholder: 'It will be granted',
+    },
+    defaultStyles: {},
+  },
+  {
     type: 'user_code_input',
     label: 'Device code input',
     icon: <ScanLine size={14} />,
@@ -562,6 +573,7 @@ export const REQUIRED_BLOCK_TYPES = new Set([
   'submit_button',
   'identity_providers',
   'user_code_input',
+  'device_consent',
   'device_approve_button',
   'device_deny_button',
 ])
@@ -767,6 +779,7 @@ export const RESTRICTED_TO_PAGE_TYPE: Record<string, ReadonlySet<string>> = {
   totp_qr_code: new Set(['totp_setup']),
   totp_secret: new Set(['totp_setup']),
   user_code_input: new Set(['device_verify']),
+  device_consent: new Set(['device_verify']),
   device_approve_button: new Set(['device_verify']),
   device_deny_button: new Set(['device_verify']),
 }

--- a/front/src/lib/builder-portal/renderer.tsx
+++ b/front/src/lib/builder-portal/renderer.tsx
@@ -42,6 +42,10 @@ type RenderOptions = {
     otpauthUrl: string
     secret: string
   }
+  deviceConsent?: {
+    clientName: string
+    scopes: string[]
+  }
   /**
    * Inline form-error message surfaced by the page's submit handler
    * (invalid credentials, email already in use, …). Read by the
@@ -507,6 +511,61 @@ function renderNode(node: BuilderNode, options: RenderOptions): ReactNode {
     // Holds its value through a hidden `name="user_code"` input so the
     // surrounding <form> picks it up; the device_verify submit branch
     // re-inserts the dash before calling the verify endpoint.
+    case 'device_consent': {
+      const consent = options.deviceConsent ?? {
+        clientName: 'Living Room TV',
+        scopes: ['openid', 'profile'],
+      }
+      return (
+        <div
+          key={node.id}
+          {...idAttr}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 6,
+            ...orderStyle(node),
+          }}
+        >
+          <p style={{ margin: 0 }}>
+            <strong>{consent.clientName}</strong>{' '}
+            {(node.props.label as string) ?? 'is asking to sign in as you.'}
+          </p>
+          {consent.scopes.length > 0 ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ fontSize: 12, opacity: 0.7 }}>
+                {(node.props.placeholder as string) ?? 'It will be granted'}
+              </span>
+              <ul
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: 4,
+                  listStyle: 'none',
+                  margin: 0,
+                  padding: 0,
+                }}
+              >
+                {consent.scopes.map((scope) => (
+                  <li
+                    key={scope}
+                    style={{
+                      borderRadius: 6,
+                      padding: '2px 8px',
+                      fontSize: 12,
+                      background: 'rgba(127,127,127,0.15)',
+                    }}
+                  >
+                    {scope}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      )
+    }
+
     case 'user_code_input':
       return (
         <div

--- a/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
+++ b/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
@@ -30,6 +30,7 @@ import {
   TotpQrCodeBlock,
   TotpSecretBlock,
   FormErrorBannerBlock,
+  treeToReactNode,
 } from '../renderer'
 import { InlineTextEditor } from './inline-text-editor'
 
@@ -174,6 +175,8 @@ export function renderVisualBlock(
       return <TotpInputBlock node={node} isSelected={isSelected} />
     case 'user_code_input':
       return <UserCodeInputBlock node={node} isSelected={isSelected} />
+    case 'device_consent':
+      return <div data-selected={isSelected}>{treeToReactNode([node])}</div>
     case 'identity_providers':
       return <IdentityProvidersPreview node={node} isSelected={isSelected} />
     case 'forgot_password_link':

--- a/front/src/pages/authentication/components/portal-layout-wrapper.tsx
+++ b/front/src/pages/authentication/components/portal-layout-wrapper.tsx
@@ -13,6 +13,7 @@ import type { BuilderNode } from '@/lib/builder-core'
 import { generateBreakpointCss, treeToReactNode } from '@/lib/builder-portal'
 import { mergeWithDefaults, themeToCssVars } from '@/pages/portal-theme/lib/theme'
 import type { Schemas } from '@/api/api.client'
+import { useDevicePreview } from '@/api/device.api'
 import { usePortalPageSubmit } from '../hooks/use-portal-page-submit'
 import { usePasskeyAuth } from '../hooks/use-passkey-auth'
 import {
@@ -104,6 +105,25 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
     realm,
     token: totpSetupToken,
   })
+  const deviceUserCode =
+    pageType === 'device_verify'
+      ? new URLSearchParams(
+          typeof window === 'undefined' ? '' : window.location.search,
+        ).get('user_code') ?? ''
+      : ''
+  const { data: devicePreviewData } = useDevicePreview({
+    realm,
+    userCode: deviceUserCode,
+    enabled: pageType === 'device_verify' && deviceUserCode.length > 0,
+  })
+  const deviceConsent = useMemo(() => {
+    if (pageType !== 'device_verify' || !devicePreviewData) return undefined
+    return {
+      clientName: devicePreviewData.client_name || devicePreviewData.client_id,
+      scopes: devicePreviewData.scopes,
+    }
+  }, [pageType, devicePreviewData])
+
   const totpSetup = useMemo(
     () => {
       if (
@@ -394,7 +414,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
 
   const pageContent: ReactNode = (
     <form onSubmit={handleSubmit}>
-      {treeToReactNode(pageTree, { runtime: true, identityProviders, totpSetup, formError, isSubmitting })}
+      {treeToReactNode(pageTree, { runtime: true, identityProviders, totpSetup, deviceConsent, formError, isSubmitting })}
     </form>
   )
 
@@ -412,7 +432,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
     <div style={cssVars} onClick={handlePortalActionClick}>
       {responsiveStyle}
       {buttonInteractionStyle}
-      {treeToReactNode(layoutTree, { runtime: true, pageContent, identityProviders, totpSetup, formError, isSubmitting })}
+      {treeToReactNode(layoutTree, { runtime: true, pageContent, identityProviders, totpSetup, deviceConsent, formError, isSubmitting })}
     </div>
   )
 }

--- a/front/src/pages/authentication/feature/page-device-verify-feature.tsx
+++ b/front/src/pages/authentication/feature/page-device-verify-feature.tsx
@@ -1,9 +1,9 @@
-import { useDeviceVerify } from '@/api/device.api'
+import { useDevicePreview, useDeviceVerify } from '@/api/device.api'
 import { Form } from '@/components/ui/form'
 import { useAuth } from '@/hooks/use-auth'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { useLocation, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import {
@@ -61,6 +61,14 @@ export default function PageDeviceVerifyFeature() {
   const redirectingToLogin = useRef(false)
 
   const { mutateAsync: verifyDevice } = useDeviceVerify()
+
+  const watchedCode = useWatch({ control: form.control, name: 'user_code' }) ?? ''
+  const normalisedCode = normalisePrefill(watchedCode)
+  const { data: preview } = useDevicePreview({
+    realm,
+    userCode: normalisedCode,
+    enabled: isAuthenticated && normalisedCode.length > 0 && status === 'idle',
+  })
 
   const onSubmit = async (
     values: DeviceVerifySchema,
@@ -143,6 +151,7 @@ export default function PageDeviceVerifyFeature() {
   return (
     <Form {...form}>
       <PageDeviceVerify
+        preview={preview}
         status={status}
         errorMessage={errorMessage}
         pendingAction={pendingAction}

--- a/front/src/pages/authentication/ui/page-device-verify.tsx
+++ b/front/src/pages/authentication/ui/page-device-verify.tsx
@@ -29,7 +29,14 @@ export type DeviceVerifyStatus =
   | 'denied'
   | 'error'
 
+export interface DeviceConsentPreview {
+  client_id: string
+  client_name: string
+  scopes: string[]
+}
+
 export interface PageDeviceVerifyProps {
+  preview?: DeviceConsentPreview
   status: DeviceVerifyStatus
   errorMessage: string | null
   pendingAction: 'approve' | 'deny' | null
@@ -38,6 +45,7 @@ export interface PageDeviceVerifyProps {
 }
 
 export default function PageDeviceVerify({
+  preview,
   status,
   errorMessage,
   pendingAction,
@@ -143,6 +151,34 @@ export default function PageDeviceVerify({
               >
                 <AlertCircle className='mt-0.5 h-4 w-4 shrink-0' />
                 <span>{errorMessage}</span>
+              </div>
+            )}
+
+            {preview && (
+              <div className='flex flex-col gap-2 rounded-lg border border-border bg-muted/30 p-3 text-sm'>
+                <p className='text-muted-foreground'>
+                  <span className='font-medium text-foreground'>
+                    {preview.client_name || preview.client_id}
+                  </span>{' '}
+                  is asking to sign in as you.
+                </p>
+                {preview.scopes.length > 0 && (
+                  <div className='flex flex-col gap-1'>
+                    <p className='text-xs uppercase tracking-wide text-muted-foreground'>
+                      It will be granted
+                    </p>
+                    <ul className='flex flex-wrap gap-1'>
+                      {preview.scopes.map((scope) => (
+                        <li
+                          key={scope}
+                          className='rounded-md bg-primary/10 px-2 py-0.5 text-xs text-foreground'
+                        >
+                          {scope}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </div>
             )}
 

--- a/libs/ferriskey-api-authentication/src/handlers/device_verify.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/device_verify.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use axum_cookie::CookieManager;
 use base64::{Engine, engine::general_purpose};
+use ferriskey_core::domain::authentication::device_flow::DeviceVerificationPreview;
 use ferriskey_core::domain::authentication::entities::AuthorizeRequestInput;
 use ferriskey_core::domain::authentication::ports::AuthService;
 use ferriskey_core::domain::jwt::entities::JwtClaim;
@@ -43,6 +44,65 @@ pub struct DeviceVerifyRequest {
 pub struct DeviceVerifyResponse {
     /// Resulting session status: `approved` or `denied`.
     pub status: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DevicePreviewQuery {
+    pub user_code: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/device/preview",
+    tag = "auth",
+    summary = "Device consent preview",
+    description = "Returns the client and the scopes a pending device session is asking for, so the verification page can show what is being approved (RFC 8628 §5.3). Requires the identity cookie and refuses codes belonging to another realm.",
+    params(
+        ("realm_name" = String, Path, description = "Realm name"),
+        ("user_code" = String, Query, description = "The end-user code shown on the device"),
+    ),
+    responses(
+        (status = 200, description = "Pending session details", body = DeviceVerificationPreview),
+        (status = 401, description = "Authentication required", body = ApiErrorResponse),
+        (status = 403, description = "The session belongs to another realm", body = ApiErrorResponse),
+    )
+)]
+#[instrument(skip(state, cookie), fields(realm_name = %realm_name))]
+pub async fn device_preview(
+    Path(realm_name): Path<String>,
+    State(state): State<AppState>,
+    cookie: CookieManager,
+    Query(query): Query<DevicePreviewQuery>,
+) -> Result<Response, ApiError> {
+    let token = cookie
+        .get(IDENTITY_COOKIE)
+        .map(|c| c.value().to_string())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| ApiError::Unauthorized("Authentication required".into()))?;
+
+    let claims = decode_jwt_claims(&token)
+        .ok_or_else(|| ApiError::Unauthorized("Invalid identity token".into()))?;
+
+    let output = state
+        .service
+        .authorize_request(AuthorizeRequestInput { claims, token })
+        .await
+        .map_err(|error| {
+            warn!(error = ?error, "Device preview: identity token rejected");
+            ApiError::Unauthorized("Invalid identity token".into())
+        })?;
+
+    let user = output
+        .identity
+        .as_user()
+        .ok_or_else(|| ApiError::Forbidden("Service accounts cannot approve devices".into()))?;
+
+    let preview = state
+        .service
+        .describe_device_user_code(realm_name, query.user_code, user.realm_id)
+        .await?;
+
+    Ok((StatusCode::OK, Json(preview)).into_response())
 }
 
 #[utoipa::path(

--- a/libs/ferriskey-api-authentication/src/router.rs
+++ b/libs/ferriskey-api-authentication/src/router.rs
@@ -10,8 +10,8 @@ use super::handlers::{
     authentificate::{__path_authenticate, authenticate},
     device_authorization::{__path_device_authorization, device_authorization},
     device_verify::{
-        __path_device_verification_page, __path_device_verify, device_verification_page,
-        device_verify,
+        __path_device_preview, __path_device_verification_page, __path_device_verify,
+        device_preview, device_verification_page, device_verify,
     },
     get_certs::{__path_get_certs, __path_get_jwks_json, get_certs, get_jwks_json},
     introspect::{__path_introspect_token, introspect_token},
@@ -37,6 +37,7 @@ use ferriskey_api_core::{app_state::AppState, auth::auth};
         introspect_token,
         authenticate,
         device_authorization,
+        device_preview,
         device_verification_page,
         device_verify,
         get_certs,
@@ -81,6 +82,10 @@ pub fn authentication_routes(state: AppState, root_path: &str) -> Router<AppStat
         .route(
             &format!("{root_path}/realms/{{realm_name}}/device"),
             get(device_verification_page),
+        )
+        .route(
+            &format!("{root_path}/realms/{{realm_name}}/device/preview"),
+            get(device_preview),
         )
         .route(
             &format!("{root_path}/realms/{{realm_name}}/device/verify"),

--- a/libs/ferriskey-api-core/src/error.rs
+++ b/libs/ferriskey-api-core/src/error.rs
@@ -351,6 +351,10 @@ impl From<DeviceFlowError> for ApiError {
                 "unauthorized_client",
                 "The client is not authorized to use the device authorization grant.",
             ),
+            DeviceFlowError::InvalidScope => oauth(
+                "invalid_scope",
+                "The requested scope is not permitted for this client.",
+            ),
             DeviceFlowError::Forbidden => {
                 Self::Forbidden("You cannot act on a device session of another realm".into())
             }

--- a/libs/ferriskey-api-trident/src/handlers/reset_password.rs
+++ b/libs/ferriskey-api-trident/src/handlers/reset_password.rs
@@ -130,6 +130,7 @@ pub async fn reset_password_with_token(
             realm_id: result.realm_id,
             base_url,
             client_id: None,
+            scope: None,
         })
         .await?;
 

--- a/libs/ferriskey-domain/src/authentication/value_objects.rs
+++ b/libs/ferriskey-domain/src/authentication/value_objects.rs
@@ -120,6 +120,7 @@ pub struct GenerateTokensForUserInput {
     pub realm_id: Uuid,
     pub base_url: String,
     pub client_id: Option<Uuid>,
+    pub scope: Option<String>,
 }
 
 impl CreateAuthSessionRequest {


### PR DESCRIPTION
## Context

FK-010, fourth part — correctif (f).

The requested scope was persisted on the device session and read back, then dropped at a type boundary: `GenerateTokensForUserInput` had no `scope` field, so `poll` could not pass `session.scope` on even though it held it. Nothing validated the scope at initiation either, so an unknown scope was accepted, a user was prompted, and the resulting token silently carried none of it.

Tokens came out with `"azp": ""` and `"scope": null` — captured verbatim from a real token in this branch's red run.

`scope` is not an authorization boundary in FerrisKey (permissions come from the database), so there is no privilege escalation here. What breaks is everything downstream that reads the token: an introspection response with no `scope` and no `azp` is unusable to a third-party resource server, and no protocol mapper is applied.

## Change

**Scope is validated at initiation.** `initiate_device_authorization` now resolves the requested scope through `resolve_scopes_for_client` — the same validator `authorization_code`, `password` and `client_credentials` already use — and stores the *resolved* scope on the session. An unassigned scope is refused with `invalid_scope` before any user is prompted, which is the point: the device learns immediately instead of after a human has approved something that will not be granted.

**Scope and `azp` reach the token.** `GenerateTokensForUserInput` gains `scope`. When a `client_id` is present, `generate_tokens_for_user` resolves the client to fill `azp` and runs the scope through the same validator; the refresh token inherits both. With no client (registration, password reset) the behaviour is unchanged.

**The two dead DTOs are deleted.** `PollDeviceTokenInput` and `VerifyUserCodeInput` carried `client_secret` and `realm_name` — exactly the fields the live path lacked before parts 2 and 3. Now that both are threaded through the real types, keeping them would preserve the trap: code that looks like the control exists, next to a path where it does not.

## Verification

Added, four integration:

| Test | Asserts |
|---|---|
| `the_issued_token_carries_the_client_and_the_granted_scope` | `azp` equals the client id and `scope` contains the grant, on both access and refresh tokens |
| `a_scope_the_client_does_not_have_is_refused_at_initiation` | `invalid_scope` at initiation, before any prompt |
| `the_consent_preview_names_the_client_and_the_requested_scopes` | the preview returns the client and the scopes |
| `the_consent_preview_requires_an_identity` | `401` without an identity cookie |

Run against the unpatched core, the first fails with `"azp": String("")` / `"scope": Null` and the second returns `200` with a usable `device_code`.

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
cargo test -p ferriskey-api --test device_flow_test -- --ignored              # 15 passed
cargo test -p ferriskey-core device_flow                                      # 28 passed
tsc --noEmit (front)                                                          # clean
npm run lint (front)                                                          # 0 errors
```

`npm run build` fails locally on a missing `@rollup/rollup-darwin-x64` binary; verified identical on a clean tree, so it is this machine's `node_modules`, not this change. CI builds the webapp in its own job.

## Found while mapping this: a deeper defect, deliberately not fixed here

`generate_tokens_for_user` (`core/src/domain/authentication/services.rs:3948`) does not go through `assemble_token_claims`/`create_jwt` as the other grants do. It calls `generate_token` directly. Beyond the `azp`/`scope` gap this PR closes, that means:

- **no protocol mapper runs** on this path, so mapper-provided claims (`realm_access.roles`, and anything an operator configured) are absent;
- **no ID token is issued**, even when `openid` is granted.

This affects three flows, not just the device one: device poll, `register_user`, and post-reset auto-login. Routing it through `create_jwt` is the correct fix and is a change with real regression surface across registration and password reset — it deserves its own PR rather than riding along here.

## The consent screen

`GET /realms/{realm}/device/preview?user_code=…` returns the pending session's client and requested scopes, and the verification page renders them above the Approve button. Without this, RFC 8628's anti-phishing countermeasure does not exist: the user is asked to approve something they cannot see.

The endpoint carries the same guards as approval — identity cookie required, caller must belong to the realm in the path, lookup scoped to that realm, and refused on denied/expired/consumed sessions. That matters: an unauthenticated preview would be an oracle telling anyone whether a given user code exists and who it belongs to. `the_consent_preview_requires_an_identity` locks that down.

The block is mirrored in the portal page builder as a `device_consent` block, page-exclusive to `device_verify`, fed through a `deviceConsent` render option exactly as `totp_setup` feeds its QR code. Without it, a realm publishing a custom theme for this page would silently lose the consent display — the builder tree replaces the React page whenever it is valid.

## Not in this PR

Part 5 remains: scheduling `purge_expired`.
