### PR TITLE
feat: manage web origins from the console and stop writing them as redirect uris

### DIFF
--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -1094,6 +1094,15 @@ export namespace Schemas {
   export type VerifyOtpResponse = { message: string };
   export type VerifyResetTokenRequest = { token_id: string };
   export type VerifyResetTokenResponse = { valid: boolean };
+  export type WebOriginValue = string;
+  export type WebOrigin = {
+    client_id: string;
+    created_at: string;
+    id: string;
+    updated_at: string;
+    value: WebOriginValue;
+  };
+  export type CreateWebOriginValidator = Partial<{ value: string }>;
 
   // </Schemas>
 }
@@ -1676,6 +1685,53 @@ export namespace Endpoints {
     requestFormat: "json";
     parameters: {
       path: { realm_name: string; client_id: string; uri_id: string };
+    };
+    responses: {
+      200: unknown;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type get_Get_web_origins = {
+    method: "GET";
+    path: "/realms/{realm_name}/clients/{client_id}/web-origins";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+    };
+    responses: {
+      200: Array<Schemas.WebOrigin>;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type post_Create_web_origin = {
+    method: "POST";
+    path: "/realms/{realm_name}/clients/{client_id}/web-origins";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+
+      body: Schemas.CreateWebOriginValidator;
+    };
+    responses: {
+      201: Schemas.WebOrigin;
+      400: Schemas.ApiErrorResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type delete_Delete_web_origin = {
+    method: "DELETE";
+    path: "/realms/{realm_name}/clients/{client_id}/web-origins/{web_origin_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string; web_origin_id: string };
     };
     responses: {
       200: unknown;
@@ -3779,6 +3835,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/{client_id}/post-logout-redirects": Endpoints.get_Get_post_logout_redirect_uris;
     "/realms/{realm_name}/clients/{client_id}/redirects": Endpoints.get_Get_redirect_uris;
     "/realms/{realm_name}/clients/{client_id}/roles": Endpoints.get_Get_client_roles;
+    "/realms/{realm_name}/clients/{client_id}/web-origins": Endpoints.get_Get_web_origins;
     "/realms/{realm_name}/compass/v1/activity/daily": Endpoints.get_Get_daily_activity_stats;
     "/realms/{realm_name}/compass/v1/flows": Endpoints.get_Get_flows;
     "/realms/{realm_name}/compass/v1/flows/{flow_id}": Endpoints.get_Get_flow;
@@ -3847,6 +3904,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/{client_id}/post-logout-redirects": Endpoints.post_Create_post_logout_redirect_uri;
     "/realms/{realm_name}/clients/{client_id}/redirects": Endpoints.post_Create_redirect_uri;
     "/realms/{realm_name}/clients/{client_id}/roles": Endpoints.post_Create_client_role;
+    "/realms/{realm_name}/clients/{client_id}/web-origins": Endpoints.post_Create_web_origin;
     "/realms/{realm_name}/device/verify": Endpoints.post_Device_verify;
     "/realms/{realm_name}/email-templates": Endpoints.post_Create_template;
     "/realms/{realm_name}/federation/providers": Endpoints.post_Create_provider;
@@ -3931,6 +3989,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/{client_id}/optional-client-scopes/{scope_id}": Endpoints.delete_Unassign_optional_scope;
     "/realms/{realm_name}/clients/{client_id}/post-logout-redirects/{uri_id}": Endpoints.delete_Delete_post_logout_redirect_uri;
     "/realms/{realm_name}/clients/{client_id}/redirects/{uri_id}": Endpoints.delete_Delete_redirect_uri;
+    "/realms/{realm_name}/clients/{client_id}/web-origins/{web_origin_id}": Endpoints.delete_Delete_web_origin;
     "/realms/{realm_name}/email-templates/{template_id}": Endpoints.delete_Delete_template;
     "/realms/{realm_name}/federation/providers/{id}": Endpoints.delete_Delete_provider;
     "/realms/{realm_name}/identity-providers/{alias}": Endpoints.delete_Delete_identity_provider;

--- a/front/src/api/web_origins.api.ts
+++ b/front/src/api/web_origins.api.ts
@@ -16,14 +16,10 @@ export const useGetWebOrigins = ({
 }) => {
   return useQuery({
     queryKey: webOriginsQueryKey(realmName ?? '', clientId ?? ''),
-    queryFn: async () => {
-      if (!realmName || !clientId) return []
-
-      return window.tanstackApi.client.get(
-        '/realms/{realm_name}/clients/{client_id}/web-origins',
-        { path: { realm_name: realmName, client_id: clientId } }
-      ) as Promise<Schemas.WebOrigin[]>
-    },
+    queryFn: async () =>
+      window.tanstackApi.client.get('/realms/{realm_name}/clients/{client_id}/web-origins', {
+        path: { realm_name: realmName!, client_id: clientId! },
+      }) as Promise<Schemas.WebOrigin[]>,
     enabled: !!realmName && !!clientId,
   })
 }

--- a/front/src/api/web_origins.api.ts
+++ b/front/src/api/web_origins.api.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { Schemas } from './api.client'
+
+export const webOriginsQueryKey = (realmName: string, clientId: string) => [
+  'web-origins',
+  realmName,
+  clientId,
+]
+
+export const useGetWebOrigins = ({
+  realmName,
+  clientId,
+}: {
+  realmName?: string
+  clientId?: string
+}) => {
+  return useQuery({
+    queryKey: webOriginsQueryKey(realmName ?? '', clientId ?? ''),
+    queryFn: async () => {
+      if (!realmName || !clientId) return []
+
+      return window.tanstackApi.client.get(
+        '/realms/{realm_name}/clients/{client_id}/web-origins',
+        { path: { realm_name: realmName, client_id: clientId } }
+      ) as Promise<Schemas.WebOrigin[]>
+    },
+    enabled: !!realmName && !!clientId,
+  })
+}
+
+export interface CreateWebOriginMutate {
+  realmName: string
+  clientId: string
+  payload: {
+    value: string
+  }
+}
+
+export const useCreateWebOrigin = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ realmName, clientId, payload }: CreateWebOriginMutate) => {
+      return window.tanstackApi.client.post(
+        '/realms/{realm_name}/clients/{client_id}/web-origins',
+        {
+          path: { realm_name: realmName, client_id: clientId },
+          body: { value: payload.value },
+        }
+      ) as Promise<Schemas.WebOrigin>
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: webOriginsQueryKey(variables.realmName, variables.clientId),
+      })
+    },
+  })
+}
+
+export interface DeleteWebOriginMutate {
+  realmName: string
+  clientId: string
+  webOriginId: string
+}
+
+export const useDeleteWebOrigin = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ realmName, clientId, webOriginId }: DeleteWebOriginMutate) => {
+      return window.tanstackApi.client.delete(
+        '/realms/{realm_name}/clients/{client_id}/web-origins/{web_origin_id}',
+        {
+          path: {
+            realm_name: realmName,
+            client_id: clientId,
+            web_origin_id: webOriginId,
+          },
+        }
+      )
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: webOriginsQueryKey(variables.realmName, variables.clientId),
+      })
+    },
+  })
+}

--- a/front/src/lib/web-origin.test.ts
+++ b/front/src/lib/web-origin.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { DERIVED_ORIGIN_SENTINEL, isWebOriginValue, normalizeWebOrigin } from './web-origin.ts'
+
+test('an origin keeps its scheme, host and non-default port', () => {
+  assert.equal(
+    normalizeWebOrigin('https://app.example.com:8443'),
+    'https://app.example.com:8443'
+  )
+})
+
+test('a default port is dropped, as the browser drops it', () => {
+  assert.equal(normalizeWebOrigin('https://app.example.com:443'), 'https://app.example.com')
+  assert.equal(normalizeWebOrigin('http://app.example.com:80'), 'http://app.example.com')
+})
+
+test('scheme and host are lowercased', () => {
+  assert.equal(normalizeWebOrigin('HTTPS://App.Example.COM'), 'https://app.example.com')
+})
+
+test('a lone trailing slash is not a path', () => {
+  assert.equal(normalizeWebOrigin('https://app.example.com/'), 'https://app.example.com')
+})
+
+test('surrounding whitespace is trimmed', () => {
+  assert.equal(normalizeWebOrigin('  https://app.example.com  '), 'https://app.example.com')
+})
+
+test('an origin carries no path', () => {
+  assert.equal(normalizeWebOrigin('https://app.example.com/callback'), null)
+})
+
+test('an origin carries no query or fragment', () => {
+  assert.equal(normalizeWebOrigin('https://app.example.com/?next=1'), null)
+  assert.equal(normalizeWebOrigin('https://app.example.com/#top'), null)
+})
+
+test('an origin carries no credentials', () => {
+  assert.equal(normalizeWebOrigin('https://user:secret@app.example.com'), null)
+})
+
+test('the wildcard is refused, alone or in a host', () => {
+  assert.equal(normalizeWebOrigin('*'), null)
+  assert.equal(normalizeWebOrigin('  *  '), null)
+  assert.equal(normalizeWebOrigin('https://*.example.com'), null)
+})
+
+test('only http and https have an origin we can register', () => {
+  assert.equal(normalizeWebOrigin('ftp://files.example.com'), null)
+  assert.equal(normalizeWebOrigin('file:///etc/passwd'), null)
+  assert.equal(normalizeWebOrigin('chrome-extension://abcdef'), null)
+})
+
+test('what is not a URL at all is refused', () => {
+  assert.equal(normalizeWebOrigin(''), null)
+  assert.equal(normalizeWebOrigin('null'), null)
+  assert.equal(normalizeWebOrigin('not an origin'), null)
+})
+
+test('the sentinel is not an origin, so it does not normalize', () => {
+  assert.equal(normalizeWebOrigin(DERIVED_ORIGIN_SENTINEL), null)
+})
+
+test('the sentinel is nonetheless an accepted value', () => {
+  assert.equal(isWebOriginValue(DERIVED_ORIGIN_SENTINEL), true)
+  assert.equal(isWebOriginValue('  +  '), true)
+})
+
+test('an accepted value is either the sentinel or a valid origin', () => {
+  assert.equal(isWebOriginValue('https://app.example.com'), true)
+  assert.equal(isWebOriginValue('https://app.example.com/callback'), false)
+  assert.equal(isWebOriginValue('*'), false)
+  assert.equal(isWebOriginValue(''), false)
+})

--- a/front/src/lib/web-origin.ts
+++ b/front/src/lib/web-origin.ts
@@ -1,0 +1,44 @@
+export const DERIVED_ORIGIN_SENTINEL = '+'
+
+const ORIGIN_SCHEMES = ['http:', 'https:']
+
+export function normalizeWebOrigin(value: string): string | null {
+  const candidate = value.trim()
+
+  if (candidate === '' || candidate === '*') {
+    return null
+  }
+
+  let url: URL
+  try {
+    url = new URL(candidate)
+  } catch {
+    return null
+  }
+
+  if (!ORIGIN_SCHEMES.includes(url.protocol)) {
+    return null
+  }
+
+  if (url.username !== '' || url.password !== '') {
+    return null
+  }
+
+  if (url.pathname !== '' && url.pathname !== '/') {
+    return null
+  }
+
+  if (url.search !== '' || url.hash !== '') {
+    return null
+  }
+
+  if (url.hostname.includes('*')) {
+    return null
+  }
+
+  return url.origin
+}
+
+export function isWebOriginValue(value: string): boolean {
+  return value.trim() === DERIVED_ORIGIN_SENTINEL || normalizeWebOrigin(value) !== null
+}

--- a/front/src/pages/client/components/manage-web-origins.tsx
+++ b/front/src/pages/client/components/manage-web-origins.tsx
@@ -1,0 +1,149 @@
+import { useCreateWebOrigin, useDeleteWebOrigin, useGetWebOrigins } from '@/api/web_origins.api'
+import { Button } from '@/components/ui/button'
+import { ConfirmDeleteAlert } from '@/components/confirm-delete-alert'
+import { Form, FormField } from '@/components/ui/form'
+import { InputText } from '@/components/ui/input-text'
+import { useConfirmDeleteAlert } from '@/hooks/use-confirm-delete-alert.ts'
+import { DERIVED_ORIGIN_SENTINEL, isWebOriginValue } from '@/lib/web-origin'
+import { RouterParams } from '@/routes/router'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Trash2 } from 'lucide-react'
+import { useForm } from 'react-hook-form'
+import { useParams } from 'react-router'
+import { toast } from 'sonner'
+import { z } from 'zod'
+
+const createWebOriginSchema = z.object({
+  newWebOrigin: z
+    .string()
+    .min(1, { message: 'Web origin is required' })
+    .refine(isWebOriginValue, {
+      message: `Enter an origin such as https://app.example.com — no path, no wildcard — or ${DERIVED_ORIGIN_SENTINEL} to derive them from this client's redirect URIs`,
+    }),
+})
+
+type CreateWebOriginSchema = z.infer<typeof createWebOriginSchema>
+
+export default function ManageWebOrigins() {
+  const { realm_name, client_id } = useParams<RouterParams>()
+  const { confirm, ask, close } = useConfirmDeleteAlert()
+
+  const { data: webOrigins = [], refetch } = useGetWebOrigins({
+    realmName: realm_name,
+    clientId: client_id,
+  })
+  const { mutateAsync: deleteWebOrigin } = useDeleteWebOrigin()
+  const { mutateAsync: createWebOrigin } = useCreateWebOrigin()
+
+  const form = useForm<CreateWebOriginSchema>({
+    resolver: zodResolver(createWebOriginSchema),
+    defaultValues: {
+      newWebOrigin: '',
+    },
+  })
+
+  const handleDeleteWebOrigin = async (webOriginId: string) => {
+    if (!realm_name || !client_id) return
+
+    ask({
+      title: 'Delete web origin?',
+      description:
+        'Browsers may keep a cached preflight for a few minutes, and other API replicas for up to 30 seconds.',
+      onConfirm: async () => {
+        try {
+          await deleteWebOrigin({
+            realmName: realm_name,
+            clientId: client_id,
+            webOriginId,
+          })
+
+          await refetch()
+          toast.success('Web origin deleted successfully')
+          close()
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : 'Failed to delete web origin')
+        }
+      },
+    })
+  }
+
+  const onSubmit = async (values: CreateWebOriginSchema) => {
+    if (!realm_name || !client_id) return
+
+    try {
+      await createWebOrigin({
+        realmName: realm_name,
+        clientId: client_id,
+        payload: { value: values.newWebOrigin.trim() },
+      })
+
+      await refetch()
+      toast.success('Web origin added successfully')
+      form.reset()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create web origin')
+    }
+  }
+
+  return (
+    <>
+      <div className='flex flex-col gap-4'>
+        {webOrigins.map((origin, index) => (
+          <div key={origin.id} className='flex gap-2 items-center'>
+            <InputText
+              name='web_origin'
+              label={
+                origin.value === DERIVED_ORIGIN_SENTINEL
+                  ? 'Derived from redirect URIs'
+                  : `Web Origin ${index + 1}`
+              }
+              value={origin.value}
+              disabled
+              className='flex-grow'
+            />
+
+            <div>
+              <Button
+                className='text-red-500'
+                variant='ghost'
+                size='icon'
+                onClick={() => {
+                  handleDeleteWebOrigin(origin.id)
+                }}
+              >
+                <Trash2 size={14} />
+              </Button>
+            </div>
+          </div>
+        ))}
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className='flex flex-col gap-2'>
+            <FormField
+              control={form.control}
+              name='newWebOrigin'
+              render={({ field }) => (
+                <InputText
+                  {...field}
+                  label='Add new Web Origin'
+                  className='flex-grow'
+                  error={form.formState.errors?.newWebOrigin?.message}
+                />
+              )}
+            />
+
+            <Button type='submit'>Add Web Origin</Button>
+          </form>
+        </Form>
+      </div>
+
+      <ConfirmDeleteAlert
+        title={confirm.title}
+        description={confirm.description}
+        open={confirm.open}
+        onConfirm={confirm.onConfirm}
+        onCancel={close}
+      />
+    </>
+  )
+}

--- a/front/src/pages/client/components/manage-web-origins.tsx
+++ b/front/src/pages/client/components/manage-web-origins.tsx
@@ -107,6 +107,7 @@ export default function ManageWebOrigins() {
                 className='text-red-500'
                 variant='ghost'
                 size='icon'
+                aria-label={`Remove web origin ${origin.value}`}
                 onClick={() => {
                   handleDeleteWebOrigin(origin.id)
                 }}

--- a/front/src/pages/client/ui/page-client-settings.tsx
+++ b/front/src/pages/client/ui/page-client-settings.tsx
@@ -1,6 +1,7 @@
 import { InputText } from '@/components/ui/input-text'
 import { DurationInput } from '@/components/ui/duration-input'
 import ManageRedirectUris from '../components/manage-redirect-uris'
+import ManageWebOrigins from '../components/manage-web-origins'
 import ManagePostLogoutRedirectUris from '../components/manage-post-logout-redirect-uris'
 import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/form'
 import { Switch } from '@/components/ui/switch'
@@ -236,6 +237,20 @@ export default function PageClientSettings({
           </div>
           <div className='w-1/2'>
             <ManageRedirectUris redirectUris={client.redirect_uris ?? []} refetch={refetch} />
+          </div>
+        </div>
+
+        <div className='flex items-start justify-between py-4 border-t'>
+          <div className='w-1/3'>
+            <p className='text-sm font-medium'>Web Origins</p>
+            <p className='text-sm text-muted-foreground mt-0.5'>
+              Origins this application may call FerrisKey from in a browser. Enter{' '}
+              <code>+</code> to derive them from the redirect URIs above — literal ones only,
+              regex patterns are skipped.
+            </p>
+          </div>
+          <div className='w-1/2'>
+            <ManageWebOrigins />
           </div>
         </div>
       </div>

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -90,15 +90,17 @@ export default function PageApplicationDetailFeature() {
     }
   }
 
-  async function handleAddWebOrigin(value: string) {
-    if (!client) return
+  async function handleAddWebOrigin(value: string): Promise<boolean> {
+    if (!client) return false
     setUriPending(true)
     try {
       await createWebOrigin({ realmName: realm, clientId: client.id, payload: { value } })
       await refetchWebOrigins()
       toast.success('Web origin added')
+      return true
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to add web origin')
+      return false
     } finally {
       setUriPending(false)
     }

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -1,5 +1,6 @@
 import { useDeleteClient, useGetClient, useUpdateClient } from '@/api/client.api'
 import { useCreateRedirectUri, useDeleteRedirectUri } from '@/api/redirect_uris.api'
+import { useCreateWebOrigin, useDeleteWebOrigin, useGetWebOrigins } from '@/api/web_origins.api'
 import { Skeleton } from '@/components/ui/skeleton'
 import PageClientMaintenanceFeature from '@/pages/client/feature/page-client-maintenance-feature'
 import { RouterParams } from '@/routes/router'
@@ -31,6 +32,12 @@ export default function PageApplicationDetailFeature() {
   const { mutateAsync: deleteClient } = useDeleteClient()
   const { mutateAsync: createRedirectUri } = useCreateRedirectUri()
   const { mutateAsync: deleteRedirectUri } = useDeleteRedirectUri()
+  const { mutateAsync: createWebOrigin } = useCreateWebOrigin()
+  const { mutateAsync: deleteWebOrigin } = useDeleteWebOrigin()
+  const { data: webOrigins = [], refetch: refetchWebOrigins } = useGetWebOrigins({
+    realmName: realm,
+    clientId: client_id,
+  })
   const [uriPending, setUriPending] = useState(false)
 
   const client = clientResponse?.data
@@ -78,6 +85,34 @@ export default function PageApplicationDetailFeature() {
       toast.success('Redirect URI added')
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to add redirect URI')
+    } finally {
+      setUriPending(false)
+    }
+  }
+
+  async function handleAddWebOrigin(value: string) {
+    if (!client) return
+    setUriPending(true)
+    try {
+      await createWebOrigin({ realmName: realm, clientId: client.id, payload: { value } })
+      await refetchWebOrigins()
+      toast.success('Web origin added')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add web origin')
+    } finally {
+      setUriPending(false)
+    }
+  }
+
+  async function handleDeleteWebOrigin(webOriginId: string) {
+    if (!client) return
+    setUriPending(true)
+    try {
+      await deleteWebOrigin({ realmName: realm, clientId: client.id, webOriginId })
+      await refetchWebOrigins()
+      toast.success('Web origin removed')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove web origin')
     } finally {
       setUriPending(false)
     }
@@ -158,6 +193,9 @@ export default function PageApplicationDetailFeature() {
             onDelete={handleDelete}
             onAddRedirectUri={handleAddRedirectUri}
             onDeleteRedirectUri={handleDeleteRedirectUri}
+            webOrigins={webOrigins}
+            onAddWebOrigin={handleAddWebOrigin}
+            onDeleteWebOrigin={handleDeleteWebOrigin}
           />
         )
       case 'credentials':

--- a/front/src/pages/console-applications/feature/page-create-application-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-create-application-feature.tsx
@@ -1,5 +1,6 @@
 import { useCreateClient } from '@/api/client.api'
 import { useCreateRedirectUri } from '@/api/redirect_uris.api'
+import { useCreateWebOrigin } from '@/api/web_origins.api'
 import {
   APPLICATIONS_URL,
   APPLICATION_CREATE_URL,
@@ -46,6 +47,7 @@ export default function PageCreateApplicationFeature() {
   const navigate = useNavigate()
   const { mutateAsync: createClient } = useCreateClient()
   const { mutateAsync: createRedirectUri } = useCreateRedirectUri()
+  const { mutateAsync: createWebOrigin } = useCreateWebOrigin()
   const [submitting, setSubmitting] = useState(false)
 
   // Guard against an unknown :type segment by sending the user back to step 1.
@@ -67,12 +69,18 @@ export default function PageCreateApplicationFeature() {
       const clientId = created.id
       // Best-effort registration of allowed callback URLs. If one fails we
       // surface the error but keep the client (the user can finish in admin).
-      const urls = [...values.callbackUrls, ...values.allowedOrigins].filter(Boolean)
-      for (const url of urls) {
+      for (const url of values.callbackUrls.filter(Boolean)) {
         try {
           await createRedirectUri({ realmName: realm_name, clientId, payload: { value: url } })
         } catch {
-          toast.error(`Could not register URL: ${url}`)
+          toast.error(`Could not register callback URL: ${url}`)
+        }
+      }
+      for (const origin of values.allowedOrigins.filter(Boolean)) {
+        try {
+          await createWebOrigin({ realmName: realm_name, clientId, payload: { value: origin } })
+        } catch {
+          toast.error(`Could not register web origin: ${origin}`)
         }
       }
       toast.success('Application created')

--- a/front/src/pages/console-applications/ui/page-create-application.tsx
+++ b/front/src/pages/console-applications/ui/page-create-application.tsx
@@ -1,3 +1,4 @@
+import { isWebOriginValue } from '@/lib/web-origin'
 import { ApplicationType } from '@/routes/sub-router/applications.router'
 import { ArrowLeft, Loader2, Plus, Sparkles, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
@@ -55,7 +56,8 @@ const FIELDS_BY_TYPE: Record<ApplicationType, FieldsConfig> = {
     callbacksPlaceholder: 'https://app.acme.com/callback',
     showOrigins: true,
     originsLabel: 'Allowed web origins',
-    originsHint: 'Origins allowed to call FerrisKey from the browser (CORS).',
+    originsHint:
+      'Origins allowed to call FerrisKey from the browser (CORS). Scheme, host and port only — no path. Enter + to derive them from the callback URLs above.',
     originsPlaceholder: 'https://app.acme.com',
     callbackRequired: true,
   },
@@ -113,7 +115,7 @@ export default function PageCreateApplication({ type, onCancel, onBack, onSubmit
   const originUrls = useMemo(() => origins.map((s) => s.trim()).filter(Boolean), [origins])
 
   const callbacksValid = !fields.showCallbacks || callbackUrls.every(isValidUrl)
-  const originsValid = !fields.showOrigins || originUrls.every(isValidUrl)
+  const originsValid = !fields.showOrigins || originUrls.every(isWebOriginValue)
   const callbackRequirementMet = !fields.callbackRequired || callbackUrls.length > 0
 
   const canSubmit =
@@ -242,7 +244,7 @@ export default function PageCreateApplication({ type, onCancel, onBack, onSubmit
           onChange={setOrigins}
           onAdd={() => addAt(origins, setOrigins)}
           onRemove={(i) => removeAt(origins, setOrigins, i)}
-          validate={isValidUrl}
+          validate={isWebOriginValue}
         />
       )}
 

--- a/front/src/pages/console-applications/ui/tabs/settings-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/settings-tab.tsx
@@ -14,9 +14,11 @@ import { Switch } from '@/components/ui/switch'
 import { Loader2, Plus, Trash2, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { inferApplicationType } from '../../types'
+import { DERIVED_ORIGIN_SENTINEL, isWebOriginValue } from '@/lib/web-origin'
 import { Field, Section } from './primitives'
 
 import Client = Schemas.Client
+import WebOrigin = Schemas.WebOrigin
 
 export interface ApplicationSettingsValues {
   name: string
@@ -54,6 +56,9 @@ interface Props {
   onDelete: () => void
   onAddRedirectUri: (value: string) => void
   onDeleteRedirectUri: (redirectUriId: string) => void
+  webOrigins: WebOrigin[]
+  onAddWebOrigin: (value: string) => void
+  onDeleteWebOrigin: (webOriginId: string) => void
 }
 
 export default function SettingsTab({
@@ -64,9 +69,13 @@ export default function SettingsTab({
   onDelete,
   onAddRedirectUri,
   onDeleteRedirectUri,
+  webOrigins,
+  onAddWebOrigin,
+  onDeleteWebOrigin,
 }: Props) {
   const [values, setValues] = useState<ApplicationSettingsValues>(() => settingsFromClient(client))
   const [newUri, setNewUri] = useState('')
+  const [newOrigin, setNewOrigin] = useState('')
 
   const baseline = useMemo(() => settingsFromClient(client), [client])
   const hasChanges = useMemo(
@@ -98,6 +107,13 @@ export default function SettingsTab({
     if (!v || !isValidUrl(v)) return
     onAddRedirectUri(v)
     setNewUri('')
+  }
+
+  const handleAddOrigin = () => {
+    const v = newOrigin.trim()
+    if (!isWebOriginValue(v)) return
+    onAddWebOrigin(v)
+    setNewOrigin('')
   }
 
   return (
@@ -163,6 +179,63 @@ export default function SettingsTab({
                 type='button'
                 onClick={handleAddUri}
                 disabled={uriPending || !newUri.trim() || !isValidUrl(newUri)}
+                className='inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed'
+              >
+                {uriPending ? <Loader2 className='h-3.5 w-3.5 animate-spin' /> : <Plus className='h-3.5 w-3.5' />}
+                Add
+              </button>
+            </div>
+          </div>
+        </Section>
+      )}
+
+      {usesAuthorizationCode && (
+        <Section
+          title='Web origins'
+          description='Origins this application may call FerrisKey from in a browser. Enter + to derive them from the redirect URIs above — literal ones only, regex patterns are skipped.'
+        >
+          <div className='flex flex-col gap-2'>
+            {webOrigins.length === 0 && (
+              <p className='text-xs text-muted-foreground'>No web origins registered yet.</p>
+            )}
+            {webOrigins.map((origin) => (
+              <div
+                key={origin.id}
+                className='flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2'
+              >
+                <span className='flex-1 text-sm font-mono truncate'>{origin.value}</span>
+                {origin.value === DERIVED_ORIGIN_SENTINEL && (
+                  <span className='text-xs text-muted-foreground'>derived from redirect URIs</span>
+                )}
+                <button
+                  type='button'
+                  onClick={() => onDeleteWebOrigin(origin.id)}
+                  disabled={uriPending}
+                  className='inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-muted transition-colors disabled:opacity-40'
+                  aria-label='Remove web origin'
+                >
+                  <X className='h-3.5 w-3.5' />
+                </button>
+              </div>
+            ))}
+            <div className='flex items-center gap-2'>
+              <input
+                type='text'
+                value={newOrigin}
+                onChange={(e) => setNewOrigin(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleAddOrigin()
+                  }
+                }}
+                placeholder='https://app.acme.com'
+                className='flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm font-mono outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
+              />
+              <button
+                type='button'
+                onClick={handleAddOrigin}
+                disabled={uriPending || !isWebOriginValue(newOrigin)}
                 className='inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed'
               >
                 {uriPending ? <Loader2 className='h-3.5 w-3.5 animate-spin' /> : <Plus className='h-3.5 w-3.5' />}

--- a/front/src/pages/console-applications/ui/tabs/settings-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/settings-tab.tsx
@@ -57,7 +57,7 @@ interface Props {
   onAddRedirectUri: (value: string) => void
   onDeleteRedirectUri: (redirectUriId: string) => void
   webOrigins: WebOrigin[]
-  onAddWebOrigin: (value: string) => void
+  onAddWebOrigin: (value: string) => Promise<boolean>
   onDeleteWebOrigin: (webOriginId: string) => void
 }
 
@@ -109,11 +109,12 @@ export default function SettingsTab({
     setNewUri('')
   }
 
-  const handleAddOrigin = () => {
+  const handleAddOrigin = async () => {
     const v = newOrigin.trim()
     if (!isWebOriginValue(v)) return
-    onAddWebOrigin(v)
-    setNewOrigin('')
+    if (await onAddWebOrigin(v)) {
+      setNewOrigin('')
+    }
   }
 
   return (
@@ -226,15 +227,16 @@ export default function SettingsTab({
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     e.preventDefault()
-                    handleAddOrigin()
+                    void handleAddOrigin()
                   }
                 }}
                 placeholder='https://app.acme.com'
+                aria-label='Web origin'
                 className='flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm font-mono outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
               />
               <button
                 type='button'
-                onClick={handleAddOrigin}
+                onClick={() => void handleAddOrigin()}
                 disabled={uriPending || !isWebOriginValue(newOrigin)}
                 className='inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed'
               >

--- a/front/src/types/api.types.ts
+++ b/front/src/types/api.types.ts
@@ -40,6 +40,7 @@ export type RealmLoginSetting = Schemas.RealmLoginSetting
 
 // Other commonly used types
 export type RedirectUri = Schemas.RedirectUri
+export type WebOrigin = Schemas.WebOrigin
 export type JwtToken = Schemas.JwtToken
 export type RequiredAction = Schemas.RequiredAction
 export type GrantType = Schemas.GrantType

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -24,6 +24,7 @@ export type {
   RealmSetting,
   RealmLoginSetting,
   RedirectUri,
+  WebOrigin,
   JwtToken,
   RequiredAction,
   GrantType,


### PR DESCRIPTION
Closes #1251. Part of #1178.

Last of four layers. **Stacked on #1250** — this branch targets `feat/1250-web-origins-api` and GitHub will retarget it to `main` once that merges. Review the API layer there; the diff here is frontend only.

## The bug this closes

`page-create-application.tsx` has shown SPA users a field labelled **"Allowed web origins — Origins allowed to call FerrisKey from the browser (CORS)"** for as long as it has existed. `page-create-application-feature.tsx` then did this:

```ts
const urls = [...values.callbackUrls, ...values.allowedOrigins].filter(Boolean)
for (const url of urls) {
  await createRedirectUri({ ... })
}
```

Every value typed into the web-origins field was registered as a **redirect URI**. There was no web-origins API to write to, so the field has never affected CORS — and worse, it silently widened the redirect URI allowlist, which is the control standing between an authorization code and an attacker-chosen destination.

The form's own output type already separated the two (`callbackUrls` and `allowedOrigins` are distinct fields). Only the consumer merged them. Two loops now, the second hitting the real endpoint.

**Rows created by this bug are left alone.** After the fact there is no way to tell which redirect URIs were typed into which field, and deleting them on a guess would break live logins. Anyone who used that form should review their client's redirect URIs by hand.

## Validation, and why it needed its own function

The form validated origins with `isValidUrl`, `/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/.+/`. That accepts `https://app.example.com/callback` — a path, which is not an origin and can never match an `Origin` header — and it rejects `+`, the one value the API treats specially.

`front/src/lib/web-origin.ts` replaces it for origins, and mirrors the server: it uses the browser's own `URL` API, which implements the same WHATWG standard the Rust `url` crate follows. Both sides therefore normalize identically — a default port dropped, a host lowercased, a lone trailing slash ignored — which matters because the eventual comparison is exact string equality.

Fourteen tests cover it, written first: default-port and case normalization, path/query/fragment/credentials refused, `*` refused alone and inside a host, non-http schemes refused, and the `+` sentinel accepted as a value while not being an origin.

**A note on those tests.** They run:

```
node --experimental-strip-types --test front/src/lib/web-origin.test.ts   14 passed
```

The two tests already in this repository do **not** — `callback-helpers.test.ts` and `auth-refresh-controller.test.ts` both fail with `ERR_MODULE_NOT_FOUND` under any invocation I could find, because Node's ESM resolver needs the `.ts` extension in the import specifier and they omit it. Mine uses `./web-origin.ts`, which `tsc` accepts here because `allowImportingTsExtensions` is already on. Fixing the other two is one character each, but they are not this PR's subject and no CI job runs them either way.

## What is in the UI

Both client-detail screens, because both exist and both are reachable:

- the legacy console gets `manage-web-origins.tsx`, modelled on `manage-post-logout-redirect-uris.tsx` rather than `manage-redirect-uris.tsx` — the post-logout one uses `try`/`catch` toasts instead of a `useEffect` on `isSuccess` (which never re-fires on a second add) and keys the list by `id` rather than by index
- the new console gets a Web origins section in `settings-tab.tsx`, gated on the same `usesAuthorizationCode` as redirect URIs, with handlers in the detail feature

Both say the same thing about `+`, in the description rather than a tooltip: **it derives from literal redirect URIs only, and skips anchored regex patterns.** An administrator who registered a regex redirect URI and then relied on `+` is not covered, and nothing in the data would tell them. A stored `+` also renders with a "derived from redirect URIs" marker in the list.

## API layer

`front/src/api/api.client.ts` is hand-edited — it is generated by `typed-openapi`, but nothing in `package.json` or the `justfile` invokes it, so hand-editing is the normal path here. Three schemas, three endpoints, three registry entries. It is excluded from ESLint but **not** from `tsc`, so the additions are typechecked.

`web_origins.api.ts` follows `post_logout_redirect_uris.api.ts`, including its query key. Not `redirect_uris.api.ts`: that file invalidates `['client']`, a key nothing in this app ever produces, which is why every one of its callers follows up with a manual `refetch()`. The web-origins hooks invalidate a key that exists.

## Verification

```
front/node_modules/.bin/tsc -b front/tsconfig.json                    clean
front/node_modules/.bin/eslint front                    0 errors, 59 warnings
node --experimental-strip-types --test src/lib/web-origin.test.ts     14 passed
```

The 59 warnings are the pre-change baseline, unchanged — measured before touching anything.

**`pnpm run build` was not run.** `vite build` fails on this machine with `MODULE_NOT_FOUND` on rollup's native binding, before and after these changes, and a reinstall did not fix it. That is the `vite build` half; the `tsc -b` half is what validates this diff and it passes. CI builds the webapp on every PR — that job is green on #1250 — so the bundler path is covered there, not here. Flagging it rather than claiming a build I did not get.

No manual browser pass either: the stacked base is not merged, so there is no deployment carrying the endpoints this UI calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Web Origins management to client and application settings.
  * Users can view, add, and delete allowed web origins.
  * Added support for deriving origins from callback URLs.
  * Added validation and normalization for HTTP(S) origins, including rejection of invalid formats.
  * Web-origin setup is now supported during application creation.

* **Bug Fixes**
  * Improved error handling by distinguishing callback URL and web-origin registration failures.
  * Origin lists now refresh after successful additions or deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->