### PR TITLE
fix: keep the login action token out of urls and make it single use

### DIFF
--- a/api/tests/mfa_bypass_test.rs
+++ b/api/tests/mfa_bypass_test.rs
@@ -341,8 +341,8 @@ mod tests {
 
             assert!(raw.contains("HttpOnly"), "cookie must be HttpOnly: {raw}");
             assert!(
-                raw.contains("SameSite=Strict"),
-                "cookie must be SameSite=Strict: {raw}"
+                raw.contains("SameSite=Lax"),
+                "cookie must carry the same SameSite policy as FERRISKEY_SESSION: {raw}"
             );
             assert!(
                 raw.contains(&format!("Path=/realms/{}/login-actions", realm())),

--- a/api/tests/mfa_bypass_test.rs
+++ b/api/tests/mfa_bypass_test.rs
@@ -257,6 +257,139 @@ mod tests {
 
     #[test]
     #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test mfa_bypass_test -- --ignored"]
+    fn a_failed_step_does_not_burn_the_token() {
+        rt().block_on(async {
+            grant_otp_credential_to_admin().await;
+            let server = make_server();
+            let authorize = start_authorization(&server).await;
+
+            let login = server
+                .post(&format!("/realms/{}/login-actions/authenticate", realm()))
+                .add_cookie(authorize.cookie("FERRISKEY_SESSION"))
+                .add_query_param("client_id", SEEDED_CLIENT_ID)
+                .json(&json!({ "username": "admin", "password": "admin" }))
+                .await;
+
+            let step_token = login.cookie("FERRISKEY_LOGIN_ACTION").value().to_string();
+            let session_id = authorize.cookie("FERRISKEY_SESSION").value().to_string();
+            let cookies =
+                format!("FERRISKEY_SESSION={session_id}; FERRISKEY_LOGIN_ACTION={step_token}");
+
+            let wrong = server
+                .post(&format!("/realms/{}/login-actions/challenge-otp", realm()))
+                .add_header("Cookie", HeaderValue::from_str(&cookies).unwrap())
+                .json(&json!({ "code": "000000" }))
+                .await;
+
+            assert_ne!(
+                wrong.status_code(),
+                401,
+                "the flow cookie must authenticate the call: {}",
+                wrong.text()
+            );
+            assert_ne!(
+                wrong.status_code(),
+                200,
+                "a wrong code must not succeed: {}",
+                wrong.text()
+            );
+
+            let retry = server
+                .post(&format!("/realms/{}/login-actions/challenge-otp", realm()))
+                .add_header("Cookie", HeaderValue::from_str(&cookies).unwrap())
+                .json(&json!({ "code": "000001" }))
+                .await;
+
+            assert_ne!(
+                retry.status_code(),
+                401,
+                "a mistyped code must not cost the user their login flow: {}",
+                retry.text()
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test mfa_bypass_test -- --ignored"]
+    fn the_step_token_is_confined_to_an_http_only_cookie() {
+        rt().block_on(async {
+            grant_otp_credential_to_admin().await;
+            let server = make_server();
+            let authorize = start_authorization(&server).await;
+
+            let login = server
+                .post(&format!("/realms/{}/login-actions/authenticate", realm()))
+                .add_cookie(authorize.cookie("FERRISKEY_SESSION"))
+                .add_query_param("client_id", SEEDED_CLIENT_ID)
+                .json(&json!({ "username": "admin", "password": "admin" }))
+                .await;
+
+            let body: Value = login.json();
+            assert!(
+                body.get("token").is_none(),
+                "the step token must not travel in the response body: {body}"
+            );
+
+            let raw = login
+                .headers()
+                .get_all("set-cookie")
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .find(|v| v.starts_with("FERRISKEY_LOGIN_ACTION="))
+                .expect("the step token must be handed back as a cookie")
+                .to_string();
+
+            assert!(raw.contains("HttpOnly"), "cookie must be HttpOnly: {raw}");
+            assert!(
+                raw.contains("SameSite=Strict"),
+                "cookie must be SameSite=Strict: {raw}"
+            );
+            assert!(
+                raw.contains(&format!("Path=/realms/{}/login-actions", realm())),
+                "cookie must be scoped to this realm's login actions: {raw}"
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test mfa_bypass_test -- --ignored"]
+    fn a_login_action_no_longer_accepts_a_bearer_header() {
+        rt().block_on(async {
+            grant_otp_credential_to_admin().await;
+            let server = make_server();
+            let authorize = start_authorization(&server).await;
+
+            let login = server
+                .post(&format!("/realms/{}/login-actions/authenticate", realm()))
+                .add_cookie(authorize.cookie("FERRISKEY_SESSION"))
+                .add_query_param("client_id", SEEDED_CLIENT_ID)
+                .json(&json!({ "username": "admin", "password": "admin" }))
+                .await;
+
+            let step_token = login.cookie("FERRISKEY_LOGIN_ACTION").value().to_string();
+
+            let response = server
+                .post(&format!("/realms/{}/login-actions/verify-otp", realm()))
+                .add_header(
+                    "Authorization",
+                    format!("Bearer {step_token}")
+                        .parse::<HeaderValue>()
+                        .unwrap(),
+                )
+                .json(&json!({ "code": "000000" }))
+                .await;
+
+            assert_eq!(
+                response.status_code(),
+                401,
+                "a token presented outside the flow cookie must be refused: {}",
+                response.text()
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test mfa_bypass_test -- --ignored"]
     fn temporary_step_token_cannot_be_replayed_to_complete_login() {
         rt().block_on(async {
             grant_otp_credential_to_admin().await;
@@ -284,10 +417,7 @@ mod tests {
                 "the account must stop at the OTP challenge, got: {body}"
             );
 
-            let step_token = body["token"]
-                .as_str()
-                .expect("the OTP challenge hands back a temporary token")
-                .to_string();
+            let step_token = login.cookie("FERRISKEY_LOGIN_ACTION").value().to_string();
 
             // Step 2 — replay that step token as a Bearer credential on the very same
             // endpoint. Before the fix this returned Success with an authorization
@@ -336,10 +466,7 @@ mod tests {
                 .json(&json!({ "username": "admin", "password": "admin" }))
                 .await;
 
-            let step_token = login.json::<Value>()["token"]
-                .as_str()
-                .expect("temporary token")
-                .to_string();
+            let step_token = login.cookie("FERRISKEY_LOGIN_ACTION").value().to_string();
 
             // The step token is exactly what `auth_login_actions` accepts, so this is
             // the enrolment endpoint an attacker holding only the password can reach.
@@ -348,13 +475,18 @@ mod tests {
             let enrol = server
                 .post(&format!("/realms/{}/login-actions/verify-otp", realm()))
                 .add_header(
-                    "Authorization",
-                    format!("Bearer {step_token}")
-                        .parse::<HeaderValue>()
-                        .unwrap(),
+                    "Cookie",
+                    HeaderValue::from_str(&format!("FERRISKEY_LOGIN_ACTION={step_token}")).unwrap(),
                 )
                 .json(&json!({ "code": "000000", "label": "attacker-device" }))
                 .await;
+
+            assert_ne!(
+                enrol.status_code(),
+                401,
+                "the flow cookie must authenticate the call, or this test proves nothing: {}",
+                enrol.text()
+            );
 
             assert_ne!(
                 enrol.status_code(),

--- a/core/migrations/20260818120000_create_login_action_tokens.down.sql
+++ b/core/migrations/20260818120000_create_login_action_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS login_action_tokens;

--- a/core/migrations/20260818120000_create_login_action_tokens.up.sql
+++ b/core/migrations/20260818120000_create_login_action_tokens.up.sql
@@ -1,0 +1,30 @@
+-- FK-011: the partial-authentication step token was a bearer credential with no
+-- server-side state: never persisted, so `revoke_token` no-opped for it and
+-- `verify_token` skipped its revocation check. It stayed replayable until `exp`,
+-- even after the user had finished the step it was minted for.
+--
+-- This table is that missing state. One row per issued step token, keyed by the
+-- token's own `jti`, consumed by compare-and-swap the moment the step it
+-- authorises actually completes.
+--
+-- Consumption is deliberately NOT on first use: `setup-otp` (GET) and
+-- `verify-otp` (POST) legitimately share one token, so consuming on first touch
+-- would make OTP enrolment impossible. It is also not on every POST: a mistyped
+-- OTP code would then cost the user a full re-login.
+CREATE TABLE login_action_tokens (
+  jti UUID PRIMARY KEY,
+  user_id UUID NOT NULL,
+  realm_id UUID NOT NULL,
+  auth_session_id UUID NOT NULL,
+  expires_at TIMESTAMP NOT NULL,
+  consumed_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_login_action_token_user
+    FOREIGN KEY (user_id)
+    REFERENCES users (id)
+    ON DELETE CASCADE
+);
+
+-- Supports purging expired rows without a sequential scan.
+CREATE INDEX idx_login_action_tokens_expires_at ON login_action_tokens (expires_at);

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -97,6 +97,7 @@ use crate::{
             device_auth_repository::PostgresDeviceAuthRepository,
             email_verification_token_repository::PostgresEmailVerificationTokenRepository,
             keystore_repository::PostgresKeyStoreRepository,
+            login_action_token_repository::PostgresLoginActionTokenRepository,
             magic_link_repository::PostgresMagicLinkRepository,
             password_policy_repository::PostgresPasswordPolicyRepository,
             password_reset_token_repository::PostgresPasswordResetTokenRepository,
@@ -173,6 +174,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
     let hasher = Arc::new(Argon2HasherRepository::new());
     let auth_session = Arc::new(PostgresAuthSessionRepository::new(postgres.get_db()));
     let device_auth = Arc::new(PostgresDeviceAuthRepository::new(postgres.get_db()));
+    let login_action_token = Arc::new(PostgresLoginActionTokenRepository::new(postgres.get_db()));
     let redirect_uri = Arc::new(PostgresRedirectUriRepository::new(postgres.get_db()));
     let post_logout_redirect_uri = Arc::new(PostgresPostLogoutRedirectUriRepository::new(
         postgres.get_db(),
@@ -301,6 +303,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
         webhook.clone(),
         security_event.clone(),
         user_session.clone(),
+        login_action_token.clone(),
         Arc::new(MapperEngine::new()),
         flow_recorder.clone(),
     );

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -122,6 +122,7 @@ use crate::{
             device_auth_repository::PostgresDeviceAuthRepository,
             email_verification_token_repository::PostgresEmailVerificationTokenRepository,
             keystore_repository::PostgresKeyStoreRepository,
+            login_action_token_repository::PostgresLoginActionTokenRepository,
             magic_link_repository::PostgresMagicLinkRepository,
             password_reset_token_repository::PostgresPasswordResetTokenRepository,
             portal_layouts_repository::PostgresPortalLayoutsRepository,
@@ -302,7 +303,10 @@ type ApplicationAuthService = AuthServiceImpl<
     WebhookRepo,
     SecurityEventRepo,
     UserSessionRepo,
+    LoginActionTokenRepo,
 >;
+
+type LoginActionTokenRepo = PostgresLoginActionTokenRepository;
 
 type DeviceAuthRepo = PostgresDeviceAuthRepository;
 
@@ -716,6 +720,16 @@ impl ApplicationService {
 
     /// Verification page: bind the authenticated user to the device session
     /// identified by `user_code` and mark it approved (RFC 8628 §3.3).
+    pub async fn consume_login_action_token(&self, jti: uuid::Uuid) -> bool {
+        use crate::domain::authentication::ports::LoginActionTokenRepository;
+
+        self.auth_service
+            .login_action_token_repository
+            .consume(jti)
+            .await
+            .unwrap_or(false)
+    }
+
     pub async fn purge_expired_device_sessions(&self) -> Result<u64, DeviceFlowError> {
         self.device_flow_service.purge_expired_sessions().await
     }

--- a/core/src/domain/authentication/entities.rs
+++ b/core/src/domain/authentication/entities.rs
@@ -106,4 +106,5 @@ pub struct AuthOutput {
 pub struct AuthorizeRequestInput {
     pub claims: JwtClaim,
     pub token: String,
+    pub realm_name: Option<String>,
 }

--- a/core/src/domain/authentication/ports.rs
+++ b/core/src/domain/authentication/ports.rs
@@ -223,3 +223,26 @@ pub trait AuthenticatePort: Send + Sync {
         base_url: String,
     ) -> impl Future<Output = Result<AuthenticationResult, CoreError>> + Send;
 }
+
+pub struct LoginActionToken {
+    pub jti: Uuid,
+    pub user_id: Uuid,
+    pub realm_id: Uuid,
+    pub auth_session_id: Uuid,
+    pub expires_at: chrono::DateTime<chrono::Utc>,
+    pub consumed_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+pub trait LoginActionTokenRepository: Send + Sync {
+    fn create(
+        &self,
+        token: LoginActionToken,
+    ) -> impl Future<Output = Result<(), AuthenticationError>> + Send;
+
+    fn get_by_jti(
+        &self,
+        jti: Uuid,
+    ) -> impl Future<Output = Result<Option<LoginActionToken>, AuthenticationError>> + Send;
+
+    fn consume(&self, jti: Uuid) -> impl Future<Output = Result<bool, AuthenticationError>> + Send;
+}

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -36,7 +36,7 @@ use crate::domain::{
             TokenIntrospectionResponse,
         },
         mapper_engine::{MapperContext, MapperEngine, TokenType},
-        ports::{AuthService, AuthSessionRepository},
+        ports::{AuthService, AuthSessionRepository, LoginActionToken, LoginActionTokenRepository},
         value_objects::{
             AuthenticationResult, CodeChallengeMethod, EndSessionInput, EndSessionOutput,
             EvaluateClientScopesInput, EvaluateClientScopesResult, EvaluatedMapper, EvaluatedRoles,
@@ -290,6 +290,8 @@ fn refuse_token_issuance_when_actions_pending(
 /// realm may have widened to hours. Realms expose a dedicated
 /// `temporary_token_lifetime`; when a realm has no settings row we fall back to
 /// `DEFAULT_TEMPORARY_TOKEN_LIFETIME` rather than to the access-token default.
+pub(crate) const LOGIN_ACTION_SESSION_CLAIM: &str = "afs";
+
 fn temporary_token_lifetime(realm_settings: Option<&RealmSetting>) -> i64 {
     realm_settings
         .map(|s| s.temporary_token_lifetime)
@@ -499,6 +501,7 @@ pub struct AuthServiceImpl<
     WR,
     SER,
     USR,
+    LAT,
 > where
     R: RealmRepository,
     C: ClientRepository,
@@ -527,6 +530,7 @@ pub struct AuthServiceImpl<
     WR: WebhookRepository,
     SER: SecurityEventRepository,
     USR: UserSessionRepository,
+    LAT: LoginActionTokenRepository,
 {
     pub(crate) realm_repository: Arc<R>,
     pub(crate) client_repository: Arc<C>,
@@ -555,6 +559,7 @@ pub struct AuthServiceImpl<
     pub(crate) webhook_repository: Arc<WR>,
     pub(crate) security_event_repository: Arc<SER>,
     pub(crate) user_session_repository: Arc<USR>,
+    pub(crate) login_action_token_repository: Arc<LAT>,
     pub(crate) mapper_engine: Arc<MapperEngine>,
     pub(crate) ldap_client: LdapClientImpl,
     pub(crate) flow_recorder: FlowRecorder,
@@ -588,6 +593,7 @@ impl<
     WR,
     SER,
     USR,
+    LAT,
 >
     AuthServiceImpl<
         R,
@@ -617,6 +623,7 @@ impl<
         WR,
         SER,
         USR,
+        LAT,
     >
 where
     R: RealmRepository,
@@ -646,6 +653,7 @@ where
     WR: WebhookRepository,
     SER: SecurityEventRepository,
     USR: UserSessionRepository,
+    LAT: LoginActionTokenRepository,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -676,6 +684,7 @@ where
         webhook_repository: Arc<WR>,
         security_event_repository: Arc<SER>,
         user_session_repository: Arc<USR>,
+        login_action_token_repository: Arc<LAT>,
         mapper_engine: Arc<MapperEngine>,
         flow_recorder: FlowRecorder,
     ) -> Self {
@@ -707,6 +716,7 @@ where
             webhook_repository,
             security_event_repository,
             user_session_repository,
+            login_action_token_repository,
             mapper_engine,
             ldap_client: LdapClientImpl,
             flow_recorder,
@@ -742,6 +752,7 @@ impl<
     WR,
     SER,
     USR,
+    LAT,
 >
     AuthServiceImpl<
         R,
@@ -771,6 +782,7 @@ impl<
         WR,
         SER,
         USR,
+        LAT,
     >
 where
     R: RealmRepository,
@@ -800,6 +812,7 @@ where
     WR: WebhookRepository,
     SER: SecurityEventRepository,
     USR: UserSessionRepository,
+    LAT: LoginActionTokenRepository,
 {
     fn expires_in_from(exp: i64) -> u32 {
         let now = Utc::now().timestamp();
@@ -2516,9 +2529,16 @@ where
                 );
             }
             let token = auth_result.token.ok_or(CoreError::InternalServerError)?;
+            let email = self
+                .user_repository
+                .get_by_id(auth_result.user_id)
+                .await
+                .ok()
+                .and_then(|user| user.email);
             return Ok(AuthenticateOutput::requires_otp_challenge(
                 auth_result.user_id,
                 token,
+                email,
             ));
         }
 
@@ -2801,7 +2821,8 @@ This is a server error that should be investigated. Do not forward back this mes
         // lifetime — it only has to survive the next hop of the login flow.
         let temporary_lifetime = temporary_token_lifetime(realm_settings.as_ref());
 
-        let jwt_claim = JwtClaim::new(
+        let auth_session_id = auth_session.id;
+        let mut jwt_claim = JwtClaim::new(
             user.id,
             user.username.clone(),
             iss,
@@ -2812,6 +2833,22 @@ This is a server error that should be investigated. Do not forward back this mes
             Some(auth_session.scope),
             temporary_lifetime,
         );
+        jwt_claim.additional_claims.insert(
+            LOGIN_ACTION_SESSION_CLAIM.to_string(),
+            serde_json::Value::String(auth_session_id.to_string()),
+        );
+
+        self.login_action_token_repository
+            .create(LoginActionToken {
+                jti: jwt_claim.jti,
+                user_id: user.id,
+                realm_id: realm.id.into(),
+                auth_session_id,
+                expires_at: Utc::now() + Duration::seconds(temporary_lifetime),
+                consumed_at: None,
+            })
+            .await
+            .map_err(|_| CoreError::InternalServerError)?;
 
         // Resolve MFA enforcement: realm-level or role-level require_mfa.
         let has_otp_credentials = credentials.iter().any(|cred| cred == "otp");
@@ -3096,6 +3133,7 @@ impl<
     WR,
     SER,
     USR,
+    LAT,
 > AuthService
     for AuthServiceImpl<
         R,
@@ -3125,6 +3163,7 @@ impl<
         WR,
         SER,
         USR,
+        LAT,
     >
 where
     R: RealmRepository,
@@ -3154,6 +3193,7 @@ where
     WR: WebhookRepository,
     SER: SecurityEventRepository,
     USR: UserSessionRepository,
+    LAT: LoginActionTokenRepository,
 {
     async fn auth(&self, input: AuthInput) -> Result<AuthOutput, CoreError> {
         let realm = self
@@ -3437,6 +3477,52 @@ where
         }
 
         let user = self.user_repository.get_by_id(input.claims.sub).await?;
+
+        if let Some(realm_name) = input.realm_name.as_deref() {
+            let realm = self
+                .realm_repository
+                .get_by_name(realm_name)
+                .await?
+                .ok_or(CoreError::InvalidRealm)?;
+
+            if realm.id != user.realm_id {
+                return Err(CoreError::InvalidToken);
+            }
+        }
+
+        let session_id = input
+            .claims
+            .additional_claims
+            .get(LOGIN_ACTION_SESSION_CLAIM)
+            .and_then(|value| value.as_str())
+            .and_then(|raw| Uuid::parse_str(raw).ok())
+            .ok_or(CoreError::InvalidToken)?;
+
+        let auth_session = self
+            .auth_session_repository
+            .get_by_session_code(session_id)
+            .await
+            .map_err(|_| CoreError::InvalidToken)?;
+
+        if auth_session.user_id.is_some_and(|owner| owner != user.id) {
+            return Err(CoreError::InvalidToken);
+        }
+
+        if auth_session.expires_at <= Utc::now() {
+            return Err(CoreError::InvalidToken);
+        }
+
+        let jti = input.claims.jti;
+        let persisted = self
+            .login_action_token_repository
+            .get_by_jti(jti)
+            .await
+            .map_err(|_| CoreError::InvalidToken)?
+            .ok_or(CoreError::InvalidToken)?;
+
+        if persisted.consumed_at.is_some() || persisted.user_id != user.id {
+            return Err(CoreError::InvalidToken);
+        }
 
         self.verify_token(input.token, user.realm_id).await?;
 

--- a/core/src/entity/login_action_tokens.rs
+++ b/core/src/entity/login_action_tokens.rs
@@ -1,0 +1,86 @@
+//! `SeaORM` Entity. Hand-written to match `20260818120000_create_login_action_tokens`;
+//! regenerate with sea-orm-cli against a live database when convenient.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Copy, Clone, Default, Debug, DeriveEntity)]
+pub struct Entity;
+
+impl EntityName for Entity {
+    fn table_name(&self) -> &str {
+        "login_action_tokens"
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, DeriveModel, DeriveActiveModel, Eq)]
+pub struct Model {
+    pub jti: Uuid,
+    pub user_id: Uuid,
+    pub realm_id: Uuid,
+    pub auth_session_id: Uuid,
+    pub expires_at: DateTime,
+    pub consumed_at: Option<DateTime>,
+    pub created_at: DateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
+pub enum Column {
+    Jti,
+    UserId,
+    RealmId,
+    AuthSessionId,
+    ExpiresAt,
+    ConsumedAt,
+    CreatedAt,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
+pub enum PrimaryKey {
+    Jti,
+}
+
+impl PrimaryKeyTrait for PrimaryKey {
+    type ValueType = Uuid;
+    fn auto_increment() -> bool {
+        false
+    }
+}
+
+#[derive(Copy, Clone, Debug, EnumIter)]
+pub enum Relation {
+    Users,
+}
+
+impl ColumnTrait for Column {
+    type EntityName = Entity;
+    fn def(&self) -> ColumnDef {
+        match self {
+            Self::Jti => ColumnType::Uuid.def(),
+            Self::UserId => ColumnType::Uuid.def(),
+            Self::RealmId => ColumnType::Uuid.def(),
+            Self::AuthSessionId => ColumnType::Uuid.def(),
+            Self::ExpiresAt => ColumnType::DateTime.def(),
+            Self::ConsumedAt => ColumnType::DateTime.def().null(),
+            Self::CreatedAt => ColumnType::DateTime.def(),
+        }
+    }
+}
+
+impl RelationTrait for Relation {
+    fn def(&self) -> RelationDef {
+        match self {
+            Self::Users => Entity::belongs_to(super::users::Entity)
+                .from(Column::UserId)
+                .to(super::users::Column::Id)
+                .into(),
+        }
+    }
+}
+
+impl Related<super::users::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Users.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/core/src/entity/mod.rs
+++ b/core/src/entity/mod.rs
@@ -21,6 +21,7 @@ pub mod email_verification_tokens;
 pub mod identity_provider_links;
 pub mod identity_providers;
 pub mod jwt_keys;
+pub mod login_action_tokens;
 pub mod magic_links;
 pub mod organization_attributes;
 pub mod organization_group_attributes;

--- a/core/src/infrastructure/repositories.rs
+++ b/core/src/infrastructure/repositories.rs
@@ -5,6 +5,7 @@ pub mod credential_repository;
 pub mod device_auth_repository;
 pub mod email_verification_token_repository;
 pub mod keystore_repository;
+pub mod login_action_token_repository;
 pub mod magic_link_repository;
 pub mod password_policy_repository;
 pub mod password_reset_token_repository;

--- a/core/src/infrastructure/repositories/login_action_token_repository.rs
+++ b/core/src/infrastructure/repositories/login_action_token_repository.rs
@@ -1,0 +1,87 @@
+use chrono::{DateTime, Utc};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    prelude::Expr,
+};
+use tracing::error;
+use uuid::Uuid;
+
+use crate::domain::authentication::entities::AuthenticationError;
+use crate::domain::authentication::ports::{LoginActionToken, LoginActionTokenRepository};
+use crate::entity::login_action_tokens::{
+    ActiveModel as LatActiveModel, Column as LatColumn, Entity as LatEntity, Model as LatModel,
+};
+
+impl From<LatModel> for LoginActionToken {
+    fn from(model: LatModel) -> Self {
+        LoginActionToken {
+            jti: model.jti,
+            user_id: model.user_id,
+            realm_id: model.realm_id,
+            auth_session_id: model.auth_session_id,
+            expires_at: model.expires_at.and_utc(),
+            consumed_at: model.consumed_at.map(|value| value.and_utc()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PostgresLoginActionTokenRepository {
+    pub db: DatabaseConnection,
+}
+
+impl PostgresLoginActionTokenRepository {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+impl LoginActionTokenRepository for PostgresLoginActionTokenRepository {
+    async fn create(&self, token: LoginActionToken) -> Result<(), AuthenticationError> {
+        let model = LatActiveModel {
+            jti: Set(token.jti),
+            user_id: Set(token.user_id),
+            realm_id: Set(token.realm_id),
+            auth_session_id: Set(token.auth_session_id),
+            expires_at: Set(token.expires_at.naive_utc()),
+            consumed_at: Set(None),
+            created_at: Set(Utc::now().naive_utc()),
+        };
+
+        model.insert(&self.db).await.map_err(|e| {
+            error!("Error creating login action token: {e:?}");
+            AuthenticationError::InternalServerError
+        })?;
+
+        Ok(())
+    }
+
+    async fn get_by_jti(&self, jti: Uuid) -> Result<Option<LoginActionToken>, AuthenticationError> {
+        let model = LatEntity::find_by_id(jti)
+            .one(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error loading login action token: {e:?}");
+                AuthenticationError::InternalServerError
+            })?;
+
+        Ok(model.map(Into::into))
+    }
+
+    async fn consume(&self, jti: Uuid) -> Result<bool, AuthenticationError> {
+        let now: DateTime<Utc> = Utc::now();
+
+        let claimed = LatEntity::update_many()
+            .col_expr(LatColumn::ConsumedAt, Expr::value(now.naive_utc()))
+            .filter(LatColumn::Jti.eq(jti))
+            .filter(LatColumn::ConsumedAt.is_null())
+            .exec(&self.db)
+            .await
+            .map_err(|e| {
+                error!("Error consuming login action token: {e:?}");
+                AuthenticationError::InternalServerError
+            })?;
+
+        Ok(claimed.rows_affected > 0)
+    }
+}

--- a/front/openapi.yaml
+++ b/front/openapi.yaml
@@ -4868,6 +4868,10 @@ components:
       required:
       - status
       properties:
+        email:
+          type:
+          - string
+          - 'null'
         message:
           type:
           - string
@@ -4880,10 +4884,6 @@ components:
             $ref: '#/components/schemas/RequiredAction'
         status:
           $ref: '#/components/schemas/AuthenticationStatus'
-        token:
-          type:
-          - string
-          - 'null'
         url:
           type:
           - string

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -99,10 +99,10 @@ export namespace Schemas {
   export type AuthenticateRequest = Partial<{ password: string | null; username: string | null }>;
   export type AuthenticationStatus = "Success" | "RequiresActions" | "RequiresOtpChallenge" | "Failed";
   export type AuthenticateResponse = {
+    email?: (string | null) | undefined;
     message?: (string | null) | undefined;
     required_actions?: (Array<RequiredAction> | null) | undefined;
     status: AuthenticationStatus;
-    token?: (string | null) | undefined;
     url?: (string | null) | undefined;
   };
   export type AuthenticationAttemptResponse = { login_url: string };

--- a/front/src/api/api.interface.ts
+++ b/front/src/api/api.interface.ts
@@ -40,7 +40,7 @@ export interface AuthenticateResponse {
   status: AuthenticationStatus
   url?: string
   required_actions?: RequiredAction[]
-  token?: string
+  email?: string
   message?: string
 }
 

--- a/front/src/api/auth.api.ts
+++ b/front/src/api/auth.api.ts
@@ -56,8 +56,6 @@ export interface AuthenticatePayload {
   data: Schemas.AuthenticateRequest
   realm: string
   clientId: string
-  useToken?: boolean
-  token?: string
 }
 
 export interface AuthQuery {
@@ -91,12 +89,9 @@ export const useAuthQuery = (params: AuthQuery) => {
 export const useAuthenticateMutation = () => {
   return useMutation({
     mutationFn: async (params: AuthenticatePayload): Promise<Schemas.AuthenticateResponse> => {
-      const headers: Record<string, string> = {}
-
-      if (params.token !== undefined) {
-        headers.Authorization = `Bearer ${params.token}`
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
       }
-      headers['Content-Type'] = 'application/json'
 
       const url = new URL(`${window.apiUrl}/realms/${params.realm}/login-actions/authenticate`)
       url.searchParams.set('client_id', params.clientId)
@@ -252,7 +247,6 @@ export const useLogoutMutation = () => {
 
 export interface ResendVerificationEmailPayload {
   realm: string
-  token: string
 }
 
 export interface ResendVerificationEmailResponse {
@@ -267,7 +261,6 @@ export const useResendVerificationEmailMutation = () => {
       const response = await fetch(url, {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${params.token}`,
           'Content-Type': 'application/json',
         },
         credentials: 'include',

--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -14,6 +14,8 @@ export interface BaseQuery {
  */
 const TOKEN_ENDPOINT_SEGMENT = '/protocol/openid-connect/token'
 
+const LOGIN_ACTIONS_SEGMENT = '/login-actions/'
+
 /**
  * Pull the realm name out of an API URL like
  * `https://api.example.com/realms/master/users/123`. Used by the 401
@@ -53,9 +55,11 @@ async function refreshSession(
 }
 
 export const fetcher: Fetcher['fetch'] = async (input) => {
+  const isLoginAction = input.url.pathname.includes(LOGIN_ACTIONS_SEGMENT)
+
   const buildHeaders = (token: string | null): Headers => {
     const h = new Headers()
-    if (token) h.set('Authorization', `Bearer ${token}`)
+    if (token && !isLoginAction) h.set('Authorization', `Bearer ${token}`)
     if (input.parameters?.header) {
       Object.entries(input.parameters.header).forEach(([key, value]) => {
         if (value != null) h.set(key, String(value))

--- a/front/src/api/trident.api.ts
+++ b/front/src/api/trident.api.ts
@@ -2,35 +2,28 @@ import { useMutation, useQuery } from '@tanstack/react-query'
 import { BaseQuery } from '.'
 import type { Schemas } from './api.client'
 
-export const useSetupOtp = ({ realm, token }: BaseQuery & { token?: string | null }) => {
+export const useSetupOtp = ({ realm, enabled = true }: BaseQuery & { enabled?: boolean }) => {
   return useQuery({
-    queryKey: ['setup-otp'],
+    queryKey: ['setup-otp', realm ?? 'master'],
     queryFn: async (): Promise<Schemas.SetupOtpResponse> => {
       return window.tanstackApi.client.get('/realms/{realm_name}/login-actions/setup-otp', {
         path: { realm_name: realm ?? 'master' },
-        header: {
-          Authorization: `Bearer ${token}`,
-        },
       } as never)
     },
-    enabled: !!token,
+    enabled,
   })
 }
 
 export interface VerifyOtpRequest {
   data: Schemas.OtpVerifyRequest
-  token: string
 }
 
 export const useVerifyOtp = () => {
   return useMutation({
-    mutationFn: async ({ realm, data, token }: BaseQuery & VerifyOtpRequest) => {
+    mutationFn: async ({ realm, data }: BaseQuery & VerifyOtpRequest) => {
       return window.tanstackApi.client.post('/realms/{realm_name}/login-actions/verify-otp', {
         path: { realm_name: realm ?? 'master' },
         body: data,
-        header: {
-          Authorization: `Bearer ${token}`,
-        },
       } as never) as Promise<Schemas.VerifyOtpResponse>
     },
   })
@@ -38,7 +31,6 @@ export const useVerifyOtp = () => {
 
 export interface MutationChallengeOtpRequest {
   data: Schemas.ChallengeOtpRequest
-  token: string
 }
 
 export const useChallengeOtp = () => {
@@ -46,14 +38,10 @@ export const useChallengeOtp = () => {
     mutationFn: async ({
       realm,
       data,
-      token,
     }: BaseQuery & MutationChallengeOtpRequest): Promise<Schemas.ChallengeOtpResponse> => {
       return window.tanstackApi.client.post('/realms/{realm_name}/login-actions/challenge-otp', {
         path: { realm_name: realm ?? 'master' },
         body: data,
-        header: {
-          Authorization: `Bearer ${token}`,
-        },
       } as never) as Promise<Schemas.ChallengeOtpResponse>
     },
   })
@@ -75,18 +63,14 @@ export const useVerifyMagicLink = () => {
 
 export interface UpdatePasswordRequest {
   data: Schemas.UpdatePasswordRequest
-  token: string
 }
 
 export const useUpdatePassword = () => {
   return useMutation({
-    mutationFn: async ({ realm, data, token }: BaseQuery & UpdatePasswordRequest) => {
+    mutationFn: async ({ realm, data }: BaseQuery & UpdatePasswordRequest) => {
       return window.tanstackApi.client.post('/realms/{realm_name}/login-actions/update-password', {
         path: { realm_name: realm ?? 'master' },
         body: data,
-        header: {
-          Authorization: `Bearer ${token}`,
-        },
       } as never) as Promise<Schemas.UpdatePasswordResponse>
     },
   })

--- a/front/src/lib/builder-portal/presets.ts
+++ b/front/src/lib/builder-portal/presets.ts
@@ -435,8 +435,7 @@ function verifyEmailCard(): BuilderNode[] {
           children: [
             // The submit button now resends the verification email. The
             // portal-page submit hook wires `verify_email` → resend
-            // mutation (token read from URL `client_data`), so a click
-            // here calls the API and toasts the result.
+            // mutation, so a click here calls the API and toasts the result.
             node('submit_button', { content: 'Resend verification email' }),
             node('back_to_login_link'),
           ],

--- a/front/src/pages/authentication/components/portal-layout-wrapper.tsx
+++ b/front/src/pages/authentication/components/portal-layout-wrapper.tsx
@@ -91,19 +91,12 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
   const identityProviders = loginSettings?.identity_providers ?? []
 
   // TOTP setup: when the user is mid-enrolment we need to fetch the QR
-  // code + secret from the backend's setup endpoint. The token lives in
-  // the URL as `client_data` (set by the auth flow). Only run the query
+  // code + secret from the backend's setup endpoint. Only run the query
   // on the totp_setup page — every other page would waste a network call
-  // and risk a 4xx if no token is present.
-  const totpSetupToken =
-    pageType === 'totp_setup'
-      ? new URLSearchParams(typeof window === 'undefined' ? '' : window.location.search).get(
-          'client_data',
-        )
-      : null
+  // and risk a 4xx outside of an enrolment flow.
   const { data: totpSetupData } = useSetupOtp({
     realm,
-    token: totpSetupToken,
+    enabled: pageType === 'totp_setup',
   })
   const deviceUserCode =
     pageType === 'device_verify'

--- a/front/src/pages/authentication/feature/execution/configure-otp-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/configure-otp-feature.tsx
@@ -1,6 +1,6 @@
 import { useSetupOtp, useVerifyOtp } from '@/api/trident.api'
 import ConfigureOtp from '../../ui/execution/configure-otp'
-import { useNavigate, useParams, useSearchParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import { RouterParams } from '@/routes/router'
 import { useAuthenticateMutation } from '@/api/auth.api'
 import { useCallback, useEffect } from 'react'
@@ -13,7 +13,6 @@ import { AuthenticationStatus } from '@/api/api.interface'
 
 export default function ConfigureOtpFeature() {
   const { realm_name } = useParams<RouterParams>()
-  const [searchParams] = useSearchParams()
   const {
     mutate: authenticate,
     data: authenticateData,
@@ -21,19 +20,9 @@ export default function ConfigureOtpFeature() {
   const navigate = useNavigate()
   const { mutate: verifyOtp, data: verifyOtpData, status: verifyOtpStatus } = useVerifyOtp()
 
-  const token = searchParams.get('client_data')
-
   const { data, isError, error } = useSetupOtp({
     realm: realm_name ?? 'master',
-    token: token,
   })
-
-  useEffect(() => {
-    if (!token) {
-      toast.error('Token is missing')
-      navigate(`/realms/${realm_name}/authentication/login`)
-    }
-  }, [token, navigate, realm_name])
 
   useEffect(() => {
     if (isError) {
@@ -55,14 +44,12 @@ export default function ConfigureOtpFeature() {
       clientId: 'security-admin-console',
       realm: realm_name ?? 'master',
       data: {},
-      useToken: true,
-      token: token ?? undefined,
     })
-  }, [authenticate, realm_name, token])
+  }, [authenticate, realm_name])
 
   const handleSubmit = (values: VerifyOtpSchema) => {
-    if (!token || !data) {
-      toast.error('Token is missing')
+    if (!data) {
+      toast.error('OTP setup is not ready yet')
       return
     }
 
@@ -73,7 +60,6 @@ export default function ConfigureOtpFeature() {
         code: values.pin,
         label: values.deviceName,
       },
-      token,
       realm: realm_name,
     })
   }
@@ -93,13 +79,12 @@ export default function ConfigureOtpFeature() {
     if (
       authenticateData.status === AuthenticationStatus.RequiresActions &&
       authenticateData.required_actions &&
-      authenticateData.required_actions.length > 0 &&
-      authenticateData.token
+      authenticateData.required_actions.length > 0
     ) {
       const firstRequiredAction = authenticateData.required_actions[0]
 
       navigate(
-        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}&client_data=${authenticateData.token}`
+        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}`
       )
     }
   }, [authenticateData, navigate, realm_name])

--- a/front/src/pages/authentication/feature/execution/configure-passkey-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/configure-passkey-feature.tsx
@@ -1,6 +1,6 @@
 import { useAuthenticateMutation } from '@/api/auth.api'
 import { useCallback, useEffect, useState } from 'react'
-import { useNavigate, useParams, useSearchParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import { RouterParams } from '@/routes/router'
 import { toast } from 'sonner'
 import { AuthenticationStatus } from '@/api/api.interface'
@@ -9,41 +9,28 @@ import { isWebAuthnAvailable, startRegistration } from '@/lib/webauthn'
 
 export default function ConfigurePasskeyFeature() {
   const { realm_name } = useParams<RouterParams>()
-  const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const {
     mutate: authenticate,
     data: authenticateData,
   } = useAuthenticateMutation()
 
-  const token = searchParams.get('client_data')
   const [isLoading, setIsLoading] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
-
-  useEffect(() => {
-    if (!token) {
-      toast.error('Token is missing')
-      navigate(`/realms/${realm_name}/authentication/login`)
-    }
-  }, [token, navigate, realm_name])
 
   const completeAuth = useCallback(() => {
     authenticate({
       clientId: 'security-admin-console',
       realm: realm_name ?? 'master',
       data: {},
-      useToken: true,
-      token: token ?? undefined,
     })
-  }, [authenticate, realm_name, token])
+  }, [authenticate, realm_name])
 
   const onRegister = useCallback(async () => {
     if (!isWebAuthnAvailable()) {
       toast.error('WebAuthn is not supported in this browser')
       return
     }
-
-    if (!token) return
 
     setIsLoading(true)
     try {
@@ -52,7 +39,6 @@ export default function ConfigurePasskeyFeature() {
         '/realms/{realm_name}/login-actions/webauthn-public-key-create-options',
         {
           path: { realm_name: realm_name ?? 'master' },
-          header: { Authorization: `Bearer ${token}` },
         } as never,
       )
 
@@ -65,7 +51,6 @@ export default function ConfigurePasskeyFeature() {
         {
           path: { realm_name: realm_name ?? 'master' },
           body: credential,
-          header: { Authorization: `Bearer ${token}` },
         } as never,
       )
 
@@ -85,7 +70,7 @@ export default function ConfigurePasskeyFeature() {
     } finally {
       setIsLoading(false)
     }
-  }, [realm_name, token, completeAuth])
+  }, [realm_name, completeAuth])
 
   useEffect(() => {
     if (!authenticateData) return
@@ -96,13 +81,12 @@ export default function ConfigurePasskeyFeature() {
     if (
       authenticateData.status === AuthenticationStatus.RequiresActions &&
       authenticateData.required_actions &&
-      authenticateData.required_actions.length > 0 &&
-      authenticateData.token
+      authenticateData.required_actions.length > 0
     ) {
       const firstRequiredAction = authenticateData.required_actions[0]
 
       navigate(
-        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}&client_data=${authenticateData.token}`
+        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}`
       )
     }
   }, [authenticateData, navigate, realm_name])

--- a/front/src/pages/authentication/feature/execution/update-password-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/update-password-feature.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams, useSearchParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import { RouterParams } from '@/routes/router.ts'
 import UpdatePassword from '@/pages/authentication/ui/execution/update-password.tsx'
 import { useUpdatePassword } from '@/api/trident.api'
@@ -7,23 +7,16 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { updatePasswordSchema, UpdatePasswordSchema } from '../../schemas/update-password.schema'
 import { Form } from '@/components/ui/form'
 import { useEffect } from 'react'
+import { toast } from 'sonner'
 import { useAuthenticateMutation } from '@/api/auth.api'
 import { AuthenticationStatus } from '@/api/api.interface'
 
 
 export default function UpdatePasswordFeature() {
   const { realm_name } = useParams<RouterParams>()
-  const [searchParams] = useSearchParams()
   const { mutate: updatePassword, data: responseUpdatePassword } = useUpdatePassword()
   const { mutate: authenticate, data: authenticateResponse } = useAuthenticateMutation()
   const navigate = useNavigate()
-  const token = searchParams.get('client_data')
-
-  useEffect(() => {
-    if (!token) {
-      navigate(`/realms/${realm_name}/authentication/login`, { replace: true })
-    }
-  }, [token, navigate, realm_name])
 
   const form = useForm<UpdatePasswordSchema>({
     resolver: zodResolver(updatePasswordSchema),
@@ -34,14 +27,19 @@ export default function UpdatePasswordFeature() {
   })
 
   const handleClick = form.handleSubmit((payload) => {
-    if (!token) return
-    updatePassword({
-      realm: realm_name ?? 'master',
-      data: {
-        value: payload.password,
+    updatePassword(
+      {
+        realm: realm_name ?? 'master',
+        data: {
+          value: payload.password,
+        },
       },
-      token,
-    })
+      {
+        onError: (error) => {
+          toast.error(error.message || 'Failed to update your password')
+        },
+      }
+    )
   })
 
   useEffect(() => {
@@ -50,10 +48,9 @@ export default function UpdatePasswordFeature() {
         clientId: 'security-admin-console',
         realm: realm_name ?? 'master',
         data: {},
-        token: token ?? undefined
       })
     }
-  }, [responseUpdatePassword, authenticate, realm_name, token])
+  }, [responseUpdatePassword, authenticate, realm_name])
 
   useEffect(() => {
     if (!authenticateResponse) return
@@ -64,13 +61,12 @@ export default function UpdatePasswordFeature() {
     if (
       authenticateResponse.status === AuthenticationStatus.RequiresActions &&
       authenticateResponse.required_actions &&
-      authenticateResponse.required_actions.length > 0 &&
-      authenticateResponse.token
+      authenticateResponse.required_actions.length > 0
     ) {
       const firstRequiredAction = authenticateResponse.required_actions[0]
 
       navigate(
-        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}&client_data=${authenticateResponse.token}`
+        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}`
       )
     }
   }, [authenticateResponse, navigate, realm_name])

--- a/front/src/pages/authentication/feature/execution/verify-email-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/verify-email-feature.tsx
@@ -3,13 +3,12 @@ import { Button } from '@/components/ui/button'
 import { RouterParams } from '@/routes/router'
 import { Mail, RefreshCw } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { useParams, useSearchParams } from 'react-router'
+import { useParams } from 'react-router'
 import { toast } from 'sonner'
 
 const VERIFY_EMAIL_CONTEXT_KEY = 'ferriskey_verify_email_context'
 
 export interface VerifyEmailContext {
-  token: string
   realm: string
   clientId: string
   timestamp: number
@@ -45,22 +44,19 @@ export function clearVerifyEmailContext() {
 
 export default function VerifyEmailFeature() {
   const { realm_name } = useParams<RouterParams>()
-  const [searchParams] = useSearchParams()
-  const token = searchParams.get('client_data')
   const [cooldown, setCooldown] = useState(0)
 
   const { mutate: resendEmail, isPending } = useResendVerificationEmailMutation()
 
   // Store auth context for use after email verification
   useEffect(() => {
-    if (token && realm_name) {
+    if (realm_name) {
       storeVerifyEmailContext({
-        token,
         realm: realm_name,
         clientId: 'security-admin-console', // TODO: get from URL params if needed
       })
     }
-  }, [token, realm_name])
+  }, [realm_name])
 
   useEffect(() => {
     if (cooldown > 0) {
@@ -70,13 +66,13 @@ export default function VerifyEmailFeature() {
   }, [cooldown])
 
   const handleResend = () => {
-    if (!token || !realm_name) {
+    if (!realm_name) {
       toast.error('Unable to resend email: missing authentication context')
       return
     }
 
     resendEmail(
-      { realm: realm_name, token },
+      { realm: realm_name },
       {
         onSuccess: () => {
           toast.success('Verification email sent! Check your inbox.')
@@ -111,7 +107,7 @@ export default function VerifyEmailFeature() {
           <Button
             variant='outline'
             onClick={handleResend}
-            disabled={isPending || cooldown > 0 || !token}
+            disabled={isPending || cooldown > 0}
           >
             {isPending ? (
               <>

--- a/front/src/pages/authentication/feature/page-otp-challenge-feature.tsx
+++ b/front/src/pages/authentication/feature/page-otp-challenge-feature.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams, useSearchParams } from 'react-router'
+import { useLocation, useNavigate, useParams } from 'react-router'
 import PageOtpChallenge from '../ui/page-otp-challenge'
 import { RouterParams } from '@/routes/router'
 import { useChallengeOtp } from '@/api/trident.api'
@@ -6,23 +6,16 @@ import { useForm } from 'react-hook-form'
 import { challengeOtpSchema, ChallengeOtpSchema } from '../schemas/challange-otp.schema'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Form } from '@/components/ui/form'
-import { useCallback, useEffect } from 'react'
+import { useEffect } from 'react'
 import { toast } from 'sonner'
 
 export default function PageOtpChallengeFeature() {
   const { realm_name } = useParams<RouterParams>()
-  const [searchParams] = useSearchParams()
+  const { state } = useLocation()
   const navigate = useNavigate()
   const { mutate: challengeOtp, data: challengeOtpData, isPending, error } = useChallengeOtp()
 
-  const token = searchParams.get('token')
-
-  const email = useCallback(() => {
-    // the token is a JWT we need to decode it to get the claim "email"
-    if (!token) return ''
-    const decodedToken = JSON.parse(atob(token.split('.')[1]))
-    return decodedToken.email
-  }, [token])
+  const email = (state as { email?: string | null } | null)?.email ?? ''
 
   const form = useForm<ChallengeOtpSchema>({
     resolver: zodResolver(challengeOtpSchema),
@@ -36,12 +29,10 @@ export default function PageOtpChallengeFeature() {
   }
 
   const handleClick = (values: ChallengeOtpSchema) => {
-    if (!token) return
     challengeOtp({
       data: {
         code: values.code,
       },
-      token,
       realm: realm_name,
     })
   }
@@ -49,14 +40,10 @@ export default function PageOtpChallengeFeature() {
   useEffect(() => {
     if (!challengeOtpData) return
 
-    if (
-      challengeOtpData.required_actions &&
-      challengeOtpData.required_actions.length > 0 &&
-      token
-    ) {
+    if (challengeOtpData.required_actions && challengeOtpData.required_actions.length > 0) {
       const firstRequiredAction = challengeOtpData.required_actions[0]
       navigate(
-        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}&client_data=${token}`
+        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}`
       )
       return
     }
@@ -64,7 +51,7 @@ export default function PageOtpChallengeFeature() {
     if (challengeOtpData.url) {
       window.location.href = challengeOtpData.url
     }
-  }, [challengeOtpData, navigate, realm_name, token])
+  }, [challengeOtpData, navigate, realm_name])
 
   useEffect(() => {
     if (error) {
@@ -77,7 +64,7 @@ export default function PageOtpChallengeFeature() {
       <PageOtpChallenge
         handleCancelClick={handleCancelClick}
         handleClick={handleClick}
-        email={email()}
+        email={email}
         isLoading={isPending}
       />
     </Form>

--- a/front/src/pages/authentication/feature/page-required-action-feature.tsx
+++ b/front/src/pages/authentication/feature/page-required-action-feature.tsx
@@ -4,15 +4,14 @@ import PageRequiredAction from '../ui/page-required-action'
 export default function PageRequiredActionFeature() {
   const [searchParams] = useSearchParams()
   const execution = searchParams.get('execution')
-  const token = searchParams.get('client_data')
 
-  if (!token) {
+  if (!execution) {
     return <div>Loading ...</div>
   }
 
   return (
     <div>
-      <PageRequiredAction execution={execution ?? ''} />
+      <PageRequiredAction execution={execution} />
     </div>
   )
 }

--- a/front/src/pages/authentication/feature/verify-email-route.tsx
+++ b/front/src/pages/authentication/feature/verify-email-route.tsx
@@ -15,10 +15,10 @@ import {
  *
  *  1. Calls the verify endpoint via `useVerifyEmail` (state machine:
  *     loading / success / expired / error).
- *  2. On success, optionally chains an `authenticate({ useToken: true })`
- *     if the user still has a verify-email context cookie (registration
- *     was on this same browser session) — that lets the backend resume
- *     the auth flow without bouncing through login.
+ *  2. On success, optionally chains an `authenticate()` call if the user
+ *     still has a verify-email context (registration was on this same
+ *     browser session) — that lets the backend resume the auth flow
+ *     without bouncing through login.
  *  3. Once everything resolves, redirects to `/email-verified` (a
  *     customisable success page) so the user never sits indefinitely on
  *     the verification screen.
@@ -64,8 +64,6 @@ export default function VerifyEmailRoute() {
       clientId: context.clientId,
       realm: context.realm,
       data: {},
-      useToken: true,
-      token: context.token,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, realm_name, authenticate])
@@ -87,11 +85,10 @@ export default function VerifyEmailRoute() {
     if (
       authenticateData.status === AuthenticationStatus.RequiresActions &&
       authenticateData.required_actions &&
-      authenticateData.required_actions.length > 0 &&
-      authenticateData.token
+      authenticateData.required_actions.length > 0
     ) {
       const first = authenticateData.required_actions[0]
-      window.location.href = `/realms/${realm_name}/authentication/required-action?execution=${first.toUpperCase()}&client_data=${authenticateData.token}`
+      window.location.href = `/realms/${realm_name}/authentication/required-action?execution=${first.toUpperCase()}`
       return
     }
 

--- a/front/src/pages/authentication/hooks/use-login-form.ts
+++ b/front/src/pages/authentication/hooks/use-login-form.ts
@@ -44,18 +44,19 @@ export function useLoginForm({ realm_name, loginError, getAuthParamsFromUrl }: O
     if (
       authenticateData.status === AuthenticationStatus.RequiresActions &&
       authenticateData.required_actions &&
-      authenticateData.required_actions.length > 0 &&
-      authenticateData.token
+      authenticateData.required_actions.length > 0
     ) {
       const firstRequiredAction = authenticateData.required_actions[0]
 
       navigate(
-        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}&client_data=${authenticateData.token}`
+        `/realms/${realm_name}/authentication/required-action?execution=${firstRequiredAction.toUpperCase()}`
       )
     }
 
     if (authenticateData.status === AuthenticationStatus.RequiresOtpChallenge) {
-      navigate(`/realms/${realm_name}/authentication/otp?token=${authenticateData.token}`)
+      navigate(`/realms/${realm_name}/authentication/otp`, {
+        state: { email: authenticateData.email ?? null },
+      })
     }
   }, [authenticateData, navigate, realm_name])
 

--- a/front/src/pages/authentication/hooks/use-portal-page-submit.ts
+++ b/front/src/pages/authentication/hooks/use-portal-page-submit.ts
@@ -78,19 +78,18 @@ export function usePortalPageSubmit(
     if (
       authenticateData.status === AuthenticationStatus.RequiresActions &&
       authenticateData.required_actions &&
-      authenticateData.required_actions.length > 0 &&
-      authenticateData.token
+      authenticateData.required_actions.length > 0
     ) {
       const first = authenticateData.required_actions[0]
       navigate(
-        `/realms/${realm_name}/authentication/required-action?execution=${first.toUpperCase()}&client_data=${authenticateData.token}`,
+        `/realms/${realm_name}/authentication/required-action?execution=${first.toUpperCase()}`,
       )
       return
     }
     if (authenticateData.status === AuthenticationStatus.RequiresOtpChallenge) {
-      navigate(
-        `/realms/${realm_name}/authentication/otp?token=${authenticateData.token}`,
-      )
+      navigate(`/realms/${realm_name}/authentication/otp`, {
+        state: { email: authenticateData.email ?? null },
+      })
     }
   }, [pageType, authenticateData, navigate, realm_name])
 
@@ -220,10 +219,7 @@ export function usePortalPageSubmit(
   )
 
   // Verify-email: the only meaningful action from the user is "send me
-  // another verification email". The token that authenticates the resend
-  // call lives in the URL as `client_data` (the React fallback stores it
-  // in sessionStorage too, but the portal tree submit has no access to
-  // that — reading from the URL is the canonical source).
+  // another verification email".
   const { mutate: resendVerification, isPending: isResendingVerification } =
     useResendVerificationEmailMutation()
 
@@ -308,13 +304,8 @@ export function usePortalPageSubmit(
   )
   const verifyEmailSubmit = useCallback(
     () => {
-      const token = new URLSearchParams(window.location.search).get('client_data')
-      if (!token) {
-        toast.error('Cannot resend verification email — missing authentication context.')
-        return
-      }
       resendVerification(
-        { realm: realm_name ?? 'master', token },
+        { realm: realm_name ?? 'master' },
         {
           onSuccess: () => toast.success('Verification email sent. Check your inbox.'),
           onError: (error) => toast.error(error.message || 'Failed to resend verification email'),
@@ -405,22 +396,18 @@ export function usePortalPageSubmit(
   // TOTP setup: submit reads the 6-digit code + optional device label from
   // the form, pulls the `secret` from the cached `useSetupOtp` query
   // (already prefetched by `PortalLayoutWrapper`), and posts to verify.
-  // On success the backend redirects via `authenticate({ useToken: true })`
+  // On success the backend redirects via a chained `authenticate()`
   // — same chained pattern as the React `ConfigureOtpFeature`.
   //
   // All hooks for this branch run unconditionally (rules-of-hooks); the
-  // query just sits idle when we're not on the totp_setup page because we
-  // pass `token: null` and the API hook short-circuits on falsy token.
-  const totpSetupToken =
-    typeof window !== 'undefined'
-      ? new URLSearchParams(window.location.search).get('client_data')
-      : null
+  // query just sits idle when we're not on the totp_setup page.
+  //
   // Called for its effect, not its data: this is what makes the server issue and
   // persist the pending enrolment that `verify-otp` later reads back. The secret it
   // returns is rendered by the portal renderer, and is no longer sent back on submit.
   useSetupOtp({
     realm: realm_name ?? 'master',
-    token: pageType === 'totp_setup' ? totpSetupToken : null,
+    enabled: pageType === 'totp_setup',
   })
   const {
     mutate: verifyOtp,
@@ -434,20 +421,17 @@ export function usePortalPageSubmit(
     useAuthenticateMutation()
   useEffect(() => {
     if (pageType !== 'totp_setup') return
-    if (verifyOtpData && verifyOtpStatus === 'success' && totpSetupToken) {
+    if (verifyOtpData && verifyOtpStatus === 'success') {
       authenticateAfterTotp({
         clientId: 'security-admin-console',
         realm: realm_name ?? 'master',
         data: {},
-        useToken: true,
-        token: totpSetupToken,
       })
     }
   }, [
     pageType,
     verifyOtpData,
     verifyOtpStatus,
-    totpSetupToken,
     authenticateAfterTotp,
     realm_name,
   ])
@@ -460,12 +444,11 @@ export function usePortalPageSubmit(
     if (
       authenticateAfterTotpData.status === AuthenticationStatus.RequiresActions &&
       authenticateAfterTotpData.required_actions &&
-      authenticateAfterTotpData.required_actions.length > 0 &&
-      authenticateAfterTotpData.token
+      authenticateAfterTotpData.required_actions.length > 0
     ) {
       const first = authenticateAfterTotpData.required_actions[0]
       navigate(
-        `/realms/${realm_name}/authentication/required-action?execution=${first.toUpperCase()}&client_data=${authenticateAfterTotpData.token}`,
+        `/realms/${realm_name}/authentication/required-action?execution=${first.toUpperCase()}`,
       )
     }
   }, [pageType, authenticateAfterTotpData, navigate, realm_name])
@@ -480,14 +463,9 @@ export function usePortalPageSubmit(
       }
       // The secret is no longer sent: the server reads back the enrolment it issued
       // itself, so a client-supplied secret is neither needed nor accepted (FK-003).
-      if (!totpSetupToken) {
-        toast.error('TOTP setup context is missing. Please restart the flow.')
-        return
-      }
       verifyOtp(
         {
           data: { code, label },
-          token: totpSetupToken,
           realm: realm_name,
         },
         {
@@ -496,7 +474,7 @@ export function usePortalPageSubmit(
         },
       )
     },
-    [realm_name, totpSetupToken, verifyOtp],
+    [realm_name, verifyOtp],
   )
 
   // All hooks above run unconditionally so the order stays stable across

--- a/libs/ferriskey-api-authentication/src/handlers/authentificate.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/authentificate.rs
@@ -1,8 +1,9 @@
 use super::auth::root_scoped_base_url;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header::SET_COOKIE};
 use axum::response::IntoResponse;
 use axum_cookie::CookieManager;
+use axum_extra::extract::cookie::{Cookie, SameSite};
 use ferriskey_api_core::api_entities::api_error::{ApiError, ValidateJson};
 use ferriskey_api_core::app_state::AppState;
 use ferriskey_api_core::decoded_token::OptionalToken;
@@ -20,6 +21,8 @@ use uuid::Uuid;
 use validator::Validate;
 
 pub use ferriskey_api_core::authentication::{AuthenticateResponse, AuthenticationStatus};
+
+pub const LOGIN_ACTION_COOKIE: &str = "FERRISKEY_LOGIN_ACTION";
 
 #[derive(Serialize, Deserialize)]
 pub struct AuthenticateQueryParams {
@@ -127,6 +130,26 @@ pub async fn authenticate(
         }
     }
 
+    let step_token = result.temporary_token.clone();
     let response: AuthenticateResponse = result.into();
-    Ok((StatusCode::OK, axum::Json(response)).into_response())
+
+    let mut headers = HeaderMap::new();
+    if let Some(token) = step_token {
+        let mut flow_cookie = Cookie::build((LOGIN_ACTION_COOKIE, token))
+            .path(format!("/realms/{realm_name}/login-actions"))
+            .http_only(true)
+            .same_site(SameSite::Strict);
+
+        if base_url.starts_with("https") {
+            flow_cookie = flow_cookie.secure(true)
+        }
+
+        headers.insert(
+            SET_COOKIE,
+            HeaderValue::from_str(&flow_cookie.to_string())
+                .map_err(|_| ApiError::InternalServerError("Invalid cookie header".into()))?,
+        );
+    }
+
+    Ok((StatusCode::OK, headers, axum::Json(response)).into_response())
 }

--- a/libs/ferriskey-api-authentication/src/handlers/authentificate.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/authentificate.rs
@@ -138,7 +138,7 @@ pub async fn authenticate(
         let mut flow_cookie = Cookie::build((LOGIN_ACTION_COOKIE, token))
             .path(format!("/realms/{realm_name}/login-actions"))
             .http_only(true)
-            .same_site(SameSite::Strict);
+            .same_site(SameSite::Lax);
 
         if base_url.starts_with("https") {
             flow_cookie = flow_cookie.secure(true)

--- a/libs/ferriskey-api-authentication/src/handlers/device_verify.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/device_verify.rs
@@ -85,7 +85,11 @@ pub async fn device_preview(
 
     let output = state
         .service
-        .authorize_request(AuthorizeRequestInput { claims, token })
+        .authorize_request(AuthorizeRequestInput {
+            claims,
+            token,
+            realm_name: None,
+        })
         .await
         .map_err(|error| {
             warn!(error = ?error, "Device preview: identity token rejected");
@@ -195,7 +199,11 @@ pub async fn device_verify(
 
     let output = state
         .service
-        .authorize_request(AuthorizeRequestInput { claims, token })
+        .authorize_request(AuthorizeRequestInput {
+            claims,
+            token,
+            realm_name: None,
+        })
         .await
         .map_err(|error| {
             warn!(error = ?error, "Device verify: identity token rejected");

--- a/libs/ferriskey-api-core/src/auth.rs
+++ b/libs/ferriskey-api-core/src/auth.rs
@@ -15,6 +15,8 @@ use ferriskey_core::domain::jwt::entities::JwtClaim;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use axum::extract::Path;
+
 use crate::app_state::AppState;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -94,35 +96,74 @@ where
         _: &S,
     ) -> Result<Self, Self::Rejection> {
         let token = extract_token_from_bearer(parts).await?;
+        decode_jwt(token)
+    }
+}
 
-        let t: Vec<&str> = token.split('.').collect();
-        if t.len() != 3 {
-            return Err(AuthError::InvalidToken);
-        }
+pub const LOGIN_ACTION_COOKIE: &str = "FERRISKEY_LOGIN_ACTION";
 
-        let payload = t[1];
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LoginActionJwt {
+    pub(crate) claims: JwtClaim,
+    pub(crate) token: String,
+}
 
-        let decoded = general_purpose::URL_SAFE_NO_PAD
-            .decode(payload)
-            .map_err(|e| {
-                tracing::error!("Failed to decode JWT payload: {:?}", e);
-                AuthError::InvalidToken
-            })?;
+impl<S> FromRequestParts<S> for LoginActionJwt
+where
+    S: Send + Sync,
+    AppState: FromRef<S>,
+{
+    type Rejection = AuthError;
 
-        let payload_str = String::from_utf8(decoded).map_err(|e| {
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let token = parts
+            .headers
+            .get(axum::http::header::COOKIE)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|raw| {
+                raw.split(';').find_map(|part| {
+                    let (name, value) = part.trim().split_once('=')?;
+                    (name == LOGIN_ACTION_COOKIE).then(|| value.to_string())
+                })
+            })
+            .ok_or(AuthError::TokenNotFound)?;
+
+        let Jwt { claims, token } = decode_jwt(token)?;
+        Ok(LoginActionJwt { claims, token })
+    }
+}
+
+fn decode_jwt(token: String) -> Result<Jwt, AuthError> {
+    let t: Vec<&str> = token.split('.').collect();
+    if t.len() != 3 {
+        return Err(AuthError::InvalidToken);
+    }
+
+    let payload = t[1];
+
+    let decoded = general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|e| {
             tracing::error!("Failed to decode JWT payload: {:?}", e);
             AuthError::InvalidToken
         })?;
-        let claims: JwtClaim = serde_json::from_str(&payload_str).map_err(|e| {
-            tracing::error!("Failed to deserialize JWT claims: {:?}", e);
-            AuthError::InvalidToken
-        })?;
 
-        Ok(Jwt {
-            claims,
-            token: token.clone(),
-        })
-    }
+    let payload_str = String::from_utf8(decoded).map_err(|e| {
+        tracing::error!("Failed to decode JWT payload: {:?}", e);
+        AuthError::InvalidToken
+    })?;
+    let claims: JwtClaim = serde_json::from_str(&payload_str).map_err(|e| {
+        tracing::error!("Failed to deserialize JWT claims: {:?}", e);
+        AuthError::InvalidToken
+    })?;
+
+    Ok(Jwt {
+        claims,
+        token: token.clone(),
+    })
 }
 
 pub async fn extract_token_from_bearer(parts: &mut Parts) -> Result<String, AuthError> {
@@ -148,6 +189,7 @@ pub async fn auth(
         .authorize_request(AuthorizeRequestInput {
             claims,
             token: jwt.token,
+            realm_name: None,
         })
         .await
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
@@ -157,24 +199,44 @@ pub async fn auth(
     Ok(next.run(req).await)
 }
 
+const STEP_COMPLETING_ACTIONS: [&str; 4] = [
+    "/login-actions/verify-otp",
+    "/login-actions/challenge-otp",
+    "/login-actions/update-password",
+    "/login-actions/webauthn-public-key-create",
+];
+
 pub async fn auth_login_actions(
     State(state): State<AppState>,
-    jwt: Jwt,
+    Path(realm_name): Path<String>,
+    jwt: LoginActionJwt,
     mut req: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
     let claims = jwt.claims;
+    let jti = claims.jti;
 
     let output = state
         .service
         .authorize_login_action_request(AuthorizeRequestInput {
             claims,
             token: jwt.token,
+            realm_name: Some(realm_name),
         })
         .await
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
     req.extensions_mut().insert(output.identity);
 
-    Ok(next.run(req).await)
+    let completes_step = STEP_COMPLETING_ACTIONS
+        .iter()
+        .any(|suffix| req.uri().path().ends_with(suffix));
+
+    let response = next.run(req).await;
+
+    if completes_step && response.status().is_success() {
+        state.service.consume_login_action_token(jti).await;
+    }
+
+    Ok(response)
 }

--- a/libs/ferriskey-api-core/src/authentication.rs
+++ b/libs/ferriskey-api-core/src/authentication.rs
@@ -18,7 +18,7 @@ pub struct AuthenticateResponse {
     pub status: AuthenticationStatus,
     pub url: Option<String>,
     pub required_actions: Option<Vec<RequiredAction>>,
-    pub token: Option<String>,
+    pub email: Option<String>,
     pub message: Option<String>,
 }
 
@@ -29,7 +29,7 @@ impl From<AuthenticateOutput> for AuthenticateResponse {
                 status: AuthenticationStatus::Success,
                 url: result.redirect_url,
                 required_actions: None,
-                token: None,
+                email: None,
                 message: Some("Authentication successful".to_string()),
             },
             AuthenticationStepStatus::RequiresActions => AuthenticateResponse {
@@ -40,21 +40,21 @@ impl From<AuthenticateOutput> for AuthenticateResponse {
                 } else {
                     Some(result.required_actions)
                 },
-                token: result.temporary_token,
+                email: None,
                 message: Some("Additional actions required before login".to_string()),
             },
             AuthenticationStepStatus::RequiresOtpChallenge => AuthenticateResponse {
                 status: AuthenticationStatus::RequiresOtpChallenge,
                 url: None,
                 required_actions: None,
-                token: result.temporary_token,
+                email: result.email.clone(),
                 message: Some("OTP verification required".to_string()),
             },
             AuthenticationStepStatus::Failed => AuthenticateResponse {
                 status: AuthenticationStatus::Failed,
                 url: None,
                 required_actions: None,
-                token: None,
+                email: None,
                 message: Some("Authentication failed".to_string()),
             },
         }

--- a/libs/ferriskey-api-trident/src/handlers/magic_link.rs
+++ b/libs/ferriskey-api-trident/src/handlers/magic_link.rs
@@ -128,7 +128,7 @@ pub async fn verify_magic_link(
         status: AuthenticationStatus::Success,
         url: Some(login_url),
         required_actions: None,
-        token: None,
+        email: None,
         message: Some("Magic link authentication successful".to_string()),
     };
 

--- a/libs/ferriskey-domain/src/authentication/entities.rs
+++ b/libs/ferriskey-domain/src/authentication/entities.rs
@@ -292,6 +292,7 @@ pub struct AuthenticateOutput {
     pub required_actions: Vec<RequiredAction>,
     pub redirect_url: Option<String>,
     pub session_state: Option<String>,
+    pub email: Option<String>,
 }
 
 impl AuthenticateOutput {
@@ -308,6 +309,7 @@ impl AuthenticateOutput {
             required_actions: Vec::new(),
             redirect_url: Some(redirect_url),
             session_state: None,
+            email: None,
         }
     }
 
@@ -324,10 +326,15 @@ impl AuthenticateOutput {
             required_actions,
             redirect_url: None,
             session_state: None,
+            email: None,
         }
     }
 
-    pub fn requires_otp_challenge(user_id: Uuid, temporary_token: String) -> Self {
+    pub fn requires_otp_challenge(
+        user_id: Uuid,
+        temporary_token: String,
+        email: Option<String>,
+    ) -> Self {
         Self {
             user_id,
             status: AuthenticationStepStatus::RequiresOtpChallenge,
@@ -336,6 +343,7 @@ impl AuthenticateOutput {
             required_actions: Vec::new(),
             redirect_url: None,
             session_state: None,
+            email,
         }
     }
 }


### PR DESCRIPTION
## Context

FK-011. The partial-authentication JWT (`ClaimsTyp::Temporary`) was written into URL query strings — `?client_data=…` and `?token=…` — at eight call sites.

That token is accepted by `auth_login_actions`, which guards `update-password`, `setup-otp`, `verify-otp`, `challenge-otp` and the WebAuthn creation routes. `POST /login-actions/update-password` takes a single `value` field and **never asks for the current password**. So anyone holding one of those URLs — from browser history, cross-device history sync, a link pasted into a support ticket, an extension — could take over the account without knowing the password. RFC 6750 §5.3 forbids carrying a bearer token in a query string.

Reproduced against the unpatched build: the authenticate response returns the signed `Temporary` JWT in its body, which the frontend then puts in the address bar.

One part of the finding is **stale**: the step token no longer borrows `access_token_lifetime`. #1224 introduced `temporary_token_lifetime(realm_settings)` with a `DEFAULT_TEMPORARY_TOKEN_LIFETIME` fallback, and both mint sites already use it.

## Change

**The token leaves the URL entirely.** `AuthenticateResponse.token` is removed (public API change) and the token is handed back as `FERRISKEY_LOGIN_ACTION` — `HttpOnly`, `SameSite=Lax`, `Secure` on https, `Path=/realms/{realm}/login-actions`. A dedicated extractor reads it there, and the login-action routes **no longer accept an `Authorization: Bearer` header**.

A cookie rather than router state: `/required-action` is reached by full page load from `verify-email-route.tsx`, and four readers used `window.location.search` directly, so router state would have been empty exactly where it mattered. The cookie also survives refresh and deep links, which the URL previously provided by leaking.

Frontend: 8 write sites, 9 read sites, and the `sessionStorage` copy that kept the token for 30 minutes — longer than the token's own lifetime. The `Bearer` header turned out to be sent from **8** places, not 2: the four trident hooks, two raw fetches in `auth.api.ts`, and the two WebAuthn calls. The shared `fetcher` now refuses to attach a store token to any `/login-actions/` request, so the rule is enforced in one place.

`AuthenticateResponse` gains `email`, because the OTP challenge page used to decode the JWT client-side to display it.

**Single use.** New table `login_action_tokens`, one row per issued step token keyed by its `jti`, consumed by compare-and-swap. The consumption point is the design decision worth reviewing:

- not on first use — `GET setup-otp` and `POST verify-otp` legitimately share one token, so consuming on first touch would make OTP enrolment impossible;
- not on every POST — a mistyped OTP code would then cost the user a full re-login;
- **on success, on the four routes that complete a step** (`verify-otp`, `challenge-otp`, `update-password`, `webauthn-public-key-create`). `webauthn-public-key-create-options` is excluded because the flow needs two POSTs.

**Binding and tenancy.** The token carries the `auth_session` that minted it; existence, expiry and ownership are checked. `auth_login_actions` now compares the realm in the URL against the user's — it previously took the realm from the user record and never looked at the path.

## Verification

| Test | Asserts |
|---|---|
| `the_step_token_is_confined_to_an_http_only_cookie` | no `token` in the body; cookie is HttpOnly, SameSite=Lax, path-scoped |
| `a_login_action_no_longer_accepts_a_bearer_header` | the same token in an `Authorization` header is refused |
| `a_failed_step_does_not_burn_the_token` | a wrong OTP code leaves the flow usable |

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
11 wired integration suites                                                   # 57 passed
tsc --noEmit / npm run lint (front)                                           # clean, 0 errors
```

## Two vacuous tests found and repaired

The first version of `a_failed_step_does_not_burn_the_token` passed while the cookie was **never sent**: the resulting `401` satisfied its `!= 200` assertion. Chasing that revealed the same defect in `verify_otp_refuses_to_enrol_without_a_pending_server_side_enrollment` — the FK-003 regression guard — which after this migration no longer reached the handler at all and passed on a `401`.

Both now send the cookie explicitly and assert `!= 401` **before** anything else, so neither can pass without exercising the path it claims to cover.

## Known gap

The positive half of single use — "a consumed token is refused" — has no automated test. Every step-completing route either mutates shared fixture state (`update-password` would change the admin password the suite's other tests log in with) or needs a live TOTP code. The guard is in the code and the negative case is covered; the positive one is not. Stated rather than papered over.

## Deployment notes

The flow cookie uses `SameSite=Lax`, the same policy as `FERRISKEY_SESSION` and `FERRISKEY_IDENTITY`, so it adds **no deployment constraint the login flow did not already have**.

`Strict` was the first choice and would have been equivalent in practice — this cookie is only ever carried by XHR, never by a top-level navigation, since its `Path` matches no front-end route, and cross-site XHR carries neither `Lax` nor `Strict`. But being stricter than the session cookie the same flow already depends on bought nothing and introduced an asymmetry, so it is aligned instead.

The residual difference `Lax` allows is a cross-site top-level `GET` to `login-actions/setup-otp`, the one GET among the protected routes. That would create an OTP enrolment and render the response to the victim's own browser; the attacker cannot read a cross-origin response, so this is noise rather than a leak.

Adds a migration. `login_action_tokens` rows are not purged yet — the same gap `purge_expired` filled for device sessions in #1240.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure, server-managed login action handling using protected, single-use cookies.
  - OTP challenge responses now provide the user’s email for a smoother verification flow.
- **Security Improvements**
  - Removed temporary authentication tokens from response bodies, URLs, and bearer headers.
  - Login action cookies are HTTP-only, scoped, and protected against replay and unauthorized use.
- **Bug Fixes**
  - Improved validation for authentication sessions, realms, expiration, and enrollment actions.
  - Added clearer error feedback when password updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->