### PR TITLE
fix: redact the client secret everywhere except creation and an audited reveal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,6 +1948,7 @@ name = "ferriskey-domain"
 version = "0.7.0"
 dependencies = [
  "chrono",
+ "maskass",
  "mockall 0.14.0",
  "rand 0.8.5",
  "regex",

--- a/api/tests/client_cross_realm_test.rs
+++ b/api/tests/client_cross_realm_test.rs
@@ -408,6 +408,14 @@ mod tests {
         );
         let body: Value = response.json();
         let uuid = body["id"].as_str().expect("victim client id").to_string();
+        let secret = body["client_secret"]
+            .as_str()
+            .expect("creation is the one place that hands back the plaintext secret")
+            .to_string();
+        assert!(
+            !secret.is_empty() && secret != "***",
+            "the leak assertions below are meaningless unless this is the real secret: {secret}"
+        );
 
         // `create_client` always persists `require_pkce: false`; the update attack
         // needs it on so that flipping it off is an observable weakening.
@@ -433,16 +441,6 @@ mod tests {
             201,
             "registering the victim's redirect URI failed: {}",
             response.text()
-        );
-
-        let client = read_victim_client(server, master, &uuid).await;
-        let secret = client["secret"]
-            .as_str()
-            .expect("a confidential client carries a secret")
-            .to_string();
-        assert!(
-            !secret.is_empty(),
-            "the victim client must carry a non-empty secret for the leak assertion to mean anything"
         );
 
         VictimClient { uuid, secret }
@@ -486,6 +484,55 @@ mod tests {
             .iter()
             .map(|uri| uri["value"].as_str().unwrap_or_default().to_string())
             .collect()
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test client_cross_realm_test -- --ignored"]
+    fn reading_a_client_never_yields_its_plaintext_secret() {
+        rt().block_on(async {
+            let server = make_server();
+            let master = master_token(&server).await;
+            let victim = create_victim_client(&server, &master).await;
+
+            let client = read_victim_client(&server, &master, &victim.uuid).await;
+            let serialized = client.to_string();
+            assert!(
+                !serialized.contains(&victim.secret),
+                "the client read endpoint must not carry the plaintext secret: {serialized}"
+            );
+            assert_eq!(
+                client["secret"], "***",
+                "the field must be present but redacted, so the console can still tell a confidential client apart: {client}"
+            );
+
+            let list = server
+                .get(&format!("/realms/{TENANT_B}/clients"))
+                .add_header("Authorization", auth_header(&master))
+                .await;
+            assert!(
+                !list.text().contains(&victim.secret),
+                "the client list must not carry the plaintext secret"
+            );
+
+            let reveal = server
+                .get(&format!(
+                    "/realms/{TENANT_B}/clients/{}/client-secret",
+                    victim.uuid
+                ))
+                .add_header("Authorization", auth_header(&master))
+                .await;
+            assert_eq!(
+                reveal.status_code(),
+                200,
+                "an operator holding ManageClients must still be able to retrieve it: {}",
+                reveal.text()
+            );
+            let body: Value = reveal.json();
+            assert_eq!(
+                body["client_secret"], victim.secret,
+                "the dedicated endpoint must return the real secret: {body}"
+            );
+        });
     }
 
     #[test]
@@ -696,11 +743,9 @@ mod tests {
                 response.text()
             );
             let body: Value = response.json();
-            assert!(
-                body["data"]["secret"]
-                    .as_str()
-                    .is_some_and(|s| !s.is_empty()),
-                "alice's own confidential client should expose its secret to her: {body}"
+            assert_eq!(
+                body["data"]["secret"], "***",
+                "alice sees her own confidential client, with the secret redacted like everyone else's: {body}"
             );
 
             // Update.

--- a/api/tests/device_flow_test.rs
+++ b/api/tests/device_flow_test.rs
@@ -287,7 +287,7 @@ mod tests {
         );
 
         let body: Value = response.json();
-        let secret = body["secret"]
+        let secret = body["client_secret"]
             .as_str()
             .unwrap_or_else(|| panic!("a confidential client carries a secret: {body}"))
             .to_string();

--- a/api/tests/token_basic_auth_test.rs
+++ b/api/tests/token_basic_auth_test.rs
@@ -169,7 +169,7 @@ mod tests {
 
         assert_eq!(response.status_code(), 201, "client creation failed");
         let body: Value = response.json();
-        let secret = body["secret"]
+        let secret = body["client_secret"]
             .as_str()
             .expect("confidential client has a secret")
             .to_string();

--- a/api/tests/token_revocation_test.rs
+++ b/api/tests/token_revocation_test.rs
@@ -307,7 +307,7 @@ mod tests {
             created.text()
         );
 
-        let secret = created.json::<Value>()["secret"]
+        let secret = created.json::<Value>()["client_secret"]
             .as_str()
             .expect("a confidential client must be given a secret")
             .to_string();

--- a/core/src/application/client/mod.rs
+++ b/core/src/application/client/mod.rs
@@ -91,6 +91,16 @@ impl ClientService for ApplicationService {
         self.client_service.get_client_by_id(identity, input).await
     }
 
+    async fn reveal_client_secret(
+        &self,
+        identity: Identity,
+        input: GetClientInput,
+    ) -> Result<Option<String>, CoreError> {
+        self.client_service
+            .reveal_client_secret(identity, input)
+            .await
+    }
+
     async fn get_client_roles(
         &self,
         identity: Identity,

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -647,7 +647,7 @@ impl ApplicationService {
             .map_err(|_| DeviceFlowError::InvalidClient)?;
 
         if !client.public_client
-            && !client_secret_matches(client.secret.as_deref(), input.client_secret.as_deref())
+            && !client_secret_matches(client.secret_str(), input.client_secret.as_deref())
         {
             return Err(DeviceFlowError::InvalidClient);
         }
@@ -704,7 +704,7 @@ impl ApplicationService {
             .map_err(|_| DeviceFlowError::InvalidClient)?;
 
         if !client.public_client
-            && !client_secret_matches(client.secret.as_deref(), input.client_secret.as_deref())
+            && !client_secret_matches(client.secret_str(), input.client_secret.as_deref())
         {
             return Err(DeviceFlowError::InvalidClient);
         }

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -338,9 +338,7 @@ fn validate_authorization_code_request(
 
     // Confidential clients must authenticate. Skipping this let anyone redeem a
     // code without ever proving they are the client it belongs to.
-    if !client.public_client
-        && !client_secret_matches(client.secret.as_deref(), request_client_secret)
-    {
+    if !client.public_client && !client_secret_matches(client.secret_str(), request_client_secret) {
         warn!(
             client_id = %client.client_id,
             "authorization_code: client secret mismatch for confidential client"
@@ -2046,7 +2044,7 @@ where
             .await
             .map_err(|_| CoreError::InvalidClient)?;
 
-        if !Self::verify_client_secret(client.secret.as_deref(), params.client_secret.as_deref()) {
+        if !Self::verify_client_secret(client.secret_str(), params.client_secret.as_deref()) {
             return Err(CoreError::InvalidClientSecret);
         }
 
@@ -2135,17 +2133,14 @@ where
             }
 
             // Confidential clients are still allowed when authenticating with a valid secret.
-            if !Self::verify_client_secret(
-                client.secret.as_deref(),
-                params.client_secret.as_deref(),
-            ) {
+            if !Self::verify_client_secret(client.secret_str(), params.client_secret.as_deref()) {
                 return Err(CoreError::InvalidClientSecret);
             }
         } else if !client.public_client {
             // When direct access grants are enabled, confidential clients may call
             // password flow without a secret; if one is provided, it must be valid.
             if let Some(provided_secret) = &params.client_secret
-                && !Self::verify_client_secret(client.secret.as_deref(), Some(provided_secret))
+                && !Self::verify_client_secret(client.secret_str(), Some(provided_secret))
             {
                 return Err(CoreError::InvalidClientSecret);
             }
@@ -3824,7 +3819,7 @@ where
             return Err(CoreError::InvalidClient);
         }
 
-        if !Self::verify_client_secret(client.secret.as_deref(), Some(&input.client_secret)) {
+        if !Self::verify_client_secret(client.secret_str(), Some(&input.client_secret)) {
             return Err(CoreError::InvalidClientSecret);
         }
 
@@ -4550,7 +4545,7 @@ mod tests {
             id,
             enabled: true,
             client_id: "app".to_string(),
-            secret: Some("s3cr3t".to_string()),
+            secret: Some(maskass::Masked::new("s3cr3t".to_string())),
             realm_id,
             protocol: "openid-connect".to_string(),
             public_client: false,

--- a/core/src/domain/client/services.rs
+++ b/core/src/domain/client/services.rs
@@ -516,6 +516,44 @@ where
             .map_err(|_| CoreError::NotFound)
     }
 
+    async fn reveal_client_secret(
+        &self,
+        identity: Identity,
+        input: GetClientInput,
+    ) -> Result<Option<String>, CoreError> {
+        let realm = self
+            .realm_repository
+            .get_by_name(&input.realm_name)
+            .await
+            .map_err(|_| CoreError::InvalidRealm)?
+            .ok_or(CoreError::InvalidRealm)?;
+
+        ensure_policy(
+            self.policy.can_update_client(&identity, &realm).await,
+            "insufficient permissions",
+        )?;
+
+        let client = self
+            .client_repository
+            .get_by_id(realm.id, input.client_id)
+            .await
+            .map_err(|_| CoreError::NotFound)?;
+
+        self.security_event_repository
+            .store_event(
+                SecurityEvent::new(
+                    realm.id,
+                    SecurityEventType::ClientSecretViewed,
+                    EventStatus::Success,
+                    identity.id(),
+                )
+                .with_target("client".to_string(), client.id, None),
+            )
+            .await?;
+
+        Ok(client.secret_str().map(str::to_string))
+    }
+
     async fn get_client_roles(
         &self,
         identity: Identity,

--- a/core/src/domain/common/services.rs
+++ b/core/src/domain/common/services.rs
@@ -685,7 +685,7 @@ pub mod tests {
         let client = Client {
             id: Uuid::new_v4(),
             client_id: "test-client".to_string(),
-            secret: Some("secret".to_string()),
+            secret: Some(maskass::Masked::new("secret".to_string())),
             name: "Test Client".to_string(),
             realm_id,
             enabled: true,

--- a/core/src/infrastructure/client/mappers/client_mapper.rs
+++ b/core/src/infrastructure/client/mappers/client_mapper.rs
@@ -15,7 +15,7 @@ impl From<Model> for Client {
             realm_id: model.realm_id.into(),
             name: model.name,
             client_id: model.client_id,
-            secret: model.secret,
+            secret: model.secret.map(maskass::Masked::new),
             enabled: model.enabled,
             protocol: model.protocol,
             public_client: model.public_client,

--- a/core/src/infrastructure/seawatch/mapper.rs
+++ b/core/src/infrastructure/seawatch/mapper.rs
@@ -72,6 +72,7 @@ fn parse_event_type(raw: &str) -> SecurityEventType {
         "client_created" => SecurityEventType::ClientCreated,
         "client_deleted" => SecurityEventType::ClientDeleted,
         "client_secret_rotated" => SecurityEventType::ClientSecretRotated,
+        "client_secret_viewed" => SecurityEventType::ClientSecretViewed,
         "realm_config_changed" => SecurityEventType::RealmConfigChanged,
         "email_not_sent" => SecurityEventType::EmailNotSent,
         "email_sent" => SecurityEventType::EmailSent,
@@ -130,6 +131,7 @@ mod tests {
         SecurityEventType::ClientCreated,
         SecurityEventType::ClientDeleted,
         SecurityEventType::ClientSecretRotated,
+        SecurityEventType::ClientSecretViewed,
         SecurityEventType::RealmConfigChanged,
         SecurityEventType::EmailNotSent,
         SecurityEventType::EmailSent,
@@ -184,6 +186,7 @@ mod tests {
                 | SecurityEventType::ClientCreated
                 | SecurityEventType::ClientDeleted
                 | SecurityEventType::ClientSecretRotated
+                | SecurityEventType::ClientSecretViewed
                 | SecurityEventType::RealmConfigChanged
                 | SecurityEventType::EmailNotSent
                 | SecurityEventType::EmailSent

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -161,6 +161,7 @@ export namespace Schemas {
   };
   export type ClientScopeMapping = { client_id: string; default_scope_type: ScopeType; scope_id: string };
   export type ClientScopesResponse = { data: Array<ClientScope> };
+  export type ClientSecretResponse = { client_secret?: (string | null) | undefined };
   export type ClientsResponse = { data: Array<Client> };
   export type CodeChallengeMethod = "S256" | "PLAIN";
   export type FlowId = string;
@@ -226,6 +227,7 @@ export namespace Schemas {
     public_client?: boolean | undefined;
     service_account_enabled?: boolean | undefined;
   };
+  export type CreatedClientResponse = Client & Partial<{ client_secret: string | null }>;
   export type EmailType = "reset_password" | "magic_link" | "email_verification";
   export type EmailTemplate = {
     created_at: string;
@@ -1356,7 +1358,7 @@ export namespace Endpoints {
       body: Schemas.CreateClientValidator;
     };
     responses: {
-      201: Schemas.Client;
+      201: Schemas.CreatedClientResponse;
       400: Schemas.ApiErrorResponse;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
@@ -1457,6 +1459,19 @@ export namespace Endpoints {
     responses: {
       200: Array<Schemas.ClientScope>;
       401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+    };
+  };
+  export type get_Get_client_secret = {
+    method: "GET";
+    path: "/realms/{realm_name}/clients/{client_id}/client-secret";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+    };
+    responses: {
+      200: Schemas.ClientSecretResponse;
       403: Schemas.ApiErrorResponse;
       404: Schemas.ApiErrorResponse;
     };
@@ -3759,6 +3774,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/settings/maintenance/whitelist": Endpoints.get_Get_realm_whitelist;
     "/realms/{realm_name}/clients/{client_id}": Endpoints.get_Get_client;
     "/realms/{realm_name}/clients/{client_id}/client-scopes": Endpoints.get_Get_client_client_scopes;
+    "/realms/{realm_name}/clients/{client_id}/client-secret": Endpoints.get_Get_client_secret;
     "/realms/{realm_name}/clients/{client_id}/maintenance/whitelist": Endpoints.get_Get_client_whitelist;
     "/realms/{realm_name}/clients/{client_id}/post-logout-redirects": Endpoints.get_Get_post_logout_redirect_uris;
     "/realms/{realm_name}/clients/{client_id}/redirects": Endpoints.get_Get_redirect_uris;

--- a/front/src/api/client.api.ts
+++ b/front/src/api/client.api.ts
@@ -25,6 +25,28 @@ export const useGetClient = ({ realm, clientId }: BaseQuery & { clientId?: strin
   })
 }
 
+export const useGetClientSecret = ({
+  realm,
+  clientId,
+  enabled,
+}: BaseQuery & { clientId?: string; enabled?: boolean }) => {
+  return useQuery({
+    ...window.tanstackApi.get('/realms/{realm_name}/clients/{client_id}/client-secret', {
+      path: {
+        realm_name: realm!,
+        client_id: clientId!,
+      },
+    }).queryOptions,
+    enabled: !!clientId && !!realm && !!enabled,
+    gcTime: 0,
+    staleTime: Infinity,
+    retry: false,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  })
+}
+
 export interface CreateClientMutate {
   realm: string
   payload: CreateClientSchema

--- a/front/src/pages/client/feature/page-client-credentials-feature.tsx
+++ b/front/src/pages/client/feature/page-client-credentials-feature.tsx
@@ -16,6 +16,6 @@ export default function PageClientCredentialsFeature() {
   }
 
   return (
-    <PageClientCredentials client={responseData.data} />
+    <PageClientCredentials client={responseData.data} realm={realm_name ?? 'master'} />
   )
 }

--- a/front/src/pages/client/ui/page-client-credentials.tsx
+++ b/front/src/pages/client/ui/page-client-credentials.tsx
@@ -1,14 +1,18 @@
 import { useState } from 'react'
 import { InputText } from '@/components/ui/input-text'
-import { Copy, Check } from 'lucide-react'
+import { Copy, Check, Eye, EyeOff, Loader2, ShieldAlert } from 'lucide-react'
 import { Schemas } from '@/api/api.client.ts'
+import { useGetClientSecret } from '@/api/client.api.ts'
 import Client = Schemas.Client
 
 export interface PageClientCredentialsProps {
   client: Client
+  realm: string
 }
 
-function CopyButton({ value }: { value: string }) {
+const MASKED_SECRET = '••••••••••••••••••••••••'
+
+function CopyButton({ value, disabled = false }: { value: string; disabled?: boolean }) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = async () => {
@@ -21,7 +25,8 @@ function CopyButton({ value }: { value: string }) {
     <button
       type='button'
       onClick={handleCopy}
-      className='shrink-0 min-h-[52px] w-11 flex items-center justify-center rounded-md border border-input bg-background text-muted-foreground transition-colors hover:border-ring hover:text-foreground'
+      disabled={disabled}
+      className='shrink-0 min-h-[52px] w-11 flex items-center justify-center rounded-md border border-input bg-background text-muted-foreground transition-colors hover:border-ring hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-input disabled:hover:text-muted-foreground'
     >
       {copied ? (
         <Check className='h-4 w-4 text-emerald-500' />
@@ -32,7 +37,20 @@ function CopyButton({ value }: { value: string }) {
   )
 }
 
-export default function PageClientCredentials({ client }: PageClientCredentialsProps) {
+export default function PageClientCredentials({ client, realm }: PageClientCredentialsProps) {
+  const [revealed, setRevealed] = useState(false)
+
+  const { data, error, isFetching } = useGetClientSecret({
+    realm,
+    clientId: client.id,
+    enabled: revealed,
+  })
+
+  const secret = revealed ? (data?.client_secret ?? null) : null
+  const status = (error as { status?: number } | null)?.status
+  const forbidden = revealed && status === 403
+  const failed = revealed && !!error && !forbidden
+
   return (
     <div className='flex flex-col gap-8'>
       <div className='flex flex-col gap-1'>
@@ -66,20 +84,51 @@ export default function PageClientCredentials({ client }: PageClientCredentialsP
           <div className='w-1/3'>
             <p className='text-sm font-medium'>Client Secret</p>
             <p className='text-sm text-muted-foreground mt-0.5'>
-              The secret used for confidential client authentication.
+              The secret used for confidential client authentication. Revealing it is recorded as a
+              security event.
             </p>
           </div>
-          <div className='w-1/2 flex items-center gap-2'>
-            <InputText
-              label='Client Secret'
-              name='client_secret'
-              type='password'
-              value={client.secret ?? ''}
-              className='flex-1'
-              disabled
-              togglePasswordVisibility={true}
-            />
-            <CopyButton value={client.secret ?? ''} />
+          <div className='w-1/2 flex flex-col gap-2'>
+            <div className='flex items-center gap-2'>
+              <InputText
+                label='Client Secret'
+                name='client_secret'
+                value={secret ?? MASKED_SECRET}
+                className='flex-1'
+                disabled
+              />
+              <button
+                type='button'
+                onClick={() => setRevealed((r) => !r)}
+                disabled={isFetching}
+                aria-label={revealed ? 'Hide client secret' : 'Reveal client secret'}
+                className='shrink-0 min-h-[52px] px-3 flex items-center justify-center gap-1.5 rounded-md border border-input bg-background text-sm font-medium text-muted-foreground transition-colors hover:border-ring hover:text-foreground disabled:opacity-60 disabled:cursor-not-allowed'
+              >
+                {isFetching ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : revealed ? (
+                  <EyeOff className='h-4 w-4' />
+                ) : (
+                  <Eye className='h-4 w-4' />
+                )}
+                {revealed ? 'Hide' : 'Reveal'}
+              </button>
+              <CopyButton value={secret ?? ''} disabled={!secret} />
+            </div>
+
+            {forbidden && (
+              <p className='flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-500'>
+                <ShieldAlert className='h-3.5 w-3.5 shrink-0 mt-0.5' />
+                You need the manage-clients permission to reveal this secret. Ask a realm
+                administrator for access.
+              </p>
+            )}
+            {failed && (
+              <p className='flex items-start gap-1.5 text-xs text-destructive'>
+                <ShieldAlert className='h-3.5 w-3.5 shrink-0 mt-0.5' />
+                The secret could not be revealed. Please try again.
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -161,7 +161,7 @@ export default function PageApplicationDetailFeature() {
           />
         )
       case 'credentials':
-        return <CredentialsTab client={client} />
+        return <CredentialsTab client={client} realm={realm} />
       case 'api-access':
         return <ApiAccessTab realm={realm} clientId={client.id} />
       case 'maintenance':

--- a/front/src/pages/console-applications/ui/tabs/credentials-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/credentials-tab.tsx
@@ -1,11 +1,12 @@
 import { Schemas } from '@/api/api.client'
-import { Check, Copy, Eye, EyeOff, RefreshCw } from 'lucide-react'
+import { useGetClientSecret } from '@/api/client.api'
+import { Check, Copy, Eye, EyeOff, Loader2, RefreshCw, ShieldAlert } from 'lucide-react'
 import { useState } from 'react'
 import { CopyRow, Field, Section } from './primitives'
 
 import Client = Schemas.Client
 
-export default function CredentialsTab({ client }: { client: Client }) {
+export default function CredentialsTab({ client, realm }: { client: Client; realm: string }) {
   const isConfidential = client.client_type === 'confidential'
 
   return (
@@ -20,7 +21,7 @@ export default function CredentialsTab({ client }: { client: Client }) {
           description='Confidential credential used to authenticate this application to FerrisKey.'
         >
           {client.secret ? (
-            <SecretField value={client.secret} />
+            <SecretField realm={realm} clientId={client.id} />
           ) : (
             <p className='text-xs text-muted-foreground'>
               The client secret is hidden for this view.
@@ -59,40 +60,86 @@ export default function CredentialsTab({ client }: { client: Client }) {
   )
 }
 
-function SecretField({ value }: { value: string }) {
+const MASKED_SECRET = '••••••••••••••••••••••••'
+
+function SecretField({ realm, clientId }: { realm: string; clientId: string }) {
   const [revealed, setRevealed] = useState(false)
   const [copied, setCopied] = useState(false)
+
+  const { data, error, isFetching } = useGetClientSecret({
+    realm,
+    clientId,
+    enabled: revealed,
+  })
+
+  const secret = revealed ? (data?.client_secret ?? null) : null
+  const status = (error as { status?: number } | null)?.status
+  const forbidden = revealed && status === 403
+  const failed = revealed && !!error && !forbidden
+
   const copy = () => {
-    void navigator.clipboard.writeText(value)
+    if (!secret) return
+    void navigator.clipboard.writeText(secret)
     setCopied(true)
     window.setTimeout(() => setCopied(false), 1500)
   }
+
   return (
-    <Field label='Secret' hint='Keep this safe — it grants full access on behalf of the application.'>
+    <Field
+      label='Secret'
+      hint='Keep this safe — it grants full access on behalf of the application. Revealing it is recorded as a security event.'
+    >
       <div className='flex items-center gap-2'>
         <input
           readOnly
-          type={revealed ? 'text' : 'password'}
-          value={value}
+          type='text'
+          value={secret ?? MASKED_SECRET}
           className='flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm font-mono outline-none'
         />
         <button
           type='button'
           onClick={() => setRevealed((r) => !r)}
-          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+          disabled={isFetching}
+          className='inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-border bg-background px-3 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-60 disabled:cursor-not-allowed'
           aria-label={revealed ? 'Hide secret' : 'Reveal secret'}
         >
-          {revealed ? <EyeOff className='h-3.5 w-3.5' /> : <Eye className='h-3.5 w-3.5' />}
+          {isFetching ? (
+            <Loader2 className='h-3.5 w-3.5 animate-spin' />
+          ) : revealed ? (
+            <EyeOff className='h-3.5 w-3.5' />
+          ) : (
+            <Eye className='h-3.5 w-3.5' />
+          )}
+          {revealed ? 'Hide' : 'Reveal'}
         </button>
         <button
           type='button'
           onClick={copy}
-          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+          disabled={!secret}
+          className='inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-background disabled:hover:text-muted-foreground'
           aria-label='Copy secret'
         >
-          {copied ? <Check className='h-3.5 w-3.5 text-emerald-500' /> : <Copy className='h-3.5 w-3.5' />}
+          {copied ? (
+            <Check className='h-3.5 w-3.5 text-emerald-500' />
+          ) : (
+            <Copy className='h-3.5 w-3.5' />
+          )}
         </button>
       </div>
+
+      {forbidden && (
+        <p className='flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-500'>
+          <ShieldAlert className='h-3.5 w-3.5 shrink-0 mt-0.5' />
+          You need the manage-clients permission to reveal this secret. Ask a realm administrator
+          for access.
+        </p>
+      )}
+      {failed && (
+        <p className='flex items-start gap-1.5 text-xs text-destructive'>
+          <ShieldAlert className='h-3.5 w-3.5 shrink-0 mt-0.5' />
+          The secret could not be revealed. Please try again.
+        </p>
+      )}
     </Field>
   )
 }

--- a/libs/ferriskey-api-client/src/handlers.rs
+++ b/libs/ferriskey-api-client/src/handlers.rs
@@ -8,6 +8,7 @@ pub mod delete_redirect_uri;
 pub mod evaluate_scopes;
 pub mod get_client;
 pub mod get_client_roles;
+pub mod get_client_secret;
 pub mod get_clients;
 pub mod get_post_logout_redirect_uris;
 pub mod get_redirect_uris;

--- a/libs/ferriskey-api-client/src/handlers/create_client.rs
+++ b/libs/ferriskey-api-client/src/handlers/create_client.rs
@@ -11,6 +11,16 @@ use ferriskey_api_core::app_state::AppState;
 use ferriskey_core::domain::authentication::value_objects::Identity;
 use ferriskey_core::domain::client::entities::Client;
 use ferriskey_core::domain::client::{entities::CreateClientInput, ports::ClientService};
+use serde::Serialize;
+use utoipa::ToSchema;
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CreatedClientResponse {
+    #[serde(flatten)]
+    pub client: Client,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+}
 
 #[utoipa::path(
     post,
@@ -34,7 +44,7 @@ pub async fn create_client(
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
     ValidateJson(payload): ValidateJson<CreateClientValidator>,
-) -> Result<Response<Client>, ApiError> {
+) -> Result<Response<CreatedClientResponse>, ApiError> {
     let client = state
         .service
         .create_client(
@@ -54,5 +64,10 @@ pub async fn create_client(
         )
         .await?;
 
-    Ok(Response::Created(client))
+    let client_secret = client.secret_str().map(str::to_string);
+
+    Ok(Response::Created(CreatedClientResponse {
+        client,
+        client_secret,
+    }))
 }

--- a/libs/ferriskey-api-client/src/handlers/get_client_secret.rs
+++ b/libs/ferriskey-api-client/src/handlers/get_client_secret.rs
@@ -1,0 +1,52 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_api_core::api_entities::{api_error::ApiError, response::Response};
+use ferriskey_api_core::app_state::AppState;
+use ferriskey_core::domain::authentication::value_objects::Identity;
+use ferriskey_core::domain::client::entities::GetClientInput;
+use ferriskey_core::domain::client::ports::ClientService;
+use serde::Serialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ClientSecretResponse {
+    pub client_secret: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/{client_id}/client-secret",
+    tag = "client",
+    summary = "Reveal a confidential client's secret",
+    description = "Returns the plaintext secret of a confidential client. Requires ManageClients (or ManageRealm) — strictly more than the ViewClients needed to read the client itself — and records a `client_secret_viewed` security event.",
+    params(
+        ("realm_name" = String, Path, description = "Realm name"),
+        ("client_id" = Uuid, Path, description = "Client ID"),
+    ),
+    responses(
+        (status = 200, body = ClientSecretResponse),
+        (status = 403, description = "Insufficient permissions"),
+        (status = 404, description = "Client not found"),
+    )
+)]
+pub async fn get_client_secret(
+    Path((realm_name, client_id)): Path<(String, Uuid)>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+) -> Result<Response<ClientSecretResponse>, ApiError> {
+    let client_secret = state
+        .service
+        .reveal_client_secret(
+            identity,
+            GetClientInput {
+                client_id,
+                realm_name,
+            },
+        )
+        .await?;
+
+    Ok(Response::OK(ClientSecretResponse { client_secret }))
+}

--- a/libs/ferriskey-api-client/src/router.rs
+++ b/libs/ferriskey-api-client/src/router.rs
@@ -19,6 +19,7 @@ use super::handlers::{
     evaluate_scopes::{__path_evaluate_scopes, evaluate_scopes},
     get_client::{__path_get_client, get_client},
     get_client_roles::{__path_get_client_roles, get_client_roles},
+    get_client_secret::{__path_get_client_secret, get_client_secret},
     get_clients::{__path_get_clients, get_clients},
     get_post_logout_redirect_uris::{
         __path_get_post_logout_redirect_uris, get_post_logout_redirect_uris,
@@ -37,6 +38,7 @@ use ferriskey_api_core::auth::auth;
 #[openapi(
     paths(
         get_client,
+        get_client_secret,
         get_clients,
         create_client,
         delete_client,
@@ -75,6 +77,13 @@ pub fn client_routes(state: AppState) -> Router<AppState> {
                 state.args.server.root_path
             ),
             get(get_client),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/clients/{{client_id}}/client-secret",
+                state.args.server.root_path
+            ),
+            get(get_client_secret),
         )
         .route(
             &format!(

--- a/libs/ferriskey-domain/Cargo.toml
+++ b/libs/ferriskey-domain/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+maskass = { path = "../maskass" }
 chrono = { version = "0.4.43", features = ["serde"] }
 rand = "0.8"
 regex = "1.11.2"

--- a/libs/ferriskey-domain/src/client/entities.rs
+++ b/libs/ferriskey-domain/src/client/entities.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
+use maskass::Masked;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -72,12 +73,12 @@ impl FromStr for ClientType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ToSchema)]
 pub struct Client {
     pub id: Uuid,
     pub enabled: bool,
     pub client_id: String,
-    pub secret: Option<String>,
+    pub secret: Option<Masked<String>>,
     pub realm_id: RealmId,
     pub protocol: String,
     pub public_client: bool,
@@ -121,13 +122,17 @@ pub struct ClientConfig {
 }
 
 impl Client {
+    pub fn secret_str(&self) -> Option<&str> {
+        self.secret.as_ref().map(|secret| secret.expose().as_str())
+    }
+
     pub fn new(config: ClientConfig) -> Self {
         let (now, timestamp) = generate_timestamp();
         Self {
             id: Uuid::new_v7(timestamp),
             enabled: config.enabled,
             client_id: config.client_id,
-            secret: config.secret,
+            secret: config.secret.map(Masked::new),
             realm_id: config.realm_id,
             protocol: config.protocol,
             public_client: config.public_client,
@@ -159,7 +164,7 @@ impl Client {
             id: Uuid::new_v7(timestamp),
             enabled: true,
             client_id: client_id.clone(),
-            secret: Some(generate_random_string()),
+            secret: Some(Masked::new(generate_random_string())),
             realm_id,
             protocol: "openid-connect".to_string(),
             public_client: false,

--- a/libs/ferriskey-domain/src/client/ports.rs
+++ b/libs/ferriskey-domain/src/client/ports.rs
@@ -68,6 +68,12 @@ pub trait ClientService: Send + Sync {
         input: GetClientsInput,
     ) -> impl Future<Output = Result<Vec<Client>, CoreError>> + Send;
 
+    fn reveal_client_secret(
+        &self,
+        identity: Identity,
+        input: GetClientInput,
+    ) -> impl Future<Output = Result<Option<String>, CoreError>> + Send;
+
     fn get_redirect_uris(
         &self,
         identity: Identity,

--- a/libs/ferriskey-seawatch/src/entities.rs
+++ b/libs/ferriskey-seawatch/src/entities.rs
@@ -55,6 +55,9 @@ pub enum SecurityEventType {
     #[serde(rename = "client_secret_rotated")]
     ClientSecretRotated,
 
+    #[serde(rename = "client_secret_viewed")]
+    ClientSecretViewed,
+
     #[serde(rename = "realm_config_changed")]
     RealmConfigChanged,
 
@@ -95,6 +98,7 @@ impl Display for SecurityEventType {
             SecurityEventType::ClientCreated => write!(f, "client_created"),
             SecurityEventType::ClientDeleted => write!(f, "client_deleted"),
             SecurityEventType::ClientSecretRotated => write!(f, "client_secret_rotated"),
+            SecurityEventType::ClientSecretViewed => write!(f, "client_secret_viewed"),
             SecurityEventType::RealmConfigChanged => write!(f, "realm_config_changed"),
             SecurityEventType::EmailNotSent => write!(f, "email_not_sent"),
             SecurityEventType::EmailSent => write!(f, "email_sent"),

--- a/libs/maskass/src/masked.rs
+++ b/libs/maskass/src/masked.rs
@@ -12,7 +12,7 @@ use utoipa::{
 use crate::strategies::{FullMask, MaskStrategy};
 
 /// What gets produced when data is serialized / logged.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ToSchema)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, ToSchema)]
 pub enum Redaction {
     /// Always "***"
     Full,
@@ -25,7 +25,7 @@ pub enum Redaction {
 /// - `Deserialize`: stores the real value
 /// - `Serialize`: outputs redacted string (never the real value)
 /// - `Debug` / `Display`: redacted
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Masked<T>
 where
     T: ToSchema,


### PR DESCRIPTION
## Context

FK-012. `Client.secret` was a plain `Option<String>` on a `Serialize` struct returned verbatim by `get_client`, `get_clients`, `create_client` and `update_client` — and embedded whole in three webhook payloads (`ClientCreated`, `ClientUpdated`, client maintenance). Secrets are stored unhashed; the SHA-256 in `verify_client_secret` exists to get a constant-time comparison, not to hash at rest.

The read vector needs an operator to have created a `ViewClients`-only role, which no default role satisfies. **The webhook vector has no such precondition**, and is the more severe of the two: creating a webhook requires `ManageWebhooks` (bit `1<<19`) or `ManageRealm` — neither of which grants any client permission. A holder of `ManageWebhooks` alone, who cannot read a single client through the API, receives every confidential client's plaintext secret at an endpoint of their choosing, potentially over plain http, where it also lands in the receiver's logs and any intervening proxy.

## Change

**`Client.secret` is typed `Option<Masked<String>>`.** One type change closes all four read endpoints and all three webhook sites at once, because the redaction lives in `Serialize` — `Masked` emits `"***"` unconditionally. This is the primitive the repo already uses for identity-provider secrets. A projection type per endpoint would have left the webhooks leaking and would have to be remembered at every future serialization site; the type cannot be forgotten.

The field stays present and non-null for confidential clients, so the console can still tell a confidential client from a public one — `client-layout.tsx` gates the Credentials tab on exactly that.

Persistence is unaffected: the DB path is hand-written mappers and a SeaORM `Set`, never serde. (Worth knowing: `IdentityProviderConfig` *is* stored as serde JSON, so the same change there would write `"***"` back to the database. Not a pattern to copy blindly.)

Internal use goes through a new `Client::secret_str() -> Option<&str>`, replacing the seven `client.secret.as_deref()` call sites that feed `client_secret_matches`.

`Masked<T>` gains `PartialOrd, Ord`, because `Role` derives `Ord` and contains a `Client`.

**The secret is delivered exactly twice, both deliberate:**
- at creation — `create_client` returns a `client_secret` field alongside the client, once;
- on demand — new `GET /realms/{realm}/clients/{client_id}/client-secret`, gated on `ManageClients`/`ManageRealm` (strictly more than the `ViewClients` needed to read the client) and recording a new `client_secret_viewed` security event with the client as target. The secret is never put in the event details.

**Frontend.** The two views that displayed the secret now fetch it only on an explicit Reveal, with `gcTime: 0` so the plaintext leaves the TanStack cache as soon as it is hidden, and `retry: false` so a 403 surfaces at once instead of replaying the audit event. A 403 renders an explicit "you need manage-clients" message rather than a blank field.

`nav-main.tsx` is untouched: it fetches the full client list on every console page, but with the field redacted that payload no longer carries anything sensitive. Replacing it with a count endpoint is a performance concern, not part of this fix.

## Three tests that had quietly become vacuous

The masking silently defanged existing assertions, in the same way this codebase has done repeatedly:

- `client_cross_realm_test` — the FK-005 guard built its `VictimClient` by reading `client["secret"]` from a read endpoint, then asserted the attacker's response body did not contain it. With masking that became "the string `***` did not appear". It now takes the real secret from the creation response, and asserts up front that it is neither empty nor `"***"`, so the leak assertions cannot pass on a placeholder.
- Same file — "alice's own confidential client should expose its secret to her" passed because `"***"` is non-empty, while asserting the opposite of the new contract. Rewritten to assert redaction.
- `device_flow_test`, `token_revocation_test`, `token_basic_auth_test` — three helpers authenticated confidential clients using the secret read back from creation. They were failing loudly (authenticating with `"***"`), which is the good case; repointed at `client_secret`.

## Verification

| Test | Asserts |
|---|---|
| `reading_a_client_never_yields_its_plaintext_secret` | neither the single read nor the list carries the real secret; the field is present as `"***"`; the dedicated endpoint returns the real one to a `ManageClients` holder |

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
11 wired integration suites                                                   # 58 passed
tsc --noEmit / npm run lint (front)                                           # clean, 0 errors
```

`token_basic_auth_test` still fails, on `Failed to set global recorder` (#1086) — the pre-existing reason it is one of the six suites not wired into CI. Its helper was fixed anyway so it is correct whenever that harness issue is resolved.

## Not in this PR

- **Hashing the secret at rest.** The finding raises it; it is a separate change with its own migration and a rotation story, and it does not overlap with stopping the disclosure.
- **A count endpoint for the sidebar** — no longer a security concern once the payload is redacted; say the word if you want it as a perf change.
- Surfacing the one-time plaintext in the creation UI. The API now returns it; no console screen shows it yet, so today the reveal endpoint is the only path.

## Noted while working

`SecurityEventType` parsing falls back to `LoginSuccess` for any unrecognised persisted string (`core/src/infrastructure/seawatch/mapper.rs`). An unknown event type therefore reads back from the audit trail as a successful login. Out of scope here, but it fails open in an audit log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added on-demand client-secret retrieval from the client and application credentials pages.
  - Secrets remain masked until explicitly revealed, with loading, permission, and error states.
  - Newly created confidential clients can receive their secret in the creation response.
- **Security**
  - Standard client views now redact secrets.
  - Revealing a secret requires appropriate permissions and records a security event.
- **Bug Fixes**
  - Updated authentication flows to validate client secrets correctly after masking changes.
- **Tests**
  - Added coverage confirming redaction and dedicated secret retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->