### PR TITLE
test: cover id token verification and record the audit event before removal

### DIFF
--- a/core/src/domain/abyss/broker_services.rs
+++ b/core/src/domain/abyss/broker_services.rs
@@ -333,86 +333,96 @@ where
             .ok_or(CoreError::InvalidIdToken)?;
         let issuer = config.issuer.as_deref().ok_or(CoreError::InvalidIdToken)?;
 
-        let header = jsonwebtoken::decode_header(id_token).map_err(|e| {
-            warn!("id_token header is not decodable: {e}");
-            CoreError::InvalidIdToken
-        })?;
-
         let jwks = self.oauth_client.fetch_jwks(jwks_url).await?;
-        let jwk_set: jsonwebtoken::jwk::JwkSet = serde_json::from_value(jwks).map_err(|e| {
-            warn!("JWKS document is not a valid key set: {e}");
-            CoreError::InvalidIdToken
-        })?;
 
-        if !ID_TOKEN_ALGORITHMS.contains(&header.alg) {
-            warn!(
-                "id_token declares algorithm {:?}, which is not accepted",
-                header.alg
-            );
-            return Err(CoreError::InvalidIdToken);
-        }
+        verify_id_token_against_jwks(id_token, &jwks, issuer, &config.client_id, expected_nonce)
+    }
+}
 
-        let jwk = match header.kid.as_deref() {
-            Some(kid) => jwk_set.find(kid),
-            None => jwk_set.keys.first(),
-        }
-        .ok_or_else(|| {
-            warn!("no JWKS key matches the id_token header");
-            CoreError::InvalidIdToken
-        })?;
+fn verify_id_token_against_jwks(
+    id_token: &str,
+    jwks: &serde_json::Value,
+    issuer: &str,
+    audience: &str,
+    expected_nonce: Option<&str>,
+) -> Result<serde_json::Value, CoreError> {
+    let header = jsonwebtoken::decode_header(id_token).map_err(|e| {
+        warn!("id_token header is not decodable: {e}");
+        CoreError::InvalidIdToken
+    })?;
 
-        if let Some(key_alg) = jwk.common.key_algorithm
-            && key_alg.to_string() != format!("{:?}", header.alg)
-        {
-            warn!("id_token algorithm does not match the JWKS key it selected");
-            return Err(CoreError::InvalidIdToken);
-        }
+    let jwk_set: jsonwebtoken::jwk::JwkSet = serde_json::from_value(jwks.clone()).map_err(|e| {
+        warn!("JWKS document is not a valid key set: {e}");
+        CoreError::InvalidIdToken
+    })?;
 
-        let key = jsonwebtoken::DecodingKey::from_jwk(jwk).map_err(|e| {
-            warn!("JWKS key is unusable: {e}");
-            CoreError::InvalidIdToken
-        })?;
-
-        let mut validation = jsonwebtoken::Validation::new(header.alg);
-        validation.set_issuer(&[issuer]);
-        validation.set_audience(&[config.client_id.as_str()]);
-        validation.validate_exp = true;
-
-        let data = jsonwebtoken::decode::<serde_json::Value>(id_token, &key, &validation).map_err(
-            |e| {
-                warn!("id_token verification failed: {e}");
-                CoreError::InvalidIdToken
-            },
-        )?;
-
-        let claims = data.claims;
-
-        if let Some(expected) = expected_nonce {
-            let presented = claims["nonce"].as_str();
-            if presented != Some(expected) {
-                warn!("id_token nonce does not match the one sent to the provider");
-                return Err(CoreError::InvalidIdToken);
-            }
-        }
-
-        Ok(claims)
+    if !ID_TOKEN_ALGORITHMS.contains(&header.alg) {
+        warn!(
+            "id_token declares algorithm {:?}, which is not accepted",
+            header.alg
+        );
+        return Err(CoreError::InvalidIdToken);
     }
 
-    fn user_info_from_claims(claims: serde_json::Value) -> Result<BrokeredUserInfo, CoreError> {
-        Ok(BrokeredUserInfo {
-            subject: claims["sub"]
-                .as_str()
-                .ok_or(CoreError::InvalidIdToken)?
-                .to_string(),
-            email: claims["email"].as_str().map(|s| s.to_string()),
-            email_verified: claims["email_verified"].as_bool(),
-            name: claims["name"].as_str().map(|s| s.to_string()),
-            given_name: claims["given_name"].as_str().map(|s| s.to_string()),
-            family_name: claims["family_name"].as_str().map(|s| s.to_string()),
-            preferred_username: claims["preferred_username"].as_str().map(|s| s.to_string()),
-            picture: claims["picture"].as_str().map(|s| s.to_string()),
-        })
+    let jwk = match header.kid.as_deref() {
+        Some(kid) => jwk_set.find(kid),
+        None => jwk_set.keys.first(),
     }
+    .ok_or_else(|| {
+        warn!("no JWKS key matches the id_token header");
+        CoreError::InvalidIdToken
+    })?;
+
+    if let Some(key_alg) = jwk.common.key_algorithm
+        && key_alg.to_string() != format!("{:?}", header.alg)
+    {
+        warn!("id_token algorithm does not match the JWKS key it selected");
+        return Err(CoreError::InvalidIdToken);
+    }
+
+    let key = jsonwebtoken::DecodingKey::from_jwk(jwk).map_err(|e| {
+        warn!("JWKS key is unusable: {e}");
+        CoreError::InvalidIdToken
+    })?;
+
+    let mut validation = jsonwebtoken::Validation::new(header.alg);
+    validation.set_issuer(&[issuer]);
+    validation.set_audience(&[audience]);
+    validation.validate_exp = true;
+
+    let data =
+        jsonwebtoken::decode::<serde_json::Value>(id_token, &key, &validation).map_err(|e| {
+            warn!("id_token verification failed: {e}");
+            CoreError::InvalidIdToken
+        })?;
+
+    let claims = data.claims;
+
+    if let Some(expected) = expected_nonce {
+        let presented = claims["nonce"].as_str();
+        if presented != Some(expected) {
+            warn!("id_token nonce does not match the one sent to the provider");
+            return Err(CoreError::InvalidIdToken);
+        }
+    }
+
+    Ok(claims)
+}
+
+fn user_info_from_claims(claims: serde_json::Value) -> Result<BrokeredUserInfo, CoreError> {
+    Ok(BrokeredUserInfo {
+        subject: claims["sub"]
+            .as_str()
+            .ok_or(CoreError::InvalidIdToken)?
+            .to_string(),
+        email: claims["email"].as_str().map(|s| s.to_string()),
+        email_verified: claims["email_verified"].as_bool(),
+        name: claims["name"].as_str().map(|s| s.to_string()),
+        given_name: claims["given_name"].as_str().map(|s| s.to_string()),
+        family_name: claims["family_name"].as_str().map(|s| s.to_string()),
+        preferred_username: claims["preferred_username"].as_str().map(|s| s.to_string()),
+        picture: claims["picture"].as_str().map(|s| s.to_string()),
+    })
 }
 
 impl<RR, IR, BR, LR, CR, RUR, UR, ASR, OC> BrokerService
@@ -814,7 +824,7 @@ where
                 .verify_id_token(id_token, config, expected_nonce)
                 .await?;
 
-            return Self::user_info_from_claims(claims);
+            return user_info_from_claims(claims);
         }
 
         // Fall back to userinfo endpoint
@@ -834,6 +844,162 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+    use chrono::Duration;
+    use rsa::pkcs1::EncodeRsaPrivateKey;
+    use rsa::pkcs8::EncodePublicKey;
+    use rsa::traits::PublicKeyParts;
+    use rsa::{RsaPrivateKey, RsaPublicKey};
+
+    const ISSUER: &str = "https://idp.example.com";
+    const AUDIENCE: &str = "ferriskey-client";
+
+    struct IdpKey {
+        encoding: jsonwebtoken::EncodingKey,
+        jwks: serde_json::Value,
+    }
+
+    fn idp_key(kid: &str) -> IdpKey {
+        let mut rng = rand::thread_rng();
+        let private = RsaPrivateKey::new(&mut rng, 2048).expect("generate rsa key");
+        let public = RsaPublicKey::from(&private);
+
+        let pem = private
+            .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+            .expect("pem");
+        let encoding =
+            jsonwebtoken::EncodingKey::from_rsa_pem(pem.as_bytes()).expect("encoding key");
+
+        let _ = public.to_public_key_pem(rsa::pkcs8::LineEnding::LF);
+        let jwks = serde_json::json!({
+            "keys": [{
+                "kty": "RSA",
+                "use": "sig",
+                "kid": kid,
+                "alg": "RS256",
+                "n": B64.encode(public.n().to_bytes_be()),
+                "e": B64.encode(public.e().to_bytes_be()),
+            }]
+        });
+
+        IdpKey { encoding, jwks }
+    }
+
+    fn sign(key: &IdpKey, kid: &str, claims: serde_json::Value) -> String {
+        let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        header.kid = Some(kid.to_string());
+        jsonwebtoken::encode(&header, &claims, &key.encoding).expect("sign id_token")
+    }
+
+    fn claims(overrides: serde_json::Value) -> serde_json::Value {
+        let mut base = serde_json::json!({
+            "sub": "idp-user-1",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "exp": (Utc::now() + Duration::minutes(5)).timestamp(),
+            "iat": Utc::now().timestamp(),
+            "nonce": "the-nonce",
+        });
+
+        for (k, v) in overrides.as_object().expect("object").iter() {
+            base[k] = v.clone();
+        }
+
+        base
+    }
+
+    #[test]
+    fn a_well_formed_id_token_is_accepted() {
+        let key = idp_key("kid-1");
+        let token = sign(&key, "kid-1", claims(serde_json::json!({})));
+
+        let verified =
+            verify_id_token_against_jwks(&token, &key.jwks, ISSUER, AUDIENCE, Some("the-nonce"))
+                .expect("a token signed by the advertised key must verify");
+
+        assert_eq!(verified["sub"], "idp-user-1");
+    }
+
+    #[test]
+    fn a_token_signed_by_another_key_is_refused() {
+        let key = idp_key("kid-1");
+        let impostor = idp_key("kid-1");
+        let token = sign(&impostor, "kid-1", claims(serde_json::json!({})));
+
+        let result =
+            verify_id_token_against_jwks(&token, &key.jwks, ISSUER, AUDIENCE, Some("the-nonce"));
+
+        assert!(matches!(result, Err(CoreError::InvalidIdToken)));
+    }
+
+    #[test]
+    fn a_token_from_another_issuer_is_refused() {
+        let key = idp_key("kid-1");
+        let token = sign(
+            &key,
+            "kid-1",
+            claims(serde_json::json!({ "iss": "https://evil.example.com" })),
+        );
+
+        let result =
+            verify_id_token_against_jwks(&token, &key.jwks, ISSUER, AUDIENCE, Some("the-nonce"));
+
+        assert!(matches!(result, Err(CoreError::InvalidIdToken)));
+    }
+
+    #[test]
+    fn a_token_for_another_audience_is_refused() {
+        let key = idp_key("kid-1");
+        let token = sign(
+            &key,
+            "kid-1",
+            claims(serde_json::json!({ "aud": "someone-else" })),
+        );
+
+        let result =
+            verify_id_token_against_jwks(&token, &key.jwks, ISSUER, AUDIENCE, Some("the-nonce"));
+
+        assert!(matches!(result, Err(CoreError::InvalidIdToken)));
+    }
+
+    #[test]
+    fn an_expired_token_is_refused() {
+        let key = idp_key("kid-1");
+        let expired = (Utc::now() - Duration::hours(1)).timestamp();
+        let token = sign(&key, "kid-1", claims(serde_json::json!({ "exp": expired })));
+
+        let result =
+            verify_id_token_against_jwks(&token, &key.jwks, ISSUER, AUDIENCE, Some("the-nonce"));
+
+        assert!(matches!(result, Err(CoreError::InvalidIdToken)));
+    }
+
+    #[test]
+    fn a_replayed_nonce_is_refused() {
+        let key = idp_key("kid-1");
+        let token = sign(
+            &key,
+            "kid-1",
+            claims(serde_json::json!({ "nonce": "a-different-login" })),
+        );
+
+        let result =
+            verify_id_token_against_jwks(&token, &key.jwks, ISSUER, AUDIENCE, Some("the-nonce"));
+
+        assert!(matches!(result, Err(CoreError::InvalidIdToken)));
+    }
+
+    #[test]
+    fn a_token_naming_an_unknown_key_is_refused() {
+        let key = idp_key("kid-1");
+        let token = sign(&key, "kid-unknown", claims(serde_json::json!({})));
+
+        let result =
+            verify_id_token_against_jwks(&token, &key.jwks, ISSUER, AUDIENCE, Some("the-nonce"));
+
+        assert!(matches!(result, Err(CoreError::InvalidIdToken)));
+    }
 
     #[test]
     fn evaluate_redirect_uri_returns_not_found_when_allowed_list_is_empty() {

--- a/core/src/domain/abyss/identity_provider_services.rs
+++ b/core/src/domain/abyss/identity_provider_services.rs
@@ -453,10 +453,6 @@ where
             .find(|(link, _)| link.id == input.link_id)
             .ok_or(CoreError::NotFound)?;
 
-        self.identity_provider_link_repository
-            .delete(link.id)
-            .await?;
-
         self.security_event_repository
             .store_event(
                 SecurityEvent::new(
@@ -471,6 +467,10 @@ where
                     "identity_provider_id": link.identity_provider_id.as_uuid(),
                 })),
             )
+            .await?;
+
+        self.identity_provider_link_repository
+            .delete(link.id)
             .await?;
 
         Ok(())


### PR DESCRIPTION
## Context

Follow-up to #1245, which merged while this work was in flight. It carries the two review points that landed after the merge.

## ID-token verification is now tested

The review asked for fixture-based coverage of `verify_id_token`, correctly noting that a live upstream IdP is not required. My earlier answer — that the harness did not exist — was the wrong conclusion: the obstacle was that the verifier sat on a service with nine generic parameters, not that testing it needed a real provider.

So the I/O and the decision are now separated. `verify_id_token` fetches the JWKS; `verify_id_token_against_jwks` is a free function that takes the document and decides. The security-critical half is pure, and testable with nothing mocked.

Seven tests, one per way the check can matter:

| Test | Asserts |
|---|---|
| `a_well_formed_id_token_is_accepted` | the happy path verifies and yields `sub` |
| `a_token_signed_by_another_key_is_refused` | signature is actually checked against the advertised key |
| `a_token_from_another_issuer_is_refused` | `iss` |
| `a_token_for_another_audience_is_refused` | `aud` |
| `an_expired_token_is_refused` | `exp` |
| `a_replayed_nonce_is_refused` | the nonce is compared to the one sent upstream |
| `a_token_naming_an_unknown_key_is_refused` | an unmatched `kid` is not silently resolved to some other key |

Each test generates a real RSA key, publishes it as a JWKS and signs a token with `jsonwebtoken` — no network, no fixture files, no doubles.

The happy-path test is what keeps the other six honest: if JWKS parsing broke, every "refused" case would pass for the wrong reason and only that test would fail. I also mutation-checked it — disabling the nonce comparison turns `a_replayed_nonce_is_refused` red, so at least one negative test is verified to exercise what it claims.

## The audit event is recorded before the link is removed

The review asked for a transaction around delete-then-record. There is a defect there, but it is not the one a transaction fixes best: if `store_event` failed, the `?` returned an error to a caller whose link **had already been deleted**. The response lied, and a retry then reported `NotFound`.

The two operations are now ordered the other way. If the audit write fails, nothing is deleted and the error the caller receives is true. If the deletion fails afterwards, the audit carries an entry for a removal that did not happen — a false positive, which for a security log is the safer direction than a silent unaudited deletion.

A real transaction would need a SeaORM handle threaded through two repository ports, which is what the hexagonal boundary exists to prevent; all 34 `store_event` sites in the domain share this shape, so it deserves a repo-wide decision rather than a one-off here.

## Verification

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test -p ferriskey-core broker                                           # 17 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity token validation for supported algorithms, keys, signatures, issuers, audiences, expiration, and nonces.
  * Improved handling of invalid or unknown signing keys.
  * Ensured successful security events are recorded before identity-provider links are deleted.
* **Tests**
  * Added comprehensive coverage for valid and invalid token scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->