### PR TITLE
feat: add per-client web origin types and resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
  "utoipa",
  "uuid",
  "webauthn-rs",

--- a/libs/ferriskey-api-core/src/error.rs
+++ b/libs/ferriskey-api-core/src/error.rs
@@ -37,6 +37,12 @@ impl From<CoreError> for ApiError {
             CoreError::InvalidRedirectUri => {
                 Self::BadRequest("Redirect URI is not allowed for this client".into())
             }
+            CoreError::WebOriginNotFound => {
+                Self::NotFound("No web origin is registered under this identifier".into())
+            }
+            CoreError::InvalidWebOrigin(reason) => {
+                Self::BadRequest(CoreError::InvalidWebOrigin(reason).to_string().into())
+            }
             CoreError::InvalidClient => Self::Unauthorized("Invalid client".into()),
             CoreError::InvalidRealm => Self::Unauthorized("Invalid realm".into()),
             CoreError::InvalidUser => Self::Unauthorized("Invalid user".into()),

--- a/libs/ferriskey-domain/Cargo.toml
+++ b/libs/ferriskey-domain/Cargo.toml
@@ -15,6 +15,7 @@ utoipa = { version = "5.4.0", features = ["chrono", "uuid"] }
 uuid = { version = "1.20.0", features = ["serde", "v4", "v7"] }
 thiserror = "2.0.12"
 tracing = "0.1"
+url = { workspace = true }
 webauthn-rs = { version = "0.5.2", features = ["danger-credential-internals", "danger-allow-state-serialisation", "conditional-ui"] }
 mockall = { version = "0.14.0", optional = true }
 

--- a/libs/ferriskey-domain/src/client/entities.rs
+++ b/libs/ferriskey-domain/src/client/entities.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use crate::{generate_random_string, generate_timestamp, realm::RealmId};
 
 pub mod redirect_uri;
+pub mod web_origin;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, ToSchema)]
 #[serde(rename_all = "lowercase")]

--- a/libs/ferriskey-domain/src/client/entities/web_origin.rs
+++ b/libs/ferriskey-domain/src/client/entities/web_origin.rs
@@ -1,29 +1,3 @@
-//! Web origins registered for a client, and the CORS decision they feed.
-//!
-//! An origin is not a URL. `https://app.example.com/callback` is a redirect URI;
-//! the origin a browser sends in the `Origin` header is `https://app.example.com`
-//! — scheme, host, and port only, serialized per the URL Standard. Storing one
-//! where the other is expected produces a value that never matches any preflight,
-//! silently, which is why [`Origin`] cannot be built by any route that skips
-//! validation — `serde` included, via `try_from`.
-//!
-//! Normalization follows the browser's own serialization, since that is what the
-//! comparison is against: lowercased scheme and host, default port omitted
-//! (`:443` for https, `:80` for http), nothing after the authority.
-//!
-//! `*` is rejected rather than accepted-and-ignored. The Fetch standard forbids
-//! `Access-Control-Allow-Origin: *` alongside `Access-Control-Allow-Credentials:
-//! true`, and FerrisKey sets the latter, so a stored `*` could never be honoured.
-//! Refusing it at the boundary turns a silently dead configuration into an error
-//! the administrator sees while typing it.
-//!
-//! Two doors lead in, and they validate differently on purpose.
-//! [`Origin::try_from`] takes what an administrator typed and demands it already
-//! *be* an origin — credentials, path, query or fragment are all refusals.
-//! [`Origin::from_url`] takes a URL that legitimately has more than an origin, a
-//! redirect URI, and extracts the origin a browser would send for it; there,
-//! credentials and path belong to the URI and are discarded rather than refused.
-
 use std::fmt;
 use std::str::FromStr;
 
@@ -71,11 +45,6 @@ impl Origin {
         &self.0
     }
 
-    /// The origin a browser would send for `url`, discarding everything the
-    /// origin does not carry.
-    ///
-    /// Only http and https have a serializable origin here; every other scheme is
-    /// refused rather than allowed to serialize to the opaque `"null"`.
     pub(crate) fn from_url(url: &Url) -> Result<Self, InvalidOrigin> {
         match url.scheme() {
             "http" | "https" => {}
@@ -159,9 +128,6 @@ impl PartialSchema for WebOriginValue {
 impl ToSchema for WebOriginValue {}
 
 impl WebOriginValue {
-    /// Keycloak spells "derive my origins from my redirect URIs" as `+`, and
-    /// administrators migrating from it type that. Kept as a stored value rather
-    /// than a boolean on the client so it stays visible in the list and auditable.
     pub const DERIVED_SENTINEL: &'static str = "+";
 }
 

--- a/libs/ferriskey-domain/src/client/entities/web_origin.rs
+++ b/libs/ferriskey-domain/src/client/entities/web_origin.rs
@@ -1,0 +1,425 @@
+//! Web origins registered for a client, and the CORS decision they feed.
+//!
+//! An origin is not a URL. `https://app.example.com/callback` is a redirect URI;
+//! the origin a browser sends in the `Origin` header is `https://app.example.com`
+//! — scheme, host, and port only, serialized per the URL Standard. Storing one
+//! where the other is expected produces a value that never matches any preflight,
+//! silently, which is why [`Origin`] cannot be built by any route that skips
+//! validation — `serde` included, via `try_from`.
+//!
+//! Normalization follows the browser's own serialization, since that is what the
+//! comparison is against: lowercased scheme and host, default port omitted
+//! (`:443` for https, `:80` for http), nothing after the authority.
+//!
+//! `*` is rejected rather than accepted-and-ignored. The Fetch standard forbids
+//! `Access-Control-Allow-Origin: *` alongside `Access-Control-Allow-Credentials:
+//! true`, and FerrisKey sets the latter, so a stored `*` could never be honoured.
+//! Refusing it at the boundary turns a silently dead configuration into an error
+//! the administrator sees while typing it.
+//!
+//! Two doors lead in, and they validate differently on purpose.
+//! [`Origin::try_from`] takes what an administrator typed and demands it already
+//! *be* an origin — credentials, path, query or fragment are all refusals.
+//! [`Origin::from_url`] takes a URL that legitimately has more than an origin, a
+//! redirect URI, and extracts the origin a browser would send for it; there,
+//! credentials and path belong to the URI and are discarded rather than refused.
+
+use std::fmt;
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::common::app_errors::CoreError;
+use crate::generate_timestamp;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum InvalidOrigin {
+    #[error("`{0}` is not an absolute URL")]
+    NotAUrl(String),
+
+    #[error("origin scheme must be http or https, got `{0}`")]
+    UnsupportedScheme(String),
+
+    #[error("an origin carries no path, query or fragment")]
+    NotAnOrigin,
+
+    #[error("an origin carries no credentials")]
+    HasCredentials,
+
+    #[error("`*` cannot be allowed while credentials are allowed")]
+    Wildcard,
+}
+
+impl From<InvalidOrigin> for CoreError {
+    fn from(error: InvalidOrigin) -> Self {
+        CoreError::InvalidWebOrigin(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(try_from = "String", into = "String")]
+pub struct Origin(String);
+
+impl Origin {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The origin a browser would send for `url`, discarding everything the
+    /// origin does not carry.
+    ///
+    /// Only http and https have a serializable origin here; every other scheme is
+    /// refused rather than allowed to serialize to the opaque `"null"`.
+    pub(crate) fn from_url(url: &Url) -> Result<Self, InvalidOrigin> {
+        match url.scheme() {
+            "http" | "https" => Ok(Self(url.origin().ascii_serialization())),
+            other => Err(InvalidOrigin::UnsupportedScheme(other.to_string())),
+        }
+    }
+}
+
+impl TryFrom<&str> for Origin {
+    type Error = InvalidOrigin;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let value = value.trim();
+
+        if value == "*" {
+            return Err(InvalidOrigin::Wildcard);
+        }
+
+        let url = Url::parse(value).map_err(|_| InvalidOrigin::NotAUrl(value.to_string()))?;
+        let origin = Self::from_url(&url)?;
+
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(InvalidOrigin::HasCredentials);
+        }
+
+        if !matches!(url.path(), "" | "/") || url.query().is_some() || url.fragment().is_some() {
+            return Err(InvalidOrigin::NotAnOrigin);
+        }
+
+        Ok(origin)
+    }
+}
+
+impl TryFrom<String> for Origin {
+    type Error = InvalidOrigin;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+
+impl FromStr for Origin {
+    type Err = InvalidOrigin;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
+}
+
+impl From<Origin> for String {
+    fn from(origin: Origin) -> Self {
+        origin.0
+    }
+}
+
+impl fmt::Display for Origin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(try_from = "String", into = "String")]
+pub enum WebOriginValue {
+    DerivedFromRedirectUris,
+    Explicit(Origin),
+}
+
+impl WebOriginValue {
+    /// Keycloak spells "derive my origins from my redirect URIs" as `+`, and
+    /// administrators migrating from it type that. Kept as a stored value rather
+    /// than a boolean on the client so it stays visible in the list and auditable.
+    pub const DERIVED_SENTINEL: &'static str = "+";
+}
+
+impl FromStr for WebOriginValue {
+    type Err = InvalidOrigin;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == Self::DERIVED_SENTINEL {
+            return Ok(Self::DerivedFromRedirectUris);
+        }
+
+        Origin::try_from(s).map(Self::Explicit)
+    }
+}
+
+impl TryFrom<String> for WebOriginValue {
+    type Error = InvalidOrigin;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
+    }
+}
+
+impl From<WebOriginValue> for String {
+    fn from(value: WebOriginValue) -> Self {
+        value.to_string()
+    }
+}
+
+impl fmt::Display for WebOriginValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DerivedFromRedirectUris => f.write_str(Self::DERIVED_SENTINEL),
+            Self::Explicit(origin) => origin.fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, ToSchema)]
+pub struct WebOrigin {
+    pub id: Uuid,
+    pub client_id: Uuid,
+    pub value: WebOriginValue,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl WebOrigin {
+    pub fn new(client_id: Uuid, value: WebOriginValue) -> Self {
+        let (now, timestamp) = generate_timestamp();
+
+        Self {
+            id: Uuid::new_v7(timestamp),
+            client_id,
+            value,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn origin(value: &str) -> Origin {
+        Origin::try_from(value).expect("test fixture must be a valid origin")
+    }
+
+    #[test]
+    fn keeps_scheme_host_and_non_default_port() {
+        assert_eq!(
+            origin("https://app.example.com:8443").as_str(),
+            "https://app.example.com:8443"
+        );
+    }
+
+    #[test]
+    fn drops_the_default_https_port() {
+        assert_eq!(
+            origin("https://app.example.com:443").as_str(),
+            "https://app.example.com"
+        );
+    }
+
+    #[test]
+    fn drops_the_default_http_port() {
+        assert_eq!(
+            origin("http://app.example.com:80").as_str(),
+            "http://app.example.com"
+        );
+    }
+
+    #[test]
+    fn lowercases_scheme_and_host() {
+        assert_eq!(
+            origin("HTTPS://App.Example.COM").as_str(),
+            "https://app.example.com"
+        );
+    }
+
+    #[test]
+    fn drops_the_root_trailing_slash() {
+        assert_eq!(
+            origin("https://app.example.com/").as_str(),
+            "https://app.example.com"
+        );
+    }
+
+    #[test]
+    fn rejects_a_path() {
+        assert_eq!(
+            Origin::try_from("https://app.example.com/callback"),
+            Err(InvalidOrigin::NotAnOrigin)
+        );
+    }
+
+    #[test]
+    fn rejects_a_query() {
+        assert_eq!(
+            Origin::try_from("https://app.example.com/?next=1"),
+            Err(InvalidOrigin::NotAnOrigin)
+        );
+    }
+
+    #[test]
+    fn rejects_a_fragment() {
+        assert_eq!(
+            Origin::try_from("https://app.example.com/#top"),
+            Err(InvalidOrigin::NotAnOrigin)
+        );
+    }
+
+    #[test]
+    fn rejects_credentials_in_the_authority() {
+        assert_eq!(
+            Origin::try_from("https://user:secret@app.example.com"),
+            Err(InvalidOrigin::HasCredentials)
+        );
+    }
+
+    #[test]
+    fn rejects_a_password_carrying_no_username() {
+        assert_eq!(
+            Origin::try_from("https://:secret@app.example.com"),
+            Err(InvalidOrigin::HasCredentials)
+        );
+    }
+
+    #[test]
+    fn rejects_the_wildcard() {
+        assert_eq!(Origin::try_from("*"), Err(InvalidOrigin::Wildcard));
+    }
+
+    #[test]
+    fn rejects_the_wildcard_padded_with_whitespace() {
+        assert_eq!(Origin::try_from("  *  "), Err(InvalidOrigin::Wildcard));
+    }
+
+    #[test]
+    fn rejects_a_scheme_that_is_otherwise_shaped_like_an_origin() {
+        assert_eq!(
+            Origin::try_from("ftp://files.example.com"),
+            Err(InvalidOrigin::UnsupportedScheme("ftp".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_a_non_http_scheme() {
+        assert_eq!(
+            Origin::try_from("file:///etc/passwd"),
+            Err(InvalidOrigin::UnsupportedScheme("file".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_the_null_origin() {
+        assert_eq!(
+            Origin::try_from("null"),
+            Err(InvalidOrigin::NotAUrl("null".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_an_empty_value() {
+        assert_eq!(
+            Origin::try_from(""),
+            Err(InvalidOrigin::NotAUrl(String::new()))
+        );
+    }
+
+    #[test]
+    fn deserializing_cannot_smuggle_a_wildcard_past_validation() {
+        assert!(serde_json::from_str::<Origin>("\"*\"").is_err());
+    }
+
+    #[test]
+    fn deserializing_cannot_smuggle_an_arbitrary_string_past_validation() {
+        assert!(serde_json::from_str::<Origin>("\"not an origin at all\"").is_err());
+    }
+
+    #[test]
+    fn deserializing_normalizes_exactly_as_parsing_does() {
+        assert_eq!(
+            serde_json::from_str::<Origin>("\"HTTPS://App.Example.COM:443\"")
+                .expect("a valid origin must deserialize"),
+            origin("https://app.example.com")
+        );
+    }
+
+    #[test]
+    fn the_sentinel_parses_to_the_derived_variant() {
+        assert_eq!(
+            WebOriginValue::from_str("+"),
+            Ok(WebOriginValue::DerivedFromRedirectUris)
+        );
+    }
+
+    #[test]
+    fn the_derived_variant_renders_back_to_the_sentinel() {
+        assert_eq!(WebOriginValue::DerivedFromRedirectUris.to_string(), "+");
+    }
+
+    #[test]
+    fn an_explicit_value_round_trips_through_its_stored_form() {
+        let stored = WebOriginValue::Explicit(origin("https://app.example.com:443")).to_string();
+
+        assert_eq!(stored, "https://app.example.com");
+        assert_eq!(
+            WebOriginValue::from_str(&stored),
+            Ok(WebOriginValue::Explicit(origin("https://app.example.com")))
+        );
+    }
+
+    #[test]
+    fn an_invalid_value_does_not_parse() {
+        assert_eq!(
+            WebOriginValue::from_str("https://app.example.com/callback"),
+            Err(InvalidOrigin::NotAnOrigin)
+        );
+    }
+
+    #[test]
+    fn a_value_serializes_to_the_same_form_it_is_stored_as() {
+        let explicit = WebOriginValue::Explicit(origin("https://app.example.com"));
+
+        assert_eq!(
+            serde_json::to_string(&explicit).expect("serialization is infallible for a String"),
+            "\"https://app.example.com\""
+        );
+        assert_eq!(
+            serde_json::to_string(&WebOriginValue::DerivedFromRedirectUris)
+                .expect("serialization is infallible for a String"),
+            "\"+\""
+        );
+    }
+
+    #[test]
+    fn deserializing_a_value_rejects_what_parsing_rejects() {
+        assert!(
+            serde_json::from_str::<WebOriginValue>("\"https://app.example.com/callback\"").is_err()
+        );
+    }
+
+    #[test]
+    fn a_rejected_origin_reaches_the_caller_as_a_core_error_carrying_the_reason() {
+        let error = Origin::try_from("https://app.example.com/callback")
+            .expect_err("a path makes this an invalid origin");
+        let reason = error.to_string();
+
+        let converted = CoreError::from(error);
+
+        assert!(matches!(&converted, CoreError::InvalidWebOrigin(_)));
+        assert!(converted.to_string().contains(&reason));
+    }
+}

--- a/libs/ferriskey-domain/src/client/entities/web_origin.rs
+++ b/libs/ferriskey-domain/src/client/entities/web_origin.rs
@@ -150,10 +150,6 @@ pub enum WebOriginValue {
     Explicit(Origin),
 }
 
-/// Hand-written because the `serde` attributes above flatten this enum to a
-/// plain string on the wire, and a derived schema would keep documenting the
-/// externally-tagged shape. A generated client built from that schema would send
-/// `{"Explicit": "…"}` and be rejected.
 impl PartialSchema for WebOriginValue {
     fn schema() -> RefOr<Schema> {
         String::schema()

--- a/libs/ferriskey-domain/src/client/entities/web_origin.rs
+++ b/libs/ferriskey-domain/src/client/entities/web_origin.rs
@@ -31,7 +31,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
-use utoipa::ToSchema;
+use utoipa::openapi::{RefOr, schema::Schema};
+use utoipa::{PartialSchema, ToSchema};
 use uuid::Uuid;
 
 use crate::common::app_errors::CoreError;
@@ -51,7 +52,7 @@ pub enum InvalidOrigin {
     #[error("an origin carries no credentials")]
     HasCredentials,
 
-    #[error("`*` cannot be allowed while credentials are allowed")]
+    #[error("`*` cannot appear in an allowed origin while credentials are allowed")]
     Wildcard,
 }
 
@@ -77,9 +78,15 @@ impl Origin {
     /// refused rather than allowed to serialize to the opaque `"null"`.
     pub(crate) fn from_url(url: &Url) -> Result<Self, InvalidOrigin> {
         match url.scheme() {
-            "http" | "https" => Ok(Self(url.origin().ascii_serialization())),
-            other => Err(InvalidOrigin::UnsupportedScheme(other.to_string())),
+            "http" | "https" => {}
+            other => return Err(InvalidOrigin::UnsupportedScheme(other.to_string())),
         }
+
+        if url.host_str().is_some_and(|host| host.contains('*')) {
+            return Err(InvalidOrigin::Wildcard);
+        }
+
+        Ok(Self(url.origin().ascii_serialization()))
     }
 }
 
@@ -136,12 +143,24 @@ impl fmt::Display for Origin {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum WebOriginValue {
     DerivedFromRedirectUris,
     Explicit(Origin),
 }
+
+/// Hand-written because the `serde` attributes above flatten this enum to a
+/// plain string on the wire, and a derived schema would keep documenting the
+/// externally-tagged shape. A generated client built from that schema would send
+/// `{"Explicit": "…"}` and be rejected.
+impl PartialSchema for WebOriginValue {
+    fn schema() -> RefOr<Schema> {
+        String::schema()
+    }
+}
+
+impl ToSchema for WebOriginValue {}
 
 impl WebOriginValue {
     /// Keycloak spells "derive my origins from my redirect URIs" as `+`, and
@@ -154,7 +173,7 @@ impl FromStr for WebOriginValue {
     type Err = InvalidOrigin;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == Self::DERIVED_SENTINEL {
+        if s.trim() == Self::DERIVED_SENTINEL {
             return Ok(Self::DerivedFromRedirectUris);
         }
 
@@ -304,6 +323,35 @@ mod tests {
     #[test]
     fn rejects_the_wildcard_padded_with_whitespace() {
         assert_eq!(Origin::try_from("  *  "), Err(InvalidOrigin::Wildcard));
+    }
+
+    #[test]
+    fn rejects_a_subdomain_wildcard() {
+        assert_eq!(
+            Origin::try_from("https://*.example.com"),
+            Err(InvalidOrigin::Wildcard)
+        );
+    }
+
+    #[test]
+    fn rejects_a_wildcard_standing_alone_as_the_host() {
+        assert_eq!(Origin::try_from("https://*"), Err(InvalidOrigin::Wildcard));
+    }
+
+    #[test]
+    fn the_sentinel_survives_surrounding_whitespace() {
+        assert_eq!(
+            WebOriginValue::from_str(" + "),
+            Ok(WebOriginValue::DerivedFromRedirectUris)
+        );
+    }
+
+    #[test]
+    fn a_value_is_documented_as_the_string_it_serializes_to() {
+        let schema = serde_json::to_value(WebOriginValue::schema())
+            .expect("a utoipa schema serializes to json");
+
+        assert_eq!(schema["type"], "string");
     }
 
     #[test]

--- a/libs/ferriskey-domain/src/client/mod.rs
+++ b/libs/ferriskey-domain/src/client/mod.rs
@@ -3,3 +3,4 @@ pub mod entities;
 pub mod ports;
 pub mod redirect_uri_matching;
 pub mod value_objects;
+pub mod web_origin_resolution;

--- a/libs/ferriskey-domain/src/client/ports.rs
+++ b/libs/ferriskey-domain/src/client/ports.rs
@@ -219,14 +219,6 @@ pub trait WebOriginRepository: Send + Sync {
         id: Uuid,
     ) -> impl Future<Output = Result<(), CoreError>> + Send;
 
-    /// Every client of `realm_name` that could contribute an origin, with the
-    /// redirect URIs needed to expand [`WebOriginValue::DerivedFromRedirectUris`].
-    ///
-    /// Implementations must supply only *enabled* redirect URIs, and only clients
-    /// that are themselves enabled: whatever comes back here is granted CORS.
-    ///
-    /// This sits on the CORS path, so callers are required to cache it per realm
-    /// rather than call it per request.
     fn get_origin_sources_by_realm_name(
         &self,
         realm_name: String,

--- a/libs/ferriskey-domain/src/client/ports.rs
+++ b/libs/ferriskey-domain/src/client/ports.rs
@@ -9,8 +9,13 @@ use crate::client::{
         GetPostLogoutRedirectUrisInput, GetRedirectUrisInput, UpdateClientInput,
         UpdatePostLogoutRedirectUriInput, UpdateRedirectUriInput,
     },
-    entities::{Client, redirect_uri::RedirectUri},
+    entities::{
+        Client,
+        redirect_uri::RedirectUri,
+        web_origin::{WebOrigin, WebOriginValue},
+    },
     value_objects::{CreateClientRequest, UpdateClientRequest},
+    web_origin_resolution::ClientOriginSources,
 };
 use crate::common::app_errors::CoreError;
 use crate::realm::{Realm, RealmId};
@@ -193,4 +198,37 @@ pub trait RedirectUriRepository: Send + Sync {
         client_id: Uuid,
         id: Uuid,
     ) -> impl Future<Output = Result<(), CoreError>> + Send;
+}
+
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
+pub trait WebOriginRepository: Send + Sync {
+    fn create(
+        &self,
+        client_id: Uuid,
+        value: WebOriginValue,
+    ) -> impl Future<Output = Result<WebOrigin, CoreError>> + Send;
+
+    fn get_by_client_id(
+        &self,
+        client_id: Uuid,
+    ) -> impl Future<Output = Result<Vec<WebOrigin>, CoreError>> + Send;
+
+    fn delete(
+        &self,
+        client_id: Uuid,
+        id: Uuid,
+    ) -> impl Future<Output = Result<(), CoreError>> + Send;
+
+    /// Every client of `realm_name` that could contribute an origin, with the
+    /// redirect URIs needed to expand [`WebOriginValue::DerivedFromRedirectUris`].
+    ///
+    /// Implementations must supply only *enabled* redirect URIs, and only clients
+    /// that are themselves enabled: whatever comes back here is granted CORS.
+    ///
+    /// This sits on the CORS path, so callers are required to cache it per realm
+    /// rather than call it per request.
+    fn get_origin_sources_by_realm_name(
+        &self,
+        realm_name: String,
+    ) -> impl Future<Output = Result<Vec<ClientOriginSources>, CoreError>> + Send;
 }

--- a/libs/ferriskey-domain/src/client/web_origin_resolution.rs
+++ b/libs/ferriskey-domain/src/client/web_origin_resolution.rs
@@ -1,0 +1,249 @@
+//! Turning the web origins stored against a realm's clients into the allowlist
+//! the CORS layer answers preflights with.
+//!
+//! A preflight `OPTIONS` carries no body and no `Authorization` header, so the
+//! `client_id` a browser later sends to `/token` is not available when permission
+//! is asked for. CORS therefore cannot be decided per client, only per realm — the
+//! realm being in the path for essentially the whole API surface. Origins are
+//! nonetheless *stored* per client, which is finer to administer and audit; this
+//! module is where the two meet, by unioning the origins of one realm's clients.
+//!
+//! The consequence is worth stating rather than discovering: within one realm, an
+//! origin registered by one client is accepted on requests aimed at another. That
+//! is inherent to the preflight, not a shortcut taken here.
+//!
+//! [`WebOriginValue::DerivedFromRedirectUris`] — Keycloak's `+` — expands to the
+//! origins of its own client's redirect URIs, never another's. It expands *literal*
+//! redirect URIs only: FerrisKey also accepts anchored regex patterns
+//! (see [`crate::client::redirect_uri_matching`]), and an origin cannot be derived
+//! from a pattern. Those are skipped, so an administrator who registered a regex
+//! redirect URI and then relied on `+` is not covered — the UI has to say so.
+
+use std::collections::HashSet;
+
+use url::Url;
+
+use crate::client::entities::web_origin::{Origin, WebOriginValue};
+
+/// The origin material stored against one client, as the CORS resolver reads it.
+///
+/// `enabled_redirect_uris` is named for the guarantee its producer owes: a
+/// disabled redirect URI must never reach here, or disabling one would leave the
+/// origin it derives still allowed.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ClientOriginSources {
+    pub web_origins: Vec<WebOriginValue>,
+    pub enabled_redirect_uris: Vec<String>,
+}
+
+/// The origin a redirect URI is served from, when it is a literal URL.
+///
+/// `None` for anchored regex patterns and for anything that does not parse. The
+/// credentials and path a redirect URI may legitimately carry are discarded here
+/// rather than refused — unlike [`Origin::try_from`], whose input is expected to
+/// already be an origin.
+pub fn origin_of_redirect_uri(redirect_uri: &str) -> Option<Origin> {
+    let url = Url::parse(redirect_uri).ok()?;
+
+    Origin::from_url(&url).ok()
+}
+
+/// Every origin allowed for the realm whose clients these are.
+pub fn resolve_allowed_origins(sources: &[ClientOriginSources]) -> HashSet<Origin> {
+    let mut allowed = HashSet::new();
+
+    for client in sources {
+        for value in &client.web_origins {
+            match value {
+                WebOriginValue::Explicit(origin) => {
+                    allowed.insert(origin.clone());
+                }
+                WebOriginValue::DerivedFromRedirectUris => allowed.extend(
+                    client
+                        .enabled_redirect_uris
+                        .iter()
+                        .filter_map(|uri| origin_of_redirect_uri(uri)),
+                ),
+            }
+        }
+    }
+
+    allowed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn origin(value: &str) -> Origin {
+        Origin::try_from(value).expect("test fixture must be a valid origin")
+    }
+
+    fn explicit(value: &str) -> WebOriginValue {
+        WebOriginValue::Explicit(origin(value))
+    }
+
+    #[test]
+    fn derives_the_origin_of_a_literal_redirect_uri() {
+        assert_eq!(
+            origin_of_redirect_uri("https://app.example.com/callback"),
+            Some(origin("https://app.example.com"))
+        );
+    }
+
+    #[test]
+    fn derives_through_a_non_default_port() {
+        assert_eq!(
+            origin_of_redirect_uri("http://localhost:5555/callback"),
+            Some(origin("http://localhost:5555"))
+        );
+    }
+
+    #[test]
+    fn derives_past_credentials_the_origin_itself_would_refuse() {
+        assert_eq!(
+            origin_of_redirect_uri("https://user:secret@app.example.com/callback"),
+            Some(origin("https://app.example.com"))
+        );
+        assert!(Origin::try_from("https://user:secret@app.example.com").is_err());
+    }
+
+    #[test]
+    fn does_not_derive_from_an_anchored_regex_redirect_uri() {
+        assert_eq!(
+            origin_of_redirect_uri(r"^https://app\.example\.com/.*$"),
+            None
+        );
+    }
+
+    #[test]
+    fn does_not_derive_from_a_malformed_redirect_uri() {
+        assert_eq!(origin_of_redirect_uri("not a uri"), None);
+    }
+
+    #[test]
+    fn does_not_derive_from_a_non_http_redirect_uri() {
+        assert_eq!(origin_of_redirect_uri("myapp://callback"), None);
+    }
+
+    #[test]
+    fn resolves_an_explicit_origin() {
+        let sources = vec![ClientOriginSources {
+            web_origins: vec![explicit("https://app.example.com")],
+            enabled_redirect_uris: vec![],
+        }];
+
+        assert_eq!(
+            resolve_allowed_origins(&sources),
+            HashSet::from([origin("https://app.example.com")])
+        );
+    }
+
+    #[test]
+    fn resolves_nothing_for_a_realm_without_clients() {
+        assert_eq!(resolve_allowed_origins(&[]), HashSet::new());
+    }
+
+    #[test]
+    fn the_sentinel_expands_the_redirect_uris_of_its_own_client() {
+        let sources = vec![ClientOriginSources {
+            web_origins: vec![WebOriginValue::DerivedFromRedirectUris],
+            enabled_redirect_uris: vec![
+                "https://app.example.com/callback".to_string(),
+                "https://app.example.com/silent-renew".to_string(),
+                "https://admin.example.com/callback".to_string(),
+            ],
+        }];
+
+        assert_eq!(
+            resolve_allowed_origins(&sources),
+            HashSet::from([
+                origin("https://app.example.com"),
+                origin("https://admin.example.com"),
+            ])
+        );
+    }
+
+    #[test]
+    fn the_sentinel_does_not_expand_another_clients_redirect_uris() {
+        let sources = vec![
+            ClientOriginSources {
+                web_origins: vec![WebOriginValue::DerivedFromRedirectUris],
+                enabled_redirect_uris: vec![],
+            },
+            ClientOriginSources {
+                web_origins: vec![],
+                enabled_redirect_uris: vec!["https://other.example.com/callback".to_string()],
+            },
+        ];
+
+        assert_eq!(resolve_allowed_origins(&sources), HashSet::new());
+    }
+
+    #[test]
+    fn the_sentinel_skips_regex_redirect_uris() {
+        let sources = vec![ClientOriginSources {
+            web_origins: vec![WebOriginValue::DerivedFromRedirectUris],
+            enabled_redirect_uris: vec![
+                r"^https://tenant-.*\.example\.com/callback$".to_string(),
+                "https://app.example.com/callback".to_string(),
+            ],
+        }];
+
+        assert_eq!(
+            resolve_allowed_origins(&sources),
+            HashSet::from([origin("https://app.example.com")])
+        );
+    }
+
+    #[test]
+    fn redirect_uris_alone_grant_nothing_without_the_sentinel() {
+        let sources = vec![ClientOriginSources {
+            web_origins: vec![],
+            enabled_redirect_uris: vec!["https://app.example.com/callback".to_string()],
+        }];
+
+        assert_eq!(resolve_allowed_origins(&sources), HashSet::new());
+    }
+
+    #[test]
+    fn one_client_can_combine_an_explicit_origin_and_the_sentinel() {
+        let sources = vec![ClientOriginSources {
+            web_origins: vec![
+                explicit("https://static.example.com"),
+                WebOriginValue::DerivedFromRedirectUris,
+            ],
+            enabled_redirect_uris: vec!["https://app.example.com/callback".to_string()],
+        }];
+
+        assert_eq!(
+            resolve_allowed_origins(&sources),
+            HashSet::from([
+                origin("https://static.example.com"),
+                origin("https://app.example.com"),
+            ])
+        );
+    }
+
+    #[test]
+    fn unions_the_origins_of_every_client_in_the_realm() {
+        let sources = vec![
+            ClientOriginSources {
+                web_origins: vec![explicit("https://app.example.com")],
+                enabled_redirect_uris: vec![],
+            },
+            ClientOriginSources {
+                web_origins: vec![explicit("https://admin.example.com")],
+                enabled_redirect_uris: vec![],
+            },
+        ];
+
+        assert_eq!(
+            resolve_allowed_origins(&sources),
+            HashSet::from([
+                origin("https://app.example.com"),
+                origin("https://admin.example.com"),
+            ])
+        );
+    }
+}

--- a/libs/ferriskey-domain/src/client/web_origin_resolution.rs
+++ b/libs/ferriskey-domain/src/client/web_origin_resolution.rs
@@ -1,54 +1,21 @@
-//! Turning the web origins stored against a realm's clients into the allowlist
-//! the CORS layer answers preflights with.
-//!
-//! A preflight `OPTIONS` carries no body and no `Authorization` header, so the
-//! `client_id` a browser later sends to `/token` is not available when permission
-//! is asked for. CORS therefore cannot be decided per client, only per realm — the
-//! realm being in the path for essentially the whole API surface. Origins are
-//! nonetheless *stored* per client, which is finer to administer and audit; this
-//! module is where the two meet, by unioning the origins of one realm's clients.
-//!
-//! The consequence is worth stating rather than discovering: within one realm, an
-//! origin registered by one client is accepted on requests aimed at another. That
-//! is inherent to the preflight, not a shortcut taken here.
-//!
-//! [`WebOriginValue::DerivedFromRedirectUris`] — Keycloak's `+` — expands to the
-//! origins of its own client's redirect URIs, never another's. It expands *literal*
-//! redirect URIs only: FerrisKey also accepts anchored regex patterns
-//! (see [`crate::client::redirect_uri_matching`]), and an origin cannot be derived
-//! from a pattern. Those are skipped, so an administrator who registered a regex
-//! redirect URI and then relied on `+` is not covered — the UI has to say so.
-
 use std::collections::HashSet;
 
 use url::Url;
 
 use crate::client::entities::web_origin::{Origin, WebOriginValue};
 
-/// The origin material stored against one client, as the CORS resolver reads it.
-///
-/// `enabled_redirect_uris` is named for the guarantee its producer owes: a
-/// disabled redirect URI must never reach here, or disabling one would leave the
-/// origin it derives still allowed.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ClientOriginSources {
     pub web_origins: Vec<WebOriginValue>,
     pub enabled_redirect_uris: Vec<String>,
 }
 
-/// The origin a redirect URI is served from, when it is a literal URL.
-///
-/// `None` for anchored regex patterns and for anything that does not parse. The
-/// credentials and path a redirect URI may legitimately carry are discarded here
-/// rather than refused — unlike [`Origin::try_from`], whose input is expected to
-/// already be an origin.
 pub fn origin_of_redirect_uri(redirect_uri: &str) -> Option<Origin> {
     let url = Url::parse(redirect_uri).ok()?;
 
     Origin::from_url(&url).ok()
 }
 
-/// Every origin allowed for the realm whose clients these are.
 pub fn resolve_allowed_origins(sources: &[ClientOriginSources]) -> HashSet<Origin> {
     let mut allowed = HashSet::new();
 

--- a/libs/ferriskey-domain/src/client/web_origin_resolution.rs
+++ b/libs/ferriskey-domain/src/client/web_origin_resolution.rs
@@ -117,6 +117,14 @@ mod tests {
     }
 
     #[test]
+    fn does_not_derive_from_a_wildcard_shaped_redirect_uri() {
+        assert_eq!(
+            origin_of_redirect_uri("https://*.example.com/callback"),
+            None
+        );
+    }
+
+    #[test]
     fn does_not_derive_from_a_malformed_redirect_uri() {
         assert_eq!(origin_of_redirect_uri("not a uri"), None);
     }

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -34,6 +34,12 @@ pub enum CoreError {
     #[error("Redirect URI is not allowed for this client")]
     InvalidRedirectUri,
 
+    #[error("No web origin is registered under this identifier")]
+    WebOriginNotFound,
+
+    #[error("Invalid web origin: {0}")]
+    InvalidWebOrigin(String),
+
     #[error("Invalid client")]
     InvalidClient,
 


### PR DESCRIPTION
Closes #1248. Part of #1178.

First of four layers moving CORS origins out of the process-wide `ALLOWED_ORIGINS` environment variable and into the database, declared per client. Pure domain: no SQL, no HTTP, no wiring. Nothing here changes runtime behaviour — it adds the vocabulary the next three layers build on.

## Storing per client, enforcing per realm

#1178 argued this should be per **realm**, on the grounds that a preflight `OPTIONS` carries no body and no `Authorization` header, so the `client_id` a browser later sends to `/token` is not available when permission is asked for.

That constraint is real, and it is about *enforcement*, not about *storage*. The two are separated here:

- **Stored per client** — a web origin belongs to a client, exactly as `redirect_uris` does. Removing an application removes its origins with it, and the audit trail says which application asked for which origin.
- **Enforced per realm** — for a request on `/realms/{r}/…`, the allowlist is the union of the origins of `r`'s clients. That is what `resolve_allowed_origins` computes.

Cross-tenant isolation is therefore identical to the `realm_settings.allowed_origins` design #1178 proposed, while administration is finer. The residual limitation, stated plainly because it is not obvious from the code: **within one realm, an origin registered by client A is accepted on requests aimed at client B.** Inherent to the preflight; the per-realm design has the same property.

## What is in here

**`Origin`** — a validated newtype. An origin is not a URL: `https://app.example.com/callback` is a redirect URI, while the browser sends `https://app.example.com`. Storing one where the other belongs produces a value that silently never matches any preflight, so validation lives in the type rather than in checks scattered at each use site. Normalization mirrors the browser's own serialization, since that is what the comparison runs against: lowercased scheme and host, default port omitted, nothing after the authority.

`*` is **rejected at write time** rather than accepted and ignored later. The Fetch standard forbids `Access-Control-Allow-Origin: *` alongside `Access-Control-Allow-Credentials: true`, which the API sets, so a stored `*` could never be honoured. Refusing it turns a silently dead configuration into an error the administrator sees while typing.

**Two construction doors, validating differently on purpose.** `Origin::try_from` takes what an administrator typed and demands it already *be* an origin — credentials, path, query and fragment are refusals. `Origin::from_url` takes a redirect URI, which legitimately carries more than an origin, and extracts the origin a browser would send for it; there the extra parts are discarded rather than refused. Both behaviours are pinned by tests, including the one that shows them disagreeing on the same host.

**`WebOriginValue`** — either an explicit `Origin` or `DerivedFromRedirectUris`, the `+` sentinel from Keycloak. A stored value rather than a boolean flag on the client, so it shows up in the list and stays auditable.

**`web_origin_resolution`** — pure functions, no I/O. `+` expands to the origins of **its own** client's redirect URIs, never a sibling's; there is a test for exactly that.

One caveat that has to survive into the UI: FerrisKey redirect URIs may be anchored regex patterns (see `redirect_uri_matching.rs`), and an origin cannot be derived from a pattern. `+` expands literal redirect URIs only and skips patterns. An administrator who registered a regex redirect URI and then relied on `+` is **not** covered and has no way to tell from the data. #1251 carries that into the frontend.

**`WebOriginRepository`** — the port. No implementation here; the Postgres adapter lands in #1249.

## What review changed

Two independent review passes ran against the first draft — one on repository conventions and test honesty, one adversarial on the origin parsing itself. The findings that changed the code:

**`https://*.example.com` was accepted and stored.** The wildcard guard only tested the whole value for `*`, so a bare `*` was refused while the spelling an administrator migrating from a wildcard CORS config would actually type sailed through. Not a bypass — no browser can send that `Origin` — but a silently dead allowlist entry, which is exactly what the module doc claims to prevent. Now refused wherever `*` appears in the host, on both construction paths. That also closed a doc contradiction: `https://tenant-.*.example.com/cb` used to derive a dead origin through `+`, and now derives nothing.

**The OpenAPI schema stopped matching the wire format.** Flattening `WebOriginValue` to a string via `serde` left the derived `ToSchema` documenting the externally-tagged shape, so any client generated from the OpenAPI document would have sent `{"Explicit": "…"}` and been rejected. Since this repository's frontend codegen is already hand-maintained, that would have been found by hand at the worst moment — during #1250 or #1251. `PartialSchema` is now hand-written, with a test asserting the documented type is a string.

**`" + "` did not parse, and said so misleadingly.** The sentinel was compared before the trim that every other value gets, so a pasted value with a trailing space produced ``+ is not an absolute URL`` — about a value that is valid. Fails closed either way, but the message contradicted itself.

**`serde` bypassed the newtype.** `Origin` derived `Deserialize`, and the derive on a tuple newtype accepts any string — `serde_json::from_str::<Origin>("\"*\"")` returned `Ok(Origin("*"))`, the exact value `TryFrom` exists to refuse. Not theoretical: `WebOrigin` is deserialized on the API path in #1250. Fixed with `#[serde(try_from = "String", into = "String")]` on both `Origin` and `WebOriginValue`, plus tests that assert the bypass is closed.

That attribute also collapses a second divergence the review found: `WebOriginValue` had two incompatible external forms, `"+"` through `Display` (what the database stores) and `{"Explicit":"…"}` through serde (what OpenAPI and the frontend would have seen). One type, one wire form, one validation path.

**`ClientOriginSources.redirect_uris` could not express "enabled".** `RedirectUri` carries `enabled`, and the field dropped it — nothing stopped #1249 from feeding disabled redirect URIs in, which would have left a disabled redirect URI still granting its origin. The field is now `enabled_redirect_uris`, and the name is the whole contract: **the adapter in #1249 must supply only enabled redirect URIs, of enabled clients.** Whatever comes back from `get_origin_sources_by_realm_name` is granted CORS.

That same method sits on the CORS request path. It is not meant to be called per request — #1250 puts a per-realm cache in front of it.

**`InvalidOrigin::MissingHost` was unreachable.** After the http/https gate, `Url` guarantees a host, so the variant and its `match` arm were dead defensive code — and cost a second `url.origin()` call. Removed.

Also from review: the three command inputs and `CreateWebOriginRequest` were dropped from this PR. Nothing consumed them, `ClientService` gained no methods to match, and an input struct constrained by nothing is a shape that gets corrected a PR later. They land in #1249 alongside the service methods that use them.

## Decisions worth recording

**No `enabled` column** on the table to come, unlike the sibling tables `redirect_uris` and `post_logout_redirect_uris`. For CORS, "declared but inactive" and "deleted" are the same observable state. Keeping it would have bought a port method, a `PUT` route and a UI control for no behaviour. Deliberate divergence from the neighbouring convention, not an oversight.

**`delete` takes `(client_id, id)`**, not `id` alone. Copied from `RedirectUriRepository`, where it scopes the delete to the client and closes an IDOR. The design note for this work originally said `id` alone; the repository's existing shape is better and won.

**`get_origin_sources_by_realm_name` takes `String`, not `&str`**, matching the 22 other domain port signatures that take `realm_name: String`. There is no `RealmName` newtype in this codebase — a real gap, but a global one, not this PR's to open.

**`CoreError` still does not derive `PartialEq`.** The conversion test asserts on the rendered message instead of comparing enum values. Deriving it on the shared kernel error enum has a blast radius unrelated to this feature.

**The lines in `libs/ferriskey-api-core/src/error.rs` are not scope creep.** The `CoreError` to HTTP mapping is an exhaustive `match`; adding variants without mapping them does not compile. `InvalidWebOrigin` maps to `400` carrying the rejection reason, which is the point of validating at write time — the administrator learns *why* the origin was refused.

## Verification

```
cargo test -p ferriskey-domain                                     84 passed
cargo build --workspace                                            ok
cargo check --all-targets                                          ok
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   clean
cargo test -p ferriskey-core --lib --no-run                        ok
cargo fmt --all --check                                            clean
```

45 of those 84 tests are new. Written test-first: every one was watched failing before an implementation existed.

**Beyond the test suite**, the adversarial review swept **128,992 inputs** — every codepoint from U+0020 to U+1FFFF embedded in a host, plus 122 hand-built structural cases — comparing our stored form against a WHATWG reference implementation. The question it was answering is the one that decides whether this feature works at all: *can any input produce a stored value that differs from what a browser would send in its `Origin` header for the same site?* Because the comparison is exact string equality, a divergence in either direction is a bug — a bypass one way, a silent block the other.

**No divergence found.** Trailing dots, uppercase hosts, IPv6 brackets and compression, IPv4 in decimal and hex, percent-encoding in the authority, ideographic full stops, zero-width spaces, default-port dropping, embedded tabs and newlines: all identical to the reference. The sweep also confirmed the stored form is always printable ASCII with no space, CR or LF, so nothing can be injected into the `Access-Control-Allow-Origin` header the API will echo.

The single value-level disagreement was `https://ẞ.example.com` (U+1E9E), where we produce `xn--zca.example.com` and Node/Ada produce `ss.example.com`. **We are the correct side**: the URL Standard mandates non-transitional IDNA processing, which is what the `url` crate does and what the authoritative `IdnaTestV2.txt` gives; Node applies transitional processing here.

One gap in that evidence, stated because it matters: the reference was Node 22 / Ada plus the Unicode conformance tables, **not a live browser** — the review could not reach one. Everything else above was verified by execution.

## Where the reasoning lives

There are no comments in this diff, of any kind — no `//`, and no rustdoc either. Everything that would have been narration in the source is in this description instead: why storage and enforcement are split, why `*` is refused at write time rather than ignored later, why the two construction paths validate differently, what `+` does not cover.

That puts a real obligation on the reviewer, so it is worth being explicit about what cannot be read off the code. The invariants are held by tests, not by prose: re-derive `ToSchema` and `a_value_is_documented_as_the_string_it_serializes_to` fails; drop the wildcard check and four tests fail; let `+` reach a sibling's redirect URIs and `the_sentinel_does_not_expand_another_clients_redirect_uris` fails. The names are the other half — `enabled_redirect_uris` states its own precondition.

## Known gap carried to the frontend issue

`chrome-extension://`, `moz-extension://`, `capacitor://localhost` and `ionic://localhost` are real `Origin` header values that Keycloak deployments do register, and this implementation refuses them by contract — only http and https have a serializable origin here. That is a deliberate scope boundary, not an oversight, but it is a concrete migration gap and #1251 should name it in the UI rather than let an administrator discover it from a blocked request.

**These tests will not run in CI.** No workflow in this repository runs `cargo test` — `integration-tests.yaml` only runs `--test <name> -- --ignored` suites, and the pre-commit workflow runs `fmt` and `clippy`. So the 40 tests compile and lint here, and never execute. That gap predates this PR and the fix is one line (`cargo test --workspace --lib` in a workflow), but it is a CI change with its own blast radius and belongs in its own PR rather than smuggled into this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated web-origin support for HTTP(S) origins.
  * Added origin allowlist resolution from explicit origins and eligible redirect URIs.
  * Added repository capabilities for creating, listing, deleting, and retrieving web origins.
  * Added support for redirect-derived origin configuration.

* **Bug Fixes**
  * Improved error handling for missing and invalid web origins, including clearer validation details.
  * Excludes malformed, wildcard, non-HTTP, and credential-bearing redirect URIs from origin resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->