### PR TITLE
fix: schedule the purge of expired device authorization sessions

### DIFF
--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -65,6 +65,7 @@ mod tests {
         realm_name: String,
         /// Pool in the isolated test schema (for direct SQL in the expiry test).
         pool: sqlx::PgPool,
+        service: ferriskey_core::application::services::ApplicationService,
     }
 
     /// Single long-lived multi-threaded runtime shared by all tests.
@@ -168,13 +169,14 @@ mod tests {
             .expect("initialize application");
 
         let args = Arc::new(Args::default());
-        let state = AppState::new(args, service);
+        let state = AppState::new(args, service.clone());
         let app = router(state).expect("build router");
 
         SharedContext {
             app: std::sync::Mutex::new(app),
             realm_name,
             pool,
+            service,
         }
     }
 
@@ -565,6 +567,51 @@ mod tests {
             assert_eq!(
                 body["error"], "authorization_pending",
                 "the refused approval must not have advanced the session: {body:?}"
+            );
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn the_purge_removes_expired_sessions_and_spares_the_others() {
+        let server = make_server();
+        rt().block_on(async {
+            let admin_token = get_admin_token(&server).await;
+            let client_id = create_device_client(&server, &admin_token).await;
+
+            let live = initiate(&server, &client_id, Some("openid")).await;
+            let live_code = live["device_code"].as_str().expect("device_code").to_string();
+
+            let stale = initiate(&server, &client_id, Some("openid")).await;
+            let stale_code = stale["device_code"].as_str().expect("device_code").to_string();
+
+            sqlx::query(
+                "UPDATE device_auth_sessions SET expires_at = now() - interval '1 hour'                  WHERE device_code = $1::uuid",
+            )
+            .bind(&stale_code)
+            .execute(&shared_ctx().pool)
+            .await
+            .expect("backdate the stale session");
+
+            let removed = shared_ctx()
+                .service
+                .purge_expired_device_sessions()
+                .await
+                .expect("purge should succeed");
+            assert!(removed >= 1, "the expired session must be removed");
+
+            let resp = poll(&server, &client_id, &stale_code).await;
+            let body: Value = resp.json();
+            assert_eq!(
+                body["error"], "invalid_grant",
+                "a purged session must be unknown, not merely expired: {body:?}"
+            );
+
+            let resp = poll(&server, &client_id, &live_code).await;
+            let body: Value = resp.json();
+            assert_eq!(
+                body["error"], "authorization_pending",
+                "a live session must survive the purge: {body:?}"
             );
         });
     }

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -12,7 +12,9 @@ use crate::{
             ClientScopeServiceImpl, ProtocolMapperServiceImpl, ScopeMappingServiceImpl,
         },
         authentication::{
-            device_flow::services::{DeviceFlowConfig, DeviceFlowServiceImpl},
+            device_flow::services::{
+                DeviceFlowConfig, DeviceFlowServiceImpl, purge_expired_device_sessions_task,
+            },
             mapper_engine::MapperEngine,
             services::AuthServiceImpl,
         },
@@ -146,6 +148,8 @@ pub mod user;
 pub mod webhook;
 
 pub use services::ApplicationService;
+
+const DEVICE_SESSION_PURGE_PERIOD: std::time::Duration = std::time::Duration::from_secs(900);
 
 pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationService, CoreError> {
     let database_url = format!(
@@ -308,6 +312,11 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
         Arc::new(auth_service.clone()),
         DeviceFlowConfig::default(),
     );
+
+    tokio::spawn(purge_expired_device_sessions_task(
+        device_flow_service.clone(),
+        DEVICE_SESSION_PURGE_PERIOD,
+    ));
 
     let app = ApplicationService {
         maintenance_service: MaintenanceServiceImpl::new(

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -716,6 +716,10 @@ impl ApplicationService {
 
     /// Verification page: bind the authenticated user to the device session
     /// identified by `user_code` and mark it approved (RFC 8628 §3.3).
+    pub async fn purge_expired_device_sessions(&self) -> Result<u64, DeviceFlowError> {
+        self.device_flow_service.purge_expired_sessions().await
+    }
+
     pub async fn describe_device_user_code(
         &self,
         realm_name: String,

--- a/core/src/domain/authentication/device_flow/ports.rs
+++ b/core/src/domain/authentication/device_flow/ports.rs
@@ -52,6 +52,8 @@ pub trait DeviceAuthRepository: Send + Sync {
         &self,
         device_code: Uuid,
     ) -> impl Future<Output = Result<(), AuthenticationError>> + Send;
+
+    fn purge_expired(&self) -> impl Future<Output = Result<u64, AuthenticationError>> + Send;
 }
 
 /// Token issuance seam for the device flow.
@@ -79,6 +81,8 @@ pub trait DeviceFlowService: Send + Sync {
 
     /// Verification page: bind the approving user and mark the session
     /// approved.
+    fn purge_expired_sessions(&self) -> impl Future<Output = Result<u64, DeviceFlowError>> + Send;
+
     fn preview_user_code(
         &self,
         user_code: String,

--- a/core/src/domain/authentication/device_flow/services.rs
+++ b/core/src/domain/authentication/device_flow/services.rs
@@ -156,6 +156,10 @@ where
         })
     }
 
+    async fn purge_expired_sessions(&self) -> Result<u64, DeviceFlowError> {
+        Ok(self.device_auth_repository.purge_expired().await?)
+    }
+
     async fn preview_user_code(
         &self,
         user_code: String,
@@ -338,6 +342,27 @@ where
                     .await?;
 
                 Err(DeviceFlowError::AuthorizationPending)
+            }
+        }
+    }
+}
+
+pub async fn purge_expired_device_sessions_task<S>(service: S, period: std::time::Duration)
+where
+    S: DeviceFlowService,
+{
+    let mut ticker = tokio::time::interval(period);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        match service.purge_expired_sessions().await {
+            Ok(0) => {}
+            Ok(removed) => {
+                tracing::info!(removed, "Purged expired device authorization sessions")
+            }
+            Err(error) => {
+                warn!(error = ?error, "Failed to purge expired device authorization sessions")
             }
         }
     }

--- a/core/src/infrastructure/repositories/device_auth_repository.rs
+++ b/core/src/infrastructure/repositories/device_auth_repository.rs
@@ -51,23 +51,6 @@ impl PostgresDeviceAuthRepository {
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }
-
-    /// Delete all sessions whose lifetime has elapsed. Returns the number of
-    /// rows removed. Intended to be run periodically by a background job.
-    #[allow(dead_code)]
-    pub async fn purge_expired(&self) -> Result<u64, AuthenticationError> {
-        let now = Utc::now().fixed_offset();
-        let result = DasEntity::delete_many()
-            .filter(DasColumn::ExpiresAt.lt(now))
-            .exec(&self.db)
-            .await
-            .map_err(|e| {
-                error!("Error purging expired device auth sessions: {e:?}");
-                AuthenticationError::InternalServerError
-            })?;
-
-        Ok(result.rows_affected)
-    }
 }
 
 impl DeviceAuthRepository for PostgresDeviceAuthRepository {
@@ -171,6 +154,20 @@ impl DeviceAuthRepository for PostgresDeviceAuthRepository {
             .ok_or(AuthenticationError::NotFound)?;
 
         Ok(model.into())
+    }
+
+    async fn purge_expired(&self) -> Result<u64, AuthenticationError> {
+        let now = Utc::now().fixed_offset();
+        let result = DasEntity::delete_many()
+            .filter(DasColumn::ExpiresAt.lt(now))
+            .exec(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error purging expired device auth sessions: {e:?}");
+                AuthenticationError::InternalServerError
+            })?;
+
+        Ok(result.rows_affected)
     }
 
     async fn mark_polled(&self, device_code: Uuid) -> Result<(), AuthenticationError> {


### PR DESCRIPTION
## Context

FK-010, fifth and last part — correctif (g).

`purge_expired` existed on `PostgresDeviceAuthRepository`, annotated `#[allow(dead_code)]`, with **zero callers anywhere in the workspace**. It was also declared on the inherent impl rather than the port, so it was unreachable through the trait even if something had wanted it. Expired device authorization sessions therefore accumulated in `device_auth_sessions` forever.

This is table hygiene, not a vulnerability: parts 1 and 2 already made an expired session unusable regardless of whether its row still exists. The `#[allow(dead_code)]` is the more interesting part — it is what let a written-but-unwired capability sit in the tree looking finished.

## Change

`purge_expired` moves onto the `DeviceAuthRepository` port and loses its `allow(dead_code)`. `DeviceFlowService` gains `purge_expired_sessions`, and `purge_expired_device_sessions_task` runs it on a `tokio::time::interval` every 15 minutes, spawned from `create_service` next to the existing `compass_writer_task`.

The ticker uses `MissedTickBehavior::Skip` so a stalled database cannot queue a burst of catch-up purges. A failing purge is logged and the loop continues — losing one sweep is not worth taking the task down, and the next tick retries.

The default lifetime of a device session is 600 seconds, so a 15-minute period keeps at most a couple of sweeps' worth of dead rows. The period is a constant rather than configuration; there is no operator knob to get wrong, and nothing in the product's behaviour depends on the exact value.

## One observable consequence

Polling a `device_code` whose session has been purged now returns `invalid_grant` rather than `expired_token`. Both are refusals and neither issues a token, but a device that distinguishes the two will see the code become unknown instead of expired once the sweep runs. `the_purge_removes_expired_sessions_and_spares_the_others` pins that transition explicitly rather than leaving it to be discovered.

## Verification

One integration test, asserting both halves — deleting the right rows is only half the requirement:

| Test | Asserts |
|---|---|
| `the_purge_removes_expired_sessions_and_spares_the_others` | a backdated session is removed and polls as `invalid_grant`; a live session survives and still polls as `authorization_pending` |

There is no meaningful "red run" here: before this PR the method had no caller, so the test would not have compiled rather than failed. What it guards against is the reverse — a future purge predicate that is too eager and deletes live sessions.

The test needed the `ApplicationService` in the suite's shared context, which it now stores alongside the existing pool.

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
cargo test -p ferriskey-api --test device_flow_test -- --ignored              # 16 passed
cargo test -p ferriskey-core device_flow                                      # 28 passed
```

The widened clippy from #1234 caught an `items after a test module` in this branch that the old CI configuration would have shipped — the first time that change has paid for itself.

## FK-010 is now complete

| Part | PR | Closed |
|---|---|---|
| 1 | #1236 | approved `device_code` replayable forever, never expiring |
| 2 | #1237 | approval from any realm |
| 3 | #1238 | no client authentication on either device endpoint |
| 4 | #1239 | scope dropped and unvalidated; no consent shown |
| 5 | this | expired sessions never purged |

Still open, found during this work and outside FK-010's scope: `generate_tokens_for_user` bypasses `assemble_token_claims`, so no protocol mapper runs and no ID token is issued on the device, registration and post-reset paths — and it never checks `user.enabled`. Both are fixed in the same place and deserve their own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of expired device authorization sessions every 15 minutes.
  * Cleanup reports how many expired sessions were removed and preserves active sessions.
* **Bug Fixes**
  * Improved handling of expired device-flow sessions and associated OAuth errors.
  * Cleanup failures are logged without interrupting application operation.
* **Tests**
  * Added integration coverage for removing expired sessions while retaining valid ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->