### PR TITLE
fix: stop asserting verified emails on self-registration and validate its input

### DIFF
--- a/api/tests/registration_test.rs
+++ b/api/tests/registration_test.rs
@@ -1,0 +1,350 @@
+#[cfg(test)]
+mod tests {
+    use std::{env, sync::Arc};
+
+    use axum::Router;
+    use axum::http::HeaderValue;
+    use axum_test::{TestResponse, TestServer};
+    use ferriskey_api::{
+        application::http::server::{app_state::AppState, http_server::router},
+        args::Args,
+    };
+    use ferriskey_core::{
+        application::create_service,
+        domain::common::{
+            DatabaseConfig, FerriskeyConfig, entities::StartupConfig, ports::CoreService,
+        },
+    };
+    use serde_json::{Value, json};
+    use sqlx::Executor;
+    use uuid::Uuid;
+
+    fn env_or(key: &str, default: &str) -> String {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+
+    fn env_u16_or(key: &str, default: u16) -> u16 {
+        env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    struct SharedContext {
+        app: std::sync::Mutex<Router>,
+        realm_name: String,
+    }
+
+    static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+
+    static CTX: std::sync::OnceLock<SharedContext> = std::sync::OnceLock::new();
+
+    fn rt() -> &'static tokio::runtime::Runtime {
+        RUNTIME.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build shared runtime")
+        })
+    }
+
+    fn shared_ctx() -> &'static SharedContext {
+        CTX.get_or_init(|| rt().block_on(init_shared_ctx()))
+    }
+
+    async fn init_shared_ctx() -> SharedContext {
+        let db_host = env_or("DATABASE_HOST", "localhost");
+        let db_port = env_u16_or("DATABASE_PORT", 5432);
+        let db_name = env_or("DATABASE_NAME", "ferriskey");
+        let db_user = env_or("DATABASE_USER", "ferriskey");
+        let db_password = env_or("DATABASE_PASSWORD", "ferriskey");
+
+        let schema = format!("registration_test_{}", Uuid::new_v4().simple());
+
+        let admin_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+
+        let admin_pool = sqlx::PgPool::connect(&admin_url)
+            .await
+            .expect("connect admin pool");
+
+        admin_pool
+            .execute(sqlx::query(&format!(
+                "CREATE SCHEMA IF NOT EXISTS \"{}\"",
+                schema
+            )))
+            .await
+            .expect("create schema");
+
+        let schema_url = format!(
+            "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
+            db_user,
+            db_password,
+            db_host,
+            db_port,
+            db_name,
+            urlencoding::encode(&schema)
+        );
+
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+
+        sqlx::migrate!("../core/migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let service = create_service(FerriskeyConfig {
+            webapp_url: "http://localhost:5555".to_string(),
+            database: DatabaseConfig {
+                host: db_host,
+                port: db_port,
+                username: db_user,
+                password: db_password,
+                name: db_name,
+                schema: schema.clone(),
+            },
+        })
+        .await
+        .expect("create service");
+
+        let realm_name = format!("realm-{}", Uuid::new_v4().simple());
+
+        service
+            .initialize_application(StartupConfig {
+                webapp_url: "http://localhost:5555".to_string(),
+                master_realm_name: realm_name.clone(),
+                admin_username: "admin".to_string(),
+                admin_password: "admin".to_string(),
+                admin_email: "admin@test.local".to_string(),
+                default_client_id: "ferriskey-admin".to_string(),
+            })
+            .await
+            .expect("initialize application");
+
+        let args = Arc::new(Args::default());
+        let state = AppState::new(args, service.clone());
+        let app = router(state).expect("build router");
+
+        SharedContext {
+            app: std::sync::Mutex::new(app),
+            realm_name,
+        }
+    }
+
+    fn make_server() -> TestServer {
+        let ctx = shared_ctx();
+        let app = ctx.app.lock().expect("router mutex poisoned").clone();
+        TestServer::new(app).expect("create test server")
+    }
+
+    fn realm() -> &'static str {
+        shared_ctx().realm_name.as_str()
+    }
+
+    async fn get_admin_token(server: &TestServer) -> String {
+        let response = server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/token",
+                realm()
+            ))
+            .form(&[
+                ("grant_type", "password"),
+                ("client_id", "admin-cli"),
+                ("username", "admin"),
+                ("password", "admin"),
+            ])
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            200,
+            "admin token request failed: {}",
+            response.text()
+        );
+        let body: Value = response.json();
+        body["access_token"]
+            .as_str()
+            .expect("access_token in response")
+            .to_string()
+    }
+
+    fn auth_header(token: &str) -> HeaderValue {
+        format!("Bearer {}", token).parse().unwrap()
+    }
+
+    fn enable_self_registration(server: &TestServer, token: &str) {
+        rt().block_on(async {
+            let response = server
+                .put(&format!("/realms/{}/settings", realm()))
+                .add_header("Authorization", auth_header(token))
+                .json(&json!({ "user_registration_enabled": true }))
+                .await;
+
+            assert_eq!(
+                response.status_code(),
+                200,
+                "enabling self-registration failed: {}",
+                response.text()
+            );
+        });
+    }
+
+    async fn register(server: &TestServer, body: Value) -> TestResponse {
+        server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/registrations",
+                realm()
+            ))
+            .json(&body)
+            .await
+    }
+
+    fn strong_password(seed: &str) -> String {
+        format!("Zq7!{seed}xV2#pLm9")
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test registration_test -- --ignored"]
+    fn a_self_registered_account_is_never_marked_verified() {
+        let server = make_server();
+        let admin = rt().block_on(get_admin_token(&server));
+        enable_self_registration(&server, &admin);
+
+        rt().block_on(async {
+            let username = format!("self-{}", Uuid::new_v4().simple());
+            let email = format!("{username}@example.com");
+
+            let response = register(
+                &server,
+                json!({
+                    "username": username,
+                    "email": email,
+                    "password": strong_password("Ab"),
+                }),
+            )
+            .await;
+
+            assert_eq!(
+                response.status_code(),
+                201,
+                "registration failed: {}",
+                response.text()
+            );
+
+            let listed = server
+                .get(&format!("/realms/{}/users", realm()))
+                .add_header("Authorization", auth_header(&admin))
+                .await;
+            assert_eq!(listed.status_code(), 200, "listing users: {}", listed.text());
+
+            let body: Value = listed.json();
+            let created = body["data"]
+                .as_array()
+                .expect("user list")
+                .iter()
+                .find(|u| u["username"] == username.as_str())
+                .unwrap_or_else(|| panic!("the registered user must exist: {body}"));
+
+            assert_eq!(
+                created["email_verified"], false,
+                "nobody proved control of this address, so the claim must not assert otherwise: {created}"
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test registration_test -- --ignored"]
+    fn a_registration_body_without_credentials_is_refused() {
+        let server = make_server();
+        let admin = rt().block_on(get_admin_token(&server));
+        enable_self_registration(&server, &admin);
+
+        rt().block_on(async {
+            let empty = register(&server, json!({})).await;
+            assert_ne!(
+                empty.status_code(),
+                201,
+                "an empty body must not create an account: {}",
+                empty.text()
+            );
+
+            let blank = register(
+                &server,
+                json!({ "username": "", "email": "", "password": "" }),
+            )
+            .await;
+            assert_ne!(
+                blank.status_code(),
+                201,
+                "blank identifiers must not squat the realm's empty values: {}",
+                blank.text()
+            );
+
+            let malformed = register(
+                &server,
+                json!({
+                    "username": format!("u-{}", Uuid::new_v4().simple()),
+                    "email": "not-an-address",
+                    "password": strong_password("Cd"),
+                }),
+            )
+            .await;
+            assert_ne!(
+                malformed.status_code(),
+                201,
+                "a malformed address must be refused: {}",
+                malformed.text()
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test registration_test -- --ignored"]
+    fn an_address_differing_only_by_case_cannot_be_registered_twice() {
+        let server = make_server();
+        let admin = rt().block_on(get_admin_token(&server));
+        enable_self_registration(&server, &admin);
+
+        rt().block_on(async {
+            let seed = Uuid::new_v4().simple().to_string();
+            let email = format!("Case-{seed}@Example.com");
+
+            let first = register(
+                &server,
+                json!({
+                    "username": format!("first-{seed}"),
+                    "email": email,
+                    "password": strong_password("Ef"),
+                }),
+            )
+            .await;
+            assert_eq!(
+                first.status_code(),
+                201,
+                "the first registration must succeed: {}",
+                first.text()
+            );
+
+            let second = register(
+                &server,
+                json!({
+                    "username": format!("second-{seed}"),
+                    "email": email.to_lowercase(),
+                    "password": strong_password("Gh"),
+                }),
+            )
+            .await;
+
+            assert!(
+                second.status_code().is_client_error(),
+                "the same address in another case must be refused as a client error, neither created nor a server error: {} {}",
+                second.status_code(),
+                second.text()
+            );
+        });
+    }
+}

--- a/core/migrations/20260820120000_case_insensitive_login_identifiers.down.sql
+++ b/core/migrations/20260820120000_case_insensitive_login_identifiers.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS unique_lower_username_per_realm;
+DROP INDEX IF EXISTS unique_lower_email_per_realm;
+
+ALTER TABLE users ADD CONSTRAINT unique_username_realm_id UNIQUE (username, realm_id);
+ALTER TABLE users ADD CONSTRAINT unique_email_per_realm UNIQUE (email, realm_id);

--- a/core/migrations/20260820120000_case_insensitive_login_identifiers.up.sql
+++ b/core/migrations/20260820120000_case_insensitive_login_identifiers.up.sql
@@ -1,0 +1,33 @@
+UPDATE users SET email = trim(email) WHERE email IS NOT NULL AND email <> trim(email);
+UPDATE users SET username = trim(username) WHERE username <> trim(username);
+UPDATE users SET email = NULL WHERE email = '';
+
+DO $$
+DECLARE
+    conflicts text;
+BEGIN
+    SELECT string_agg(format('realm %s: %s', realm_id, identifiers), E'\n')
+    INTO conflicts
+    FROM (
+        SELECT realm_id, string_agg(DISTINCT email, ', ') AS identifiers
+        FROM users
+        WHERE email IS NOT NULL
+        GROUP BY realm_id, lower(email)
+        HAVING count(*) > 1
+        UNION ALL
+        SELECT realm_id, string_agg(DISTINCT username, ', ') AS identifiers
+        FROM users
+        GROUP BY realm_id, lower(username)
+        HAVING count(*) > 1
+    ) AS duplicated;
+
+    IF conflicts IS NOT NULL THEN
+        RAISE EXCEPTION E'Accounts differing only by letter case share a login identifier and must be resolved before this migration can enforce uniqueness. Merge or rename them, then run the migration again.\n%', conflicts;
+    END IF;
+END $$;
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS unique_email_per_realm;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS unique_username_realm_id;
+
+CREATE UNIQUE INDEX unique_lower_email_per_realm ON users (realm_id, lower(email)) WHERE email IS NOT NULL;
+CREATE UNIQUE INDEX unique_lower_username_per_realm ON users (realm_id, lower(username));

--- a/core/src/application/services.rs
+++ b/core/src/application/services.rs
@@ -558,14 +558,28 @@ impl ApplicationService {
         realm_name: String,
         password: &str,
     ) -> Result<(), CoreError> {
+        self.validate_password_policy_for_identity(realm_name, password, None, None)
+            .await
+    }
+
+    pub async fn validate_password_policy_for_identity(
+        &self,
+        realm_name: String,
+        password: &str,
+        username: Option<&str>,
+        email: Option<&str>,
+    ) -> Result<(), CoreError> {
         let realm = self
             .realm_service
             .realm_repository
             .get_by_name(&realm_name)
             .await?
             .ok_or(CoreError::InvalidRealm)?;
+
+        let email_local = email.and_then(|value| value.split('@').next());
+
         self.password_policy_service
-            .enforce(realm.id.into(), password)
+            .enforce_for_identity(realm.id.into(), password, username, email_local)
             .await
     }
 

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -301,6 +301,10 @@ fn temporary_token_lifetime(realm_settings: Option<&RealmSetting>) -> i64 {
 /// Constant-time comparison of a configured client secret against the one
 /// presented on the token endpoint. `(None, None)` means "no secret configured
 /// and none presented", which is only ever reached for public clients.
+pub(crate) fn normalize_login_email(email: &str) -> String {
+    email.trim().to_lowercase()
+}
+
 pub(crate) fn client_secret_matches(stored: Option<&str>, provided: Option<&str>) -> bool {
     match (stored, provided) {
         (Some(s), Some(p)) => {
@@ -1691,6 +1695,43 @@ where
             .map_err(|_| CoreError::InternalServerError)?;
 
         Ok(is_valid)
+    }
+
+    async fn refuse_login_identifier_collision(
+        &self,
+        realm: &crate::domain::realm::entities::Realm,
+        username: &str,
+        email: &str,
+    ) -> Result<(), CoreError> {
+        let aliases = realm
+            .settings
+            .as_ref()
+            .map(|settings| settings.login_aliases.clone())
+            .unwrap_or_default();
+
+        if aliases.as_slice().len() < 2 {
+            return Ok(());
+        }
+
+        if self
+            .user_repository
+            .get_by_email(username, realm.id)
+            .await?
+            .is_some()
+        {
+            return Err(CoreError::UsernameAlreadyExists);
+        }
+
+        if self
+            .user_repository
+            .find_by_username(email.to_string(), realm.id)
+            .await?
+            .is_some()
+        {
+            return Err(CoreError::EmailAlreadyExists);
+        }
+
+        Ok(())
     }
 
     async fn resolve_pending_auth_step(
@@ -3594,23 +3635,33 @@ where
         let firstname = input.first_name;
         let lastname = input.last_name;
 
+        let email = normalize_login_email(&input.email);
+        let username = input.username.trim().to_string();
+
+        if email.is_empty() || username.is_empty() {
+            return Err(CoreError::InvalidRequest);
+        }
+
         let email_verification_enabled = realm
             .settings
             .as_ref()
             .map(|s| s.email_verification_enabled)
             .unwrap_or(false);
 
+        self.refuse_login_identifier_collision(&realm, &username, &email)
+            .await?;
+
         let user = self
             .user_repository
             .create_user(CreateUserRequest {
                 client_id: None,
-                email: Some(input.email),
-                email_verified: !email_verification_enabled,
+                email: Some(email),
+                email_verified: false,
                 enabled: true,
                 firstname,
                 lastname,
                 realm_id: realm.id,
-                username: input.username,
+                username,
             })
             .await?;
 

--- a/core/src/infrastructure/user/repository.rs
+++ b/core/src/infrastructure/user/repository.rs
@@ -26,12 +26,16 @@ fn classify_user_unique_violation_message(message: &str) -> Option<UserUniqueVio
     let err_str = message.to_lowercase();
 
     if err_str.contains("unique_username_realm_id")
+        || err_str.contains("unique_lower_username_per_realm")
         || err_str.contains("key (username")
+        || err_str.contains("key (realm_id, lower(username")
         || err_str.contains("username, realm_id")
     {
         Some(UserUniqueViolation::Username)
     } else if err_str.contains("unique_email_per_realm")
+        || err_str.contains("unique_lower_email_per_realm")
         || err_str.contains("key (email")
+        || err_str.contains("key (realm_id, lower(email")
         || err_str.contains("email, realm_id")
     {
         Some(UserUniqueViolation::Email)
@@ -113,7 +117,12 @@ impl UserRepository for PostgresUserRepository {
         realm_id: RealmId,
     ) -> Result<Option<User>, CoreError> {
         let users_model = crate::entity::users::Entity::find()
-            .filter(crate::entity::users::Column::Username.eq(username.clone()))
+            .filter(
+                sea_orm::sea_query::Expr::expr(sea_orm::sea_query::Func::lower(
+                    sea_orm::sea_query::Expr::col(crate::entity::users::Column::Username),
+                ))
+                .eq(username.trim().to_lowercase()),
+            )
             .filter(crate::entity::users::Column::RealmId.eq::<Uuid>(realm_id.into()))
             .find_also_related(crate::entity::realms::Entity)
             .all(&self.db)
@@ -231,7 +240,12 @@ impl UserRepository for PostgresUserRepository {
         realm_id: RealmId,
     ) -> Result<Option<User>, CoreError> {
         let user = crate::entity::users::Entity::find()
-            .filter(crate::entity::users::Column::Email.eq(email))
+            .filter(
+                sea_orm::sea_query::Expr::expr(sea_orm::sea_query::Func::lower(
+                    sea_orm::sea_query::Expr::col(crate::entity::users::Column::Email),
+                ))
+                .eq(email.trim().to_lowercase()),
+            )
             .filter(crate::entity::users::Column::RealmId.eq::<Uuid>(realm_id.into()))
             .one(&self.db)
             .await
@@ -406,6 +420,23 @@ mod tests {
 
         assert_eq!(
             classify_user_unique_violation_message(message),
+            Some(UserUniqueViolation::Email)
+        );
+    }
+
+    #[test]
+    fn classifies_the_case_insensitive_indexes() {
+        assert_eq!(
+            classify_user_unique_violation_message(
+                r#"ERROR: duplicate key value violates unique constraint "unique_lower_username_per_realm""#
+            ),
+            Some(UserUniqueViolation::Username)
+        );
+
+        assert_eq!(
+            classify_user_unique_violation_message(
+                r#"ERROR: duplicate key value violates unique constraint "unique_lower_email_per_realm""#
+            ),
             Some(UserUniqueViolation::Email)
         );
     }

--- a/libs/ferriskey-api-authentication/src/handlers/registration.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/registration.rs
@@ -25,14 +25,19 @@ use ferriskey_api_core::{
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct RegistrationRequest {
-    #[serde(default)]
+    #[validate(length(min = 1, max = 255, message = "username is required"))]
     pub username: String,
-    #[serde(default)]
+    #[validate(
+        email(message = "email must be a valid address"),
+        length(max = 255, message = "email is too long")
+    )]
     pub email: String,
-    #[serde(default)]
+    #[validate(length(min = 1, message = "password is required"))]
     pub password: String,
 
+    #[validate(length(max = 255, message = "first_name is too long"))]
     pub first_name: Option<String>,
+    #[validate(length(max = 255, message = "last_name is too long"))]
     pub last_name: Option<String>,
 }
 
@@ -107,7 +112,12 @@ pub async fn registration_handler(
 
     state
         .service
-        .validate_password_policy(realm_name.clone(), &req.password)
+        .validate_password_policy_for_identity(
+            realm_name.clone(),
+            &req.password,
+            Some(req.username.trim()),
+            Some(req.email.trim()),
+        )
         .await?;
 
     let url_context = registration_url_context(
@@ -169,15 +179,26 @@ mod tests {
     }
 
     #[test]
-    fn test_registration_request_deserialization_with_defaults() {
-        let json = r#"{}"#;
+    fn an_empty_body_is_rejected_rather_than_defaulted() {
+        let parsed = serde_json::from_str::<RegistrationRequest>(r#"{}"#);
 
-        let request: RegistrationRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(request.username, "");
-        assert_eq!(request.email, "");
-        assert_eq!(request.password, "");
-        assert_eq!(request.first_name, None);
-        assert_eq!(request.last_name, None);
+        assert!(
+            parsed.is_err(),
+            "username, email and password are required: a bare body must not deserialize into empty strings"
+        );
+    }
+
+    #[test]
+    fn a_blank_username_or_malformed_email_is_refused() {
+        let request: RegistrationRequest =
+            serde_json::from_str(r#"{"username": "", "email": "not-an-address", "password": "x"}"#)
+                .expect("the shape is valid, the values are not");
+
+        let errors = request.validate().expect_err("validation must reject this");
+        let fields = errors.field_errors();
+
+        assert!(fields.contains_key("username"), "errors: {fields:?}");
+        assert!(fields.contains_key("email"), "errors: {fields:?}");
     }
 
     #[test]

--- a/libs/ferriskey-password-policy/src/service.rs
+++ b/libs/ferriskey-password-policy/src/service.rs
@@ -72,16 +72,23 @@ where
     }
 
     pub async fn enforce(&self, realm_id: Uuid, password: &str) -> Result<(), CoreError> {
+        self.enforce_for_identity(realm_id, password, None, None)
+            .await
+    }
+
+    pub async fn enforce_for_identity(
+        &self,
+        realm_id: Uuid,
+        password: &str,
+        username: Option<&str>,
+        email_local: Option<&str>,
+    ) -> Result<(), CoreError> {
         let policy = self
             .repository
             .find_by_realm_id(realm_id)
             .await?
             .unwrap_or_else(|| PasswordPolicy::default(realm_id));
-        // Use the full validator (entropy + common-password checks) so the pre-flight
-        // check matches the enforcement done later in `reset_password`. Username/email
-        // context is unavailable here, so those similarity checks run only in the
-        // credential flow where the target user is known.
-        validator::validate(password, &policy, None, None).map_err(|errors| {
+        validator::validate(password, &policy, username, email_local).map_err(|errors| {
             let violations: Vec<PasswordPolicyViolation> = errors.iter().map(Into::into).collect();
             CoreError::PasswordPolicyViolation(
                 serde_json::to_string(&violations).unwrap_or_default(),


### PR DESCRIPTION
## Context

FK-016. Self-registration asserted a claim nobody had earned, behind an endpoint that validated nothing.

`register_user` wrote `email_verified: !email_verification_enabled`. That setting defaults to `false` — twice over, both in `RealmSetting::new` and in the `unwrap_or(false)` fallback — so on a default realm **every self-registered account was written with `email_verified: true` having never proven control of the address**. The claim is not internal: `email` is a default scope, its `email_verified` mapper is wired into the access token and the id_token, and `/userinfo` returns it verbatim. A relying party keying on `(iss, email, email_verified)` — the use OIDC Core defines, where the claim MUST mean the address was verified — granted access on an arbitrary address.

Alongside it, `RegistrationRequest` derived `Validate` with **zero** `#[validate]` attributes and carried `#[serde(default)]` on username, email and password, so `POST {}` deserialized into three empty strings. A unit test asserted exactly that, freezing the permissive behaviour.

Reproduced against the unpatched build: registration returns `201` with a JWT carrying `"email":"not-an-address"`, and the created account reads back `email_verified: true`.

## Change

**The claim tells the truth.** `email_verified` is now `false` unconditionally at self-registration. Nobody proved anything, so the token says nothing.

**Deliberate deviation from the finding**, worth review: it asks to also set the `VerifyEmail` required action *in all cases*. I did not. Sending the mail stays conditional on the realm setting, so on a realm with verification disabled that would strand every new account behind a step no email ever arrives to complete. Setting the claim to `false` removes the lie without creating a lockout; posing an unsatisfiable action would trade one defect for a worse one.

**The input contract is enforced.** `username` is `length(min = 1, max = 255)`, `email` is `email` + `length(max = 255)`, `password` is `length(min = 1)`, and the optional names are bounded. `#[serde(default)]` is gone from the required fields, so an absent field is a deserialization error rather than an empty string. The test that froze the old behaviour is replaced by two that require the refusal.

**Identifiers are compared without regard to case.** Registration trims and lowercases the address; `find_by_username` and `get_by_email` compare on `lower(...)`; a migration replaces the two case-sensitive constraints with functional unique indexes on `(realm_id, lower(email))` and `(realm_id, lower(username))`. `Alice@corp.com` and `alice@corp.com` can no longer both exist, each marked verified and indistinguishable downstream.

**Alias-namespace collision is refused.** When a realm accepts more than one login alias, registering a username equal to another account's email — or the reverse — is rejected. Alias resolution returns on first match, so without this an attacker registering `username = "victim@corp.com"` captures the victim's email login: her password is checked against his credential, and her failed attempts lock *his* account.

**The password policy finally sees who it is protecting.** `enforce` was called with `None, None`, so the `forbid_common` username/email-similarity rule was inert on this path — a user could register with a password identical to their own username. `enforce_for_identity` threads the registrant's username and email local-part through. `enforce` remains as a thin wrapper, so no other call site changes.

## Verification

New suite `api/tests/registration_test.rs` — `api/tests/` had **no registration coverage at all**.

| Test | Asserts |
|---|---|
| `a_self_registered_account_is_never_marked_verified` | the created account reads back `email_verified: false` |
| `a_registration_body_without_credentials_is_refused` | empty body, blank identifiers and a malformed address are all refused |
| `an_address_differing_only_by_case_cannot_be_registered_twice` | the second registration is a client error — neither created nor a 500 |

All three fail on the unpatched tree.

```
cargo clippy --all --all-targets --exclude ferriskey-client -- -D warnings   # clean
cargo fmt --all -- --check                                                    # clean
cargo test --workspace                                                        # 0 failures
13 DB suites (11 wired + registration + web_origin)                           # all green
```

`login_aliases_test` fails on `Failed to set global recorder` (#1086). Verified identical on the unmodified tree — it is one of the six suites not wired into CI for that reason.

## A defect this change introduced, found and fixed

The migration renames the uniqueness constraints, and `classify_user_unique_violation` matched the **old names**. A duplicate registration therefore returned `500` to an unauthenticated caller instead of a classified conflict. The classifier now knows both the old constraint names and the new index names, covered by a unit test.

I found it only because the integration test asserted the *shape* of the refusal rather than merely "not created". An assertion of `!= 201` alone would have passed on the 500.

## Migration behaviour on existing data

The migration trims whitespace, then **aborts with the list of conflicting rows** if any accounts in a realm differ only by letter case. It does not merge, rename or null anything: these are identity records, and silently collapsing two accounts — or emptying one's address — is worse than asking an operator to decide. The exception names each realm and the addresses involved.

## Not in this PR

- Admin user creation is unchanged. It already normalizes through `normalize_optional_email` (trim only) and is gated behind `ManageUsers`; making it lowercase-normalize too would be consistent but belongs with a review of that path.
- `CreateUserValidator` still has no `#[validate(email)]` on its optional address.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login usernames and email addresses are now matched case-insensitively.
  * Registration normalizes identifiers and prevents duplicate accounts using different capitalization.
  * Password policies now consider username and email context.
* **Bug Fixes**
  * Registration rejects missing, blank, malformed, or oversized identity fields.
  * New registrations are initially marked with unverified email addresses.
  * Improved validation and clearer duplicate-identifier handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->