### PR TITLE
fix: issue user tokens through the common path and refuse disabled accounts

### DIFF
--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -726,6 +726,15 @@ mod tests {
                 refresh["azp"], client_id,
                 "the refresh token must carry the same client: {refresh:?}"
             );
+
+            let id_token = body["id_token"]
+                .as_str()
+                .expect("an openid grant must yield an id_token");
+            let id_claims = decode_jwt_payload(id_token);
+            assert_eq!(
+                id_claims["aud"], client_id,
+                "the id_token must be audienced to the client: {id_claims:?}"
+            );
         });
     }
 

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -4056,6 +4056,14 @@ where
 
         let user = self.user_repository.get_by_id(input.user_id).await?;
 
+        if !user.enabled {
+            warn!(
+                user_id = %user.id,
+                "Refusing to mint tokens: the account is disabled"
+            );
+            return Err(CoreError::Forbidden("account is disabled".to_string()));
+        }
+
         let pending_step = self.resolve_pending_auth_step(user.id, realm.id).await?;
 
         if let Err(error) = refuse_token_issuance_when_step_pending(pending_step.as_ref()) {
@@ -4071,19 +4079,51 @@ where
             .create_user_session(user.id, realm.id, lifetimes.refresh_token)
             .await?;
 
-        let (azp, scope) = match input.client_id {
-            Some(client_uuid) => {
-                let client = self
-                    .client_repository
-                    .get_by_id(realm.id, client_uuid)
-                    .await?;
-                let scope = self
-                    .resolve_scopes_for_client(client_uuid, input.scope.clone())
-                    .await?;
-                (client.client_id, Some(scope))
-            }
-            None => ("".to_string(), None),
-        };
+        if let Some(client_uuid) = input.client_id {
+            let client = self
+                .client_repository
+                .get_by_id(realm.id, client_uuid)
+                .await?;
+            let scope = self
+                .resolve_scopes_for_client(client_uuid, input.scope.clone())
+                .await?;
+
+            let (jwt, refresh_token, id_token) = self
+                .create_jwt(GenerateTokenInput {
+                    base_url: input.base_url.clone(),
+                    realm_name: realm.name.clone(),
+                    user_id: user.id,
+                    username: user.username.clone(),
+                    firstname: user.firstname.clone().unwrap_or_default(),
+                    lastname: user.lastname.clone().unwrap_or_default(),
+                    email_verified: user.email_verified,
+                    client_id: client.client_id,
+                    client_uuid,
+                    email: user.email.clone().unwrap_or_default(),
+                    realm_id: realm.id,
+                    scope: Some(scope),
+                    access_token_lifetime: lifetimes.access_token,
+                    refresh_token_lifetime: lifetimes.refresh_token,
+                    id_token_lifetime: lifetimes.id_token,
+                    nonce: None,
+                    refresh_jti_override: None,
+                    session_id: Some(user_session.id),
+                })
+                .await?;
+
+            return Ok(JwtToken::new(
+                jwt.token,
+                "Bearer".to_string(),
+                refresh_token.token,
+                lifetimes.access_token as u32,
+                lifetimes.refresh_token as u32,
+                None,
+                id_token.map(|token| token.token),
+            ));
+        }
+
+        let azp = String::new();
+        let scope = None;
 
         let iss = format!("{}/realms/{}", input.base_url, realm.name);
         let mut claims = JwtClaim::new(


### PR DESCRIPTION
## Context

Found while mapping FK-010 and flagged on every device flow PR since. `generate_tokens_for_user` did not go through `assemble_token_claims` / `create_jwt` as the four OAuth grants do — it called `generate_token` directly and hand-rolled its own claims and persistence.

Three consequences, on three flows: the device `poll`, `register_user`, and post-reset auto-login.

- **No protocol mapper ran.** Mapper-provided claims — anything an operator configured, `realm_access.roles` — were simply absent, because mapper resolution lives in `assemble_token_claims`.
- **No ID token was issued**, even when `openid` was granted, because only `create_jwt` builds one.
- **`user.enabled` was never checked**, while the password flows check it in three places (`services.rs:2158`, `:2322`, `:2597`). A disabled account still received a full token pair.

#1239 patched `azp` and `scope` onto this path by hand. That was a plaster over the real defect: the path existed at all.

## Change

**Disabled accounts are refused**, before any token is minted, on all three flows.

**When a client is present, issuance goes through `create_jwt`** — the same path `authorization_code`, `password` and `client_credentials` use. Mappers resolve, the ID token is built when `openid` is granted, `azp` and `scope` come from the common assembly rather than being set by hand, and token persistence is the shared implementation instead of a duplicate.

When no client is present — `register_user` and post-reset auto-login pass `client_id: None` — the direct path remains. That is deliberate rather than an omission: scope resolution and mapper lookup are both keyed on a client, so there is nothing for the common path to resolve. Those flows keep exactly the behaviour they had, minus the disabled-account hole.

The hand-rolled `(azp, scope)` resolution #1239 added is deleted; the client branch returns before reaching it, so leaving it would have been code that could never run.

## Verification

`the_issued_token_carries_the_client_and_the_granted_scope` is extended to assert the device token now yields an `id_token` audienced to the client. Run against the unpatched core it fails on `an openid grant must yield an id_token` — the ID token did not exist before this change.

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
11 wired integration suites                                                   # 57 passed
```

The 16 device flow tests, including the scope and `azp` assertions added by #1239, pass unchanged — the common path produces what the hand-rolled one did, plus the ID token.

## Two things not asserted, and why

**Mapper execution.** Structurally it now runs — it is the same call as the other grants — but no test proves it, because the suite's device client has no client-scope assignments, so no mapper applies to it. Asserting it would mean building a client with scopes and mappers attached; worth doing when a fixture for that exists.

An earlier draft of this PR asserted `preferred_username` on the token and failed. The assertion was wrong, not the code: identity claims come only from mappers now (`services.rs:1155-1156` clears them deliberately), so a client without scopes correctly yields none.

**The disabled-account guard.** Every route into `generate_tokens_for_user` requires an active, authenticated user, so reaching the guard end-to-end means disabling an account mid-flow. In this suite that means disabling `admin`, which the other tests log in with — and they run in parallel. Rather than ship a test that corrupts shared fixtures, the gap is stated. The guard is five lines and mirrors the three existing `if !user.enabled` checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled accounts can no longer receive authentication tokens.
  * Tokens issued to a specified client now include the correct client-specific claims.
  * Improved token issuance consistency, including ID and refresh tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->