### PR TITLE
fix: authorize federation listing, connection tests and user sync

### DIFF
--- a/api/tests/user_cross_realm_test.rs
+++ b/api/tests/user_cross_realm_test.rs
@@ -497,6 +497,54 @@ mod tests {
     /// Worst impact: the tenant-a admin sets the password of a tenant-b user and
     /// owns the account.
     #[test]
+    #[ignore]
+    fn alice_cannot_reach_federation_of_another_tenant() {
+        let server = make_server();
+        rt().block_on(async {
+            let stranger = Uuid::new_v4();
+
+            let listing = server
+                .get(&format!("/realms/{}/federation/providers", tenant_b()))
+                .add_header("Authorization", auth_header(alice_token()))
+                .await;
+            assert_eq!(
+                listing.status_code(),
+                403,
+                "listing another tenant's federation providers must be refused: {}",
+                listing.text()
+            );
+
+            let test_connection = server
+                .post(&format!(
+                    "/realms/{}/federation/providers/{stranger}/test-connection",
+                    tenant_b()
+                ))
+                .add_header("Authorization", auth_header(alice_token()))
+                .await;
+            assert_eq!(
+                test_connection.status_code(),
+                403,
+                "authorization must be decided before the provider is looked up, so a stranger learns nothing about which ids exist: {}",
+                test_connection.text()
+            );
+
+            let sync = server
+                .post(&format!(
+                    "/realms/{}/federation/providers/{stranger}/sync-users",
+                    tenant_b()
+                ))
+                .add_header("Authorization", auth_header(alice_token()))
+                .await;
+            assert_eq!(
+                sync.status_code(),
+                403,
+                "triggering a directory sync on another tenant's provider must be refused: {}",
+                sync.text()
+            );
+        });
+    }
+
+    #[test]
     #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test user_cross_realm_test -- --ignored"]
     fn reset_password_across_tenant_realms_is_refused() {
         rt().block_on(async {

--- a/core/src/application/abyss/federation/mod.rs
+++ b/core/src/application/abyss/federation/mod.rs
@@ -72,18 +72,24 @@ impl FederationService for ApplicationService {
 
     async fn test_federation_connection(
         &self,
+        identity: Identity,
+        realm_name: String,
         id: Uuid,
     ) -> Result<TestConnectionResult, CoreError> {
-        self.federation_service.test_federation_connection(id).await
+        self.federation_service
+            .test_federation_connection(identity, realm_name, id)
+            .await
     }
 
     async fn sync_federation_users(
         &self,
+        identity: Identity,
+        realm_name: String,
         id: Uuid,
         mode: SyncMode,
     ) -> Result<SyncResult, CoreError> {
         self.federation_service
-            .sync_federation_users(id, mode)
+            .sync_federation_users(identity, realm_name, id, mode)
             .await
     }
 }

--- a/core/src/domain/abyss/federation/ports.rs
+++ b/core/src/domain/abyss/federation/ports.rs
@@ -115,10 +115,14 @@ pub trait FederationService: Send + Sync {
 
     fn test_federation_connection(
         &self,
+        identity: Identity,
+        realm_name: String,
         id: Uuid,
     ) -> impl Future<Output = Result<TestConnectionResult, CoreError>> + Send;
     fn sync_federation_users(
         &self,
+        identity: Identity,
+        realm_name: String,
         id: Uuid,
         mode: SyncMode,
     ) -> impl Future<Output = Result<SyncResult, CoreError>> + Send;

--- a/core/src/domain/abyss/federation/services.rs
+++ b/core/src/domain/abyss/federation/services.rs
@@ -205,7 +205,7 @@ where
         self.federation_repository.delete(id).await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, identity))]
     async fn list_federation_providers(
         &self,
         identity: Identity,
@@ -217,21 +217,28 @@ where
             .await?
             .ok_or(CoreError::InvalidRealm)?;
 
+        ensure_policy(
+            self.policy
+                .can_view_federation_provider(&identity, &realm)
+                .await,
+            "insufficient permissions to list providers",
+        )?;
+
         self.federation_repository
             .list_by_realm(realm.id.into())
             .await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, identity))]
     async fn test_federation_connection(
         &self,
+        identity: Identity,
+        realm_name: String,
         id: Uuid,
     ) -> Result<TestConnectionResult, CoreError> {
         let provider = self
-            .federation_repository
-            .get_by_id(id)
-            .await?
-            .ok_or(CoreError::NotFound)?;
+            .resolve_provider_for_management(&identity, &realm_name, id)
+            .await?;
 
         match provider.provider_type {
             FederationType::Ldap | FederationType::ActiveDirectory => {
@@ -245,17 +252,17 @@ where
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, identity))]
     async fn sync_federation_users(
         &self,
+        identity: Identity,
+        realm_name: String,
         id: Uuid,
         mode: SyncMode,
     ) -> Result<SyncResult, CoreError> {
         let provider = self
-            .federation_repository
-            .get_by_id(id)
-            .await?
-            .ok_or(CoreError::NotFound)?;
+            .resolve_provider_for_management(&identity, &realm_name, id)
+            .await?;
 
         info!(
             "Starting federation sync for provider '{}' (ID: {}), mode: {:?}",
@@ -281,6 +288,39 @@ where
     U: UserRepository,
     CR: CredentialRepository,
 {
+    async fn resolve_provider_for_management(
+        &self,
+        identity: &Identity,
+        realm_name: &str,
+        id: Uuid,
+    ) -> Result<FederationProvider, CoreError> {
+        let realm = self
+            .realm_repository
+            .get_by_name(realm_name)
+            .await?
+            .ok_or(CoreError::InvalidRealm)?;
+
+        ensure_policy(
+            self.policy
+                .can_update_federation_provider(identity, &realm)
+                .await,
+            "insufficient permissions to operate this provider",
+        )?;
+
+        let provider = self
+            .federation_repository
+            .get_by_id(id)
+            .await?
+            .ok_or(CoreError::NotFound)?;
+
+        if provider.realm_id != Into::<Uuid>::into(realm.id) {
+            error!("Provider realm ID does not match requested realm");
+            return Err(CoreError::NotFound);
+        }
+
+        Ok(provider)
+    }
+
     /// Comprehensive LDAP user synchronization with reconciliation
     ///
     /// This method performs a "diff" between LDAP and the local database:
@@ -397,6 +437,14 @@ where
                     }
                     ReconcileAction::NoChange => {
                         // User exists and is up to date
+                    }
+                    ReconcileAction::Skipped => {
+                        result.failed += 1;
+                        result.errors.push(SyncError {
+                            username: Some(ldap_user.username.clone()),
+                            external_id: ldap_user.external_id.clone(),
+                            error: "a local account with this username already exists and is not federated; link it explicitly before syncing".to_string(),
+                        });
                     }
                 },
                 Err(e) => {
@@ -650,25 +698,11 @@ where
                     Ok(user) => {
                         // User exists but has no mapping - link it (orphan user case)
                         warn!(
-                            "Found existing user '{}' (ID: {}) without federation mapping, linking to LDAP provider '{}'",
+                            "Refusing to link local user '{}' (ID: {}) to LDAP provider '{}': the account exists locally with no federation mapping, so claiming it from the directory would hand it to whoever controls that username",
                             user.username, user.id, provider.name
                         );
 
-                        // Update user attributes from LDAP
-                        let update_request = UpdateUserRequest {
-                            email: ldap_user.email.clone().or(user.email.clone()),
-                            firstname: ldap_user.first_name.clone().or(user.firstname.clone()),
-                            lastname: ldap_user.last_name.clone().or(user.lastname.clone()),
-                            enabled: true,
-                            email_verified: user.email_verified,
-                            required_actions: None,
-                        };
-
-                        self.user_repository
-                            .update_user(user.id, update_request)
-                            .await?;
-
-                        user
+                        return Ok(ReconcileAction::Skipped);
                     }
                     Err(_) => {
                         // User doesn't exist - create new user
@@ -842,4 +876,5 @@ enum ReconcileAction {
     Created,
     Updated,
     NoChange,
+    Skipped,
 }

--- a/libs/ferriskey-api-abyss/src/federation/handlers/sync_users.rs
+++ b/libs/ferriskey-api-abyss/src/federation/handlers/sync_users.rs
@@ -1,3 +1,4 @@
+use axum::Extension;
 use axum::extract::{Path, State};
 use ferriskey_core::domain::abyss::federation::{entities::SyncMode, ports::FederationService};
 use uuid::Uuid;
@@ -5,6 +6,7 @@ use uuid::Uuid;
 use crate::federation::dto::SyncUsersResponse;
 use ferriskey_api_core::api_entities::{api_error::ApiError, response::Response};
 use ferriskey_api_core::app_state::AppState;
+use ferriskey_core::domain::authentication::value_objects::Identity;
 
 #[utoipa::path(
     post,
@@ -25,13 +27,14 @@ use ferriskey_api_core::app_state::AppState;
     tag = "federation"
 )]
 pub async fn sync_users(
-    Path((_, id)): Path<(String, Uuid)>,
+    Path((realm_name, id)): Path<(String, Uuid)>,
     State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
 ) -> Result<Response<SyncUsersResponse>, ApiError> {
     // Default to Import mode for safety (Force would disable missing users)
     let result = state
         .service
-        .sync_federation_users(id, SyncMode::Import)
+        .sync_federation_users(identity, realm_name, id, SyncMode::Import)
         .await
         .map_err(ApiError::from)?;
 

--- a/libs/ferriskey-api-abyss/src/federation/handlers/test_connection.rs
+++ b/libs/ferriskey-api-abyss/src/federation/handlers/test_connection.rs
@@ -1,3 +1,4 @@
+use axum::Extension;
 use axum::extract::{Path, State};
 use ferriskey_core::domain::abyss::federation::ports::FederationService;
 use uuid::Uuid;
@@ -5,6 +6,7 @@ use uuid::Uuid;
 use crate::federation::dto::TestConnectionResponse;
 use ferriskey_api_core::api_entities::{api_error::ApiError, response::Response};
 use ferriskey_api_core::app_state::AppState;
+use ferriskey_core::domain::authentication::value_objects::Identity;
 
 #[utoipa::path(
     post,
@@ -24,12 +26,13 @@ use ferriskey_api_core::app_state::AppState;
     tag = "federation"
 )]
 pub async fn test_connection(
-    Path((_, id)): Path<(String, Uuid)>,
+    Path((realm_name, id)): Path<(String, Uuid)>,
     State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
 ) -> Result<Response<TestConnectionResponse>, ApiError> {
     let result = state
         .service
-        .test_federation_connection(id)
+        .test_federation_connection(identity, realm_name, id)
         .await
         .map_err(ApiError::from)?;
 


### PR DESCRIPTION
## Context

FK-013, first of three. This PR closes the authorization half; SSRF and the LDAP client follow separately.

The federation routes sit behind an authentication-only layer — `auth` validates the JWT and injects the identity, with `realm_name: None`, and performs no permission check and no realm binding. On top of that:

- `list_federation_providers` received `identity` and never used it. No `ensure_policy`, unlike `get`, `update` and `delete` on either side of it. The compiler could not complain because `#[instrument(skip(self))]` consumes the parameter — the neighbouring methods all use `skip(self, identity)`.
- `test_federation_connection` and `sync_federation_users` took **neither `identity` nor `realm_name`**. That is worse than a missing check: with no realm to compare against, they resolve a provider by bare UUID and never verify it belongs to the caller's realm. **Any authenticated principal, from any realm, could test-connect or trigger a directory sync against any provider in the deployment.**

The response discloses the directory topology: `connection.server_url`, `port`, `bind.bind_dn`, `search.base_dn`, `user_search_filter`. The bind password is correctly masked by the sanitizer.

Reproduced: a tenant-A administrator lists tenant B's federation providers and gets `200 {"data":[]}` — a 200 she should never have reached.

## Change

**`list_federation_providers`** gains `ensure_policy(can_view_federation_provider)` and its `#[instrument]` now skips `identity`. That attribute is not cosmetic: `#[instrument]` records every non-skipped argument through `Debug`, so the full `User` — including its role graph — was being written into the span on every call.

**`test_federation_connection` and `sync_federation_users`** take `identity` and `realm_name`, threaded through all four layers (handler, facade, port, domain impl). Both now go through one `resolve_provider_for_management` helper that resolves the realm, checks `can_update_federation_provider`, then loads the provider and rejects a realm mismatch with `NotFound`.

The ordering matters and is deliberate: **the policy is checked before the provider is looked up**. Doing it the other way — which is what `delete_federation_provider` does today — lets an unauthorized caller tell an existing provider id from a non-existent one by the 404/403 difference. The test asserts the 403.

`ManageRealm` (via `can_update_federation_provider`) is the gate for both, not the view permission: one exercises stored service-account credentials against an external directory, the other mutates local users.

**Orphan linking is now refused.** Beyond the finding: in `reconcile_user_optimized`, a directory entry whose username matched a local account with no federation mapping was silently linked to the provider and updated from LDAP. Whoever controls a username in the directory could therefore claim an existing local account — including a local administrator — and then authenticate as it through the federation path. It now refuses, and reports the collision to the operator through the existing `errors` list rather than failing silently.

This is a behaviour change: a legitimate migration that relied on implicit linking must now link explicitly. Fail-closed is the right default for a path that grants control of an existing account.

## Verification

| Test | Asserts |
|---|---|
| `alice_cannot_reach_federation_of_another_tenant` | a tenant-A admin gets 403 on tenant B's provider list, test-connection and sync-users — the last two on a random UUID, proving authorization is decided before existence |

It lives in `user_cross_realm_test` rather than a new suite: same harness, same class of defect (cross-realm IDOR), and the file already exists for exactly that.

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
11 wired integration suites                                                   # 59 passed
```

## Stale in the finding

The remediation says federation policies must be added. They already exist, in `core/src/domain/abyss/federation/policies.rs` rather than the shared `common/policies.rs` — so this PR adds no policy, it only calls the ones that were there.

## Not in this PR

- **SSRF** (finding items c, d) — next PR. Note for it: the finding's guidance says the email and LDAP modules show the timeout pattern is already known in this repo. That is wrong — no HTTP client here sets a timeout, and the webhook sender is a bare `Client::new()`, i.e. a second unguarded outbound surface that belongs in the scope rather than the remediation.
- **LDAP client** (items e, f, g) — third PR.
- **`decrypt_password`** (item h) is base64 with a plaintext fallback and a KMS/Vault TODO. That is an integration decision, not a patch to write here, and it should be treated as blocking before the LDAP module is used in production.
- `enabled: true` remains hardcoded when reconciling a mapped user. With sync now restricted to `ManageRealm` this is an administrator-initiated action rather than something any user can trigger, which is defensible — but it still overrides an administrative disable and clears `required_actions`. Worth revisiting in the third PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Federation provider listings, connection tests, and user synchronization now enforce identity-based authorization and realm ownership.
  * Cross-realm access attempts are correctly rejected.
  * LDAP synchronization skips local accounts without federation mappings and reports them as skipped instead of modifying them.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->