### PR TITLE
fix: seed the admin password only when it is missing

### DIFF
--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -562,6 +562,8 @@ mod tests {
                 ports::ClientService,
             },
             common::FerriskeyConfig,
+            common::entities::StartupConfig,
+            common::ports::CoreService,
             realm::entities::Realm,
             realm::ports::{RealmRepository, RealmService},
             role::{
@@ -756,6 +758,112 @@ mod tests {
         .expect("count optional mappings");
 
         assert_eq!(optional_count.0, 0);
+
+        admin_pool
+            .execute(format!("DROP SCHEMA IF EXISTS \"{}\" CASCADE", schema).as_str())
+            .await
+            .expect("drop schema");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn seeding_twice_keeps_one_admin_password_and_does_not_rotate_it() {
+        let db_host = env_or("DATABASE_HOST", "localhost");
+        let db_port = env_u16_or("DATABASE_PORT", 5432);
+        let db_name = env_or("DATABASE_NAME", "ferriskey");
+        let db_user = env_or("DATABASE_USER", "ferriskey");
+        let db_password = env_or("DATABASE_PASSWORD", "ferriskey");
+
+        let schema = format!("seed_idempotence_{}", Uuid::new_v4().simple());
+
+        let admin_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+        let admin_pool = sqlx::PgPool::connect(&admin_url)
+            .await
+            .expect("connect admin pool");
+        admin_pool
+            .execute(format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema).as_str())
+            .await
+            .expect("create schema");
+
+        let schema_url = format!(
+            "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
+            db_user,
+            db_password,
+            db_host,
+            db_port,
+            db_name,
+            urlencoding::encode(&schema)
+        );
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let app = create_service(FerriskeyConfig {
+            database: crate::domain::common::DatabaseConfig {
+                host: db_host,
+                port: db_port,
+                username: db_user,
+                password: db_password,
+                name: db_name,
+                schema: schema.clone(),
+            },
+            webapp_url: "http://localhost:5555".to_string(),
+        })
+        .await
+        .expect("create service");
+
+        let realm_name = format!("realm-{}", Uuid::new_v4().simple());
+        let startup = || StartupConfig {
+            webapp_url: "http://localhost:5555".to_string(),
+            master_realm_name: realm_name.clone(),
+            admin_username: "admin".to_string(),
+            admin_password: "admin".to_string(),
+            admin_email: "admin@test.local".to_string(),
+            default_client_id: "ferriskey-admin".to_string(),
+        };
+
+        app.initialize_application(startup())
+            .await
+            .expect("first seeding");
+
+        let after_first: (uuid::Uuid, String) = sqlx::query_as(
+            "SELECT c.id, c.secret_data FROM credentials c \
+             JOIN users u ON u.id = c.user_id \
+             WHERE u.username = 'admin' AND c.credential_type = 'password'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("exactly one password credential after the first seeding");
+
+        app.initialize_application(startup())
+            .await
+            .expect("second seeding");
+
+        let after_second: Vec<(uuid::Uuid, String)> = sqlx::query_as(
+            "SELECT c.id, c.secret_data FROM credentials c \
+             JOIN users u ON u.id = c.user_id \
+             WHERE u.username = 'admin' AND c.credential_type = 'password'",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("query password credentials");
+
+        assert_eq!(
+            after_second.len(),
+            1,
+            "seeding a second time must not add a password credential"
+        );
+        assert_eq!(
+            after_second[0], after_first,
+            "seeding a second time must leave the stored password untouched"
+        );
 
         admin_pool
             .execute(format!("DROP SCHEMA IF EXISTS \"{}\" CASCADE", schema).as_str())

--- a/core/src/domain/common/services.rs
+++ b/core/src/domain/common/services.rs
@@ -348,22 +348,35 @@ where
             }
         }
 
-        let hash = self
-            .hasher_repository
-            .hash_password(&config.admin_password)
-            .await
-            .map_err(|e| CoreError::HashPasswordError(e.to_string()))?;
-
-        match self
+        let password_credential_exists = self
             .credential_repository
-            .create_credential(user.id, "password".to_string(), hash, "".into(), false)
+            .get_password_credential(user.id)
             .await
-        {
-            Ok(_) => {
-                tracing::info!("credential created for user {:}", user.username);
-            }
-            Err(_) => {
-                tracing::info!("credential already exists for user {:}", user.username);
+            .is_ok();
+
+        if password_credential_exists {
+            tracing::info!("credential already exists for user {:}", user.username);
+        } else {
+            let hash = self
+                .hasher_repository
+                .hash_password(&config.admin_password)
+                .await
+                .map_err(|e| CoreError::HashPasswordError(e.to_string()))?;
+
+            match self
+                .credential_repository
+                .create_credential(user.id, "password".to_string(), hash, "".into(), false)
+                .await
+            {
+                Ok(_) => {
+                    tracing::info!("credential created for user {:}", user.username);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "failed to create credential for user {:}: {e:?}",
+                        user.username
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
No issue for this one — reported directly while starting the app locally.

## Symptom

Every start of the API after the very first one logs this, at `ERROR`:

```
ERROR ferriskey_core::infrastructure::repositories::credential_repository:
  Error creating credential for user 019f8533-…:
  Query(SqlxError(Database(PgDatabaseError { severity: Error, code: "23505",
  message: "duplicate key value violates unique constraint \"unique_credential_type_per_user_id_idx\"",
  detail: Some("Key (user_id, credential_type)=(019f8533-…, password) already exists.") … })))
```

**Startup is not broken.** The very next line is `INFO credential already exists for user admin`, and the app carries on. What is broken is the signal: an IAM prints an `ERROR` with a Postgres internals dump on every restart, which is exactly how operators learn to stop reading `ERROR` lines.

## Root cause

`core/src/domain/common/services.rs` seeded the admin password by calling `create_credential` unconditionally and treating the resulting failure as "already exists":

```rust
match self.credential_repository.create_credential(user.id, "password".to_string(), hash, "".into(), false).await {
    Ok(_)  => tracing::info!("credential created for user {:}", user.username),
    Err(_) => tracing::info!("credential already exists for user {:}", user.username),
}
```

The unique index was doing the job an existence check should do — a database constraint violation used as a control-flow branch.

The correct pattern was already in the same function, twenty lines below: the redirect URI seeding reads the existing values, compares, and only creates what is missing. This now does the same, using `get_password_credential`, which the port has always exposed.

## A second defect, hidden by the first

The `Err(_)` arm claimed "already exists" for **every** failure. A genuine problem — database unreachable, column constraint, serialization failure — was reported as a routine skip at `INFO`, and the seeding moved on as if the admin had a password. It does not any more: a real creation failure now logs at `ERROR` with the actual error.

## Verified by running it, not by reasoning about it

Three boots against scratch databases, with the real binary:

| | before | after |
|---|---|---|
| fresh database | `INFO credential created for user admin` | `INFO credential created for user admin` |
| second boot, same database | `ERROR … 23505 …` then `INFO credential already exists` | `INFO credential already exists`, **0 `ERROR`, 0 `23505`** |
| `POST /token` password grant, admin/admin | — | **HTTP 200 with an `access_token`** |

The last row is the one that matters: the fix could have silently skipped seeding on a fresh install, so the check is that the admin can still actually log in.

## About the test

`seeding_twice_keeps_one_admin_password_and_does_not_rotate_it` runs `initialize_application` twice and asserts exactly one password credential survives, with the same `id` and the same `secret_data`.

**It is a guard, not a reproduction — it passes on the unfixed code too**, because the old behaviour ended in the same database state; the defect was only ever visible in the logs. The reproduction was running the binary, above.

What it does guard is the invariant someone could plausibly break while "simplifying" this: a delete-then-recreate would rotate the admin password on every restart, and both assertions catch that.

## Left alone, deliberately

`ADMIN_PASSWORD` still does **not** rotate an existing admin password. Changing it and restarting logs `credential already exists` and keeps the old one. That is the existing behaviour and arguably the right one — re-seeding should not silently undo a password the admin changed in the UI — but the flag is documented only as "The admin password to use", which does not say so. Worth its own decision; not smuggled into a log fix.

## Verification

```
cargo test -p ferriskey-core --lib                                313 passed, 15 ignored
cargo test -p ferriskey-core --lib seeding_twice -- --ignored       1 passed
cargo check --all-targets                                          ok
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   clean
cargo fmt --all --check                                            clean
```

Unrelated finding, not touched here: the API binary does not run migrations at startup. Pointing it at an unmigrated database fails with `relation "realms" does not exist` rather than anything actionable. `sqlx migrate run` / `just migrate` is the documented path, so this is working as designed — noting it because it cost me a confusing minute while reproducing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented application reinitialization from creating duplicate administrator password credentials.
  * Existing credential IDs and values are now preserved across repeated initialization.
  * Password hashing and credential creation failures are handled more safely during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->