### PR TITLE
feat: derive a self-signed x509 certificate from the realm signing key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2121,7 @@ dependencies = [
  "jsonwebtoken",
  "mockall 0.14.0",
  "rand 0.8.5",
+ "rcgen",
  "rsa",
  "serde",
  "serde_json",
@@ -2119,6 +2129,7 @@ dependencies = [
  "thiserror 2.0.20",
  "utoipa",
  "uuid",
+ "x509-parser 0.18.0",
 ]
 
 [[package]]
@@ -4481,6 +4492,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.18.0",
+ "yasna",
 ]
 
 [[package]]
@@ -7285,6 +7310,7 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry 0.8.1",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.20",
  "time",
@@ -7301,6 +7327,16 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/core/migrations/20260826100000_add_certificate_to_jwt_keys.down.sql
+++ b/core/migrations/20260826100000_add_certificate_to_jwt_keys.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS jwt_keys_realm_id_key;
+
+ALTER TABLE jwt_keys DROP COLUMN IF EXISTS certificate;
+
+INSERT INTO jwt_keys (id, realm_id, private_key, public_key, created_at)
+SELECT id, realm_id, private_key, public_key, created_at
+FROM jwt_keys_superseded
+ON CONFLICT (id) DO NOTHING;
+
+DROP TABLE IF EXISTS jwt_keys_superseded;

--- a/core/migrations/20260826100000_add_certificate_to_jwt_keys.up.sql
+++ b/core/migrations/20260826100000_add_certificate_to_jwt_keys.up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS jwt_keys_superseded (
+    id UUID PRIMARY KEY,
+    realm_id UUID NOT NULL REFERENCES realms(id) ON DELETE CASCADE,
+    private_key TEXT NOT NULL,
+    public_key TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    superseded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+WITH ranked_realm_keys AS (
+    SELECT
+        id,
+        realm_id,
+        private_key,
+        public_key,
+        created_at,
+        ROW_NUMBER() OVER (PARTITION BY realm_id ORDER BY ctid) AS scan_position
+    FROM jwt_keys
+),
+archived_realm_keys AS (
+    INSERT INTO jwt_keys_superseded (id, realm_id, private_key, public_key, created_at)
+    SELECT id, realm_id, private_key, public_key, created_at
+    FROM ranked_realm_keys
+    WHERE scan_position > 1
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+DELETE FROM jwt_keys
+WHERE id IN (SELECT id FROM archived_realm_keys);
+
+ALTER TABLE jwt_keys ADD COLUMN IF NOT EXISTS certificate TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS jwt_keys_realm_id_key ON jwt_keys (realm_id);

--- a/core/src/entity/jwt_keys_superseded.rs
+++ b/core/src/entity/jwt_keys_superseded.rs
@@ -7,7 +7,7 @@ pub struct Entity;
 
 impl EntityName for Entity {
     fn table_name(&self) -> &str {
-        "jwt_keys"
+        "jwt_keys_superseded"
     }
 }
 
@@ -18,7 +18,7 @@ pub struct Model {
     pub private_key: String,
     pub public_key: String,
     pub created_at: DateTime,
-    pub certificate: Option<String>,
+    pub superseded_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -28,7 +28,7 @@ pub enum Column {
     PrivateKey,
     PublicKey,
     CreatedAt,
-    Certificate,
+    SupersededAt,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -53,11 +53,11 @@ impl ColumnTrait for Column {
     fn def(&self) -> ColumnDef {
         match self {
             Self::Id => ColumnType::Uuid.def(),
-            Self::RealmId => ColumnType::Uuid.def().unique(),
+            Self::RealmId => ColumnType::Uuid.def(),
             Self::PrivateKey => ColumnType::Text.def(),
             Self::PublicKey => ColumnType::Text.def(),
             Self::CreatedAt => ColumnType::DateTime.def(),
-            Self::Certificate => ColumnType::Text.def().null(),
+            Self::SupersededAt => ColumnType::DateTime.def(),
         }
     }
 }

--- a/core/src/entity/mod.rs
+++ b/core/src/entity/mod.rs
@@ -22,6 +22,7 @@ pub mod email_verification_tokens;
 pub mod identity_provider_links;
 pub mod identity_providers;
 pub mod jwt_keys;
+pub mod jwt_keys_superseded;
 pub mod login_action_tokens;
 pub mod magic_links;
 pub mod organization_attributes;

--- a/core/src/entity/prelude.rs
+++ b/core/src/entity/prelude.rs
@@ -20,6 +20,7 @@ pub use super::email_verification_tokens::Entity as EmailVerificationTokens;
 pub use super::identity_provider_links::Entity as IdentityProviderLinks;
 pub use super::identity_providers::Entity as IdentityProviders;
 pub use super::jwt_keys::Entity as JwtKeys;
+pub use super::jwt_keys_superseded::Entity as JwtKeysSuperseded;
 pub use super::magic_links::Entity as MagicLinks;
 pub use super::organization_attributes::Entity as OrganizationAttributes;
 pub use super::organization_members::Entity as OrganizationMembers;

--- a/core/src/entity/realms.rs
+++ b/core/src/entity/realms.rs
@@ -54,6 +54,7 @@ pub enum Relation {
     EmailVerificationTokens,
     IdentityProviders,
     JwtKeys,
+    JwtKeysSuperseded,
     MagicLinks,
     Organizations,
     PasswordPolicy,
@@ -105,6 +106,7 @@ impl RelationTrait for Relation {
             }
             Self::IdentityProviders => Entity::has_many(super::identity_providers::Entity).into(),
             Self::JwtKeys => Entity::has_many(super::jwt_keys::Entity).into(),
+            Self::JwtKeysSuperseded => Entity::has_many(super::jwt_keys_superseded::Entity).into(),
             Self::MagicLinks => Entity::has_many(super::magic_links::Entity).into(),
             Self::Organizations => Entity::has_many(super::organizations::Entity).into(),
             Self::PasswordPolicy => Entity::has_one(super::password_policy::Entity).into(),
@@ -188,6 +190,12 @@ impl Related<super::email_verification_tokens::Entity> for Entity {
 impl Related<super::identity_providers::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::IdentityProviders.def()
+    }
+}
+
+impl Related<super::jwt_keys_superseded::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::JwtKeysSuperseded.def()
     }
 }
 

--- a/core/src/infrastructure/repositories/keystore_repository.rs
+++ b/core/src/infrastructure/repositories/keystore_repository.rs
@@ -1,6 +1,8 @@
 use ferriskey_security::jwt::ports::KeyStoreRepository;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    ActiveValue::Set,
+    ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    sea_query::{Expr, OnConflict},
 };
 use uuid::Uuid;
 
@@ -9,21 +11,7 @@ use crate::domain::{
     common::generate_uuid_v7,
     jwt::{JwtError, entities::JwtKeyPair},
 };
-
-impl TryFrom<crate::entity::jwt_keys::Model> for JwtKeyPair {
-    type Error = JwtError;
-
-    fn try_from(value: crate::entity::jwt_keys::Model) -> Result<Self, Self::Error> {
-        let jwt_key_pair = JwtKeyPair::from_pem(
-            &value.private_key,
-            &value.public_key,
-            value.realm_id,
-            value.id,
-        )?;
-
-        Ok(jwt_key_pair)
-    }
-}
+use crate::entity::{jwt_keys, realms};
 
 #[derive(Debug, Clone)]
 pub struct PostgresKeyStoreRepository {
@@ -34,39 +22,277 @@ impl PostgresKeyStoreRepository {
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }
+
+    async fn find_by_realm(&self, realm_id: Uuid) -> Result<Option<jwt_keys::Model>, JwtError> {
+        jwt_keys::Entity::find()
+            .filter(jwt_keys::Column::RealmId.eq(realm_id))
+            .one(&self.db)
+            .await
+            .map_err(|_| JwtError::RealmKeyNotFound)
+    }
+
+    async fn certificate_common_name(&self, realm_id: Uuid) -> Result<String, JwtError> {
+        realms::Entity::find_by_id(realm_id)
+            .one(&self.db)
+            .await
+            .map_err(|e| JwtError::GenerationError(e.to_string()))?
+            .map(|realm| realm.name)
+            .ok_or(JwtError::RealmKeyNotFound)
+    }
+
+    async fn generate_key(&self, realm_id: Uuid) -> Result<jwt_keys::Model, JwtError> {
+        let common_name = self.certificate_common_name(realm_id).await?;
+        let (private_key, public_key) = JwtKeyPair::generate()?;
+        let certificate = JwtKeyPair::self_signed_certificate(&private_key, &common_name)?;
+
+        let new_key = jwt_keys::ActiveModel {
+            id: Set(generate_uuid_v7()),
+            realm_id: Set(realm_id),
+            public_key: Set(public_key),
+            private_key: Set(private_key),
+            certificate: Set(Some(certificate)),
+            created_at: Set(chrono::Utc::now().naive_utc()),
+        };
+
+        jwt_keys::Entity::insert(new_key)
+            .on_conflict(
+                OnConflict::column(jwt_keys::Column::RealmId)
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .exec_without_returning(&self.db)
+            .await
+            .map_err(|e| JwtError::GenerationError(e.to_string()))?;
+
+        self.find_by_realm(realm_id)
+            .await?
+            .ok_or(JwtError::RealmKeyNotFound)
+    }
+
+    async fn backfill_certificate(
+        &self,
+        key: &jwt_keys::Model,
+    ) -> Result<jwt_keys::Model, JwtError> {
+        let common_name = self.certificate_common_name(key.realm_id).await?;
+        let certificate = JwtKeyPair::self_signed_certificate(&key.private_key, &common_name)?;
+
+        jwt_keys::Entity::update_many()
+            .col_expr(jwt_keys::Column::Certificate, Expr::value(certificate))
+            .filter(jwt_keys::Column::Id.eq(key.id))
+            .filter(jwt_keys::Column::Certificate.is_null())
+            .exec(&self.db)
+            .await
+            .map_err(|e| JwtError::GenerationError(e.to_string()))?;
+
+        self.find_by_realm(key.realm_id)
+            .await?
+            .ok_or(JwtError::RealmKeyNotFound)
+    }
 }
 
 impl KeyStoreRepository for PostgresKeyStoreRepository {
     async fn get_or_generate_key(&self, realm_id: RealmId) -> Result<JwtKeyPair, JwtError> {
-        let key = crate::entity::jwt_keys::Entity::find()
-            .filter(crate::entity::jwt_keys::Column::RealmId.eq::<Uuid>(realm_id.into()))
-            .one(&self.db)
-            .await
-            .map_err(|_| JwtError::RealmKeyNotFound)?;
+        let realm_id: Uuid = realm_id.into();
 
-        if let Some(key) = key {
-            return key.try_into();
-        }
-
-        let id = generate_uuid_v7();
-
-        // Generate a new key pair
-        let (private_key, public_key) = JwtKeyPair::generate()?;
-
-        let new_key = crate::entity::jwt_keys::ActiveModel {
-            id: Set(id),
-            realm_id: Set(realm_id.into()),
-            public_key: Set(public_key),
-            private_key: Set(private_key),
-            created_at: Set(chrono::Utc::now().naive_utc()),
+        let key = match self.find_by_realm(realm_id).await? {
+            Some(key) => key,
+            None => self.generate_key(realm_id).await?,
         };
 
-        // Insert the new key into the database
-        let result = new_key
-            .insert(&self.db)
-            .await
-            .map_err(|e| JwtError::GenerationError(e.to_string()))?;
+        let key = if key.certificate.is_some() {
+            key
+        } else {
+            self.backfill_certificate(&key).await?
+        };
 
-        result.try_into()
+        let certificate = key.certificate.ok_or(JwtError::RealmKeyNotFound)?;
+
+        JwtKeyPair::from_pem(
+            &key.private_key,
+            &key.public_key,
+            &certificate,
+            key.realm_id,
+            key.id,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::Database as SeaOrmDatabase;
+    use sqlx::Executor as _;
+    use x509_parser::pem::parse_x509_pem;
+
+    struct Fixture {
+        repository: PostgresKeyStoreRepository,
+        pool: sqlx::PgPool,
+    }
+
+    async fn setup() -> Fixture {
+        let base_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+            "postgres://ferriskey:ferriskey@localhost:5432/ferriskey".to_string()
+        });
+
+        let schema = format!("keystore_repository_test_{}", Uuid::new_v4().simple());
+
+        let admin_pool = sqlx::PgPool::connect(&base_url)
+            .await
+            .expect("connect admin pool");
+        admin_pool
+            .execute(sqlx::query(&format!(r#"CREATE SCHEMA "{}""#, schema)))
+            .await
+            .expect("create test schema");
+
+        let separator = if base_url.contains('?') { '&' } else { '?' };
+        let schema_url = format!("{base_url}{separator}options=-c search_path={schema}");
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let db = SeaOrmDatabase::connect(&schema_url)
+            .await
+            .expect("sea-orm connect");
+
+        Fixture {
+            repository: PostgresKeyStoreRepository::new(db),
+            pool,
+        }
+    }
+
+    async fn insert_realm(pool: &sqlx::PgPool, name: &str) -> RealmId {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO realms (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW())",
+        )
+        .bind(id)
+        .bind(name)
+        .execute(pool)
+        .await
+        .expect("insert realm");
+        RealmId::new(id)
+    }
+
+    async fn count_keys(pool: &sqlx::PgPool, realm_id: RealmId) -> i64 {
+        sqlx::query_scalar("SELECT count(*) FROM jwt_keys WHERE realm_id = $1")
+            .bind(Uuid::from(realm_id))
+            .fetch_one(pool)
+            .await
+            .expect("count keys")
+    }
+
+    fn common_name_of(certificate_pem: &str) -> String {
+        let (_, pem) =
+            parse_x509_pem(certificate_pem.as_bytes()).expect("certificate is valid PEM");
+        pem.parse_x509()
+            .expect("certificate is valid X.509")
+            .subject()
+            .to_string()
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-core -- --ignored"]
+    async fn a_realm_key_is_generated_once_with_a_certificate_for_the_realm() {
+        let fixture = setup().await;
+        let realm_id = insert_realm(&fixture.pool, "tenant-alpha").await;
+
+        let first = fixture
+            .repository
+            .get_or_generate_key(realm_id)
+            .await
+            .expect("generate realm key");
+
+        assert_eq!(common_name_of(&first.certificate), "CN=tenant-alpha");
+        assert_eq!(count_keys(&fixture.pool, realm_id).await, 1);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-core -- --ignored"]
+    async fn a_realm_key_is_stable_across_calls() {
+        let fixture = setup().await;
+        let realm_id = insert_realm(&fixture.pool, "tenant-beta").await;
+
+        let first = fixture
+            .repository
+            .get_or_generate_key(realm_id)
+            .await
+            .expect("generate realm key");
+        let second = fixture
+            .repository
+            .get_or_generate_key(realm_id)
+            .await
+            .expect("read realm key");
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.private_key, second.private_key);
+        assert_eq!(first.certificate, second.certificate);
+        assert_eq!(count_keys(&fixture.pool, realm_id).await, 1);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-core -- --ignored"]
+    async fn a_key_predating_certificates_is_backfilled_in_place() {
+        let fixture = setup().await;
+        let realm_id = insert_realm(&fixture.pool, "tenant-legacy").await;
+
+        let (private_key, public_key) = JwtKeyPair::generate().expect("generate legacy key");
+        let legacy_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO jwt_keys (id, realm_id, private_key, public_key, created_at) \
+             VALUES ($1, $2, $3, $4, NOW())",
+        )
+        .bind(legacy_id)
+        .bind(Uuid::from(realm_id))
+        .bind(&private_key)
+        .bind(&public_key)
+        .execute(&fixture.pool)
+        .await
+        .expect("insert legacy key");
+
+        let key_pair = fixture
+            .repository
+            .get_or_generate_key(realm_id)
+            .await
+            .expect("backfill certificate");
+
+        assert_eq!(key_pair.id, legacy_id);
+        assert_eq!(key_pair.private_key, private_key);
+        assert_eq!(common_name_of(&key_pair.certificate), "CN=tenant-legacy");
+        assert_eq!(count_keys(&fixture.pool, realm_id).await, 1);
+
+        let persisted: Option<String> =
+            sqlx::query_scalar("SELECT certificate FROM jwt_keys WHERE id = $1")
+                .bind(legacy_id)
+                .fetch_one(&fixture.pool)
+                .await
+                .expect("read back certificate");
+        assert_eq!(persisted.as_deref(), Some(key_pair.certificate.as_str()));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-core -- --ignored"]
+    async fn keys_of_two_realms_stay_distinct() {
+        let fixture = setup().await;
+        let alpha = insert_realm(&fixture.pool, "tenant-one").await;
+        let beta = insert_realm(&fixture.pool, "tenant-two").await;
+
+        let alpha_key = fixture
+            .repository
+            .get_or_generate_key(alpha)
+            .await
+            .expect("generate key for tenant-one");
+        let beta_key = fixture
+            .repository
+            .get_or_generate_key(beta)
+            .await
+            .expect("generate key for tenant-two");
+
+        assert_ne!(alpha_key.certificate, beta_key.certificate);
+        assert_eq!(common_name_of(&alpha_key.certificate), "CN=tenant-one");
+        assert_eq!(common_name_of(&beta_key.certificate), "CN=tenant-two");
     }
 }

--- a/libs/ferriskey-security/Cargo.toml
+++ b/libs/ferriskey-security/Cargo.toml
@@ -11,6 +11,11 @@ base64 = "0.22.1"
 chrono = "0.4.43"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 rand = "0.8.0"
+rcgen = { version = "0.14.9", default-features = false, features = [
+    "pem",
+    "crypto",
+    "ring",
+] }
 rsa = "0.9.10"
 serde = "1.0.228"
 serde_json = "1.0.149"
@@ -22,6 +27,7 @@ mockall = { version = "0.14.0", optional = true }
 
 [dev-dependencies]
 mockall = "0.14.0"
+x509-parser = "0.18.0"
 
 [features]
 mock = ["mockall"]

--- a/libs/ferriskey-security/src/jwt/entities.rs
+++ b/libs/ferriskey-security/src/jwt/entities.rs
@@ -1,8 +1,15 @@
 use std::collections::HashMap;
 
-use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
-use chrono::{DateTime, Utc};
+use base64::{
+    Engine,
+    prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD},
+};
+use chrono::{DateTime, Datelike, Utc};
 use jsonwebtoken::{DecodingKey, EncodingKey};
+use rcgen::{
+    CertificateParams, DistinguishedName, DnType, KeyPair as CertificateKeyPair, KeyUsagePurpose,
+    date_time_ymd,
+};
 use rsa::{
     RsaPrivateKey, RsaPublicKey,
     pkcs8::{DecodePublicKey, EncodePrivateKey, EncodePublicKey, LineEnding},
@@ -210,13 +217,17 @@ pub struct Jwt {
     pub expires_at: i64,
 }
 
+pub const CERTIFICATE_VALIDITY_YEARS: i32 = 10;
+
 #[derive(Clone)]
 pub struct JwtKeyPair {
     pub id: Uuid,
     pub realm_id: Uuid,
     pub encoding_key: EncodingKey,
     pub decoding_key: DecodingKey,
+    pub private_key: String,
     pub public_key: String,
+    pub certificate: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, ToSchema)]
@@ -352,6 +363,7 @@ impl JwtKeyPair {
     pub fn from_pem(
         private_pem: &str,
         public_pem: &str,
+        certificate_pem: &str,
         realm_id: Uuid,
         id: Uuid,
     ) -> Result<Self, SecurityError> {
@@ -366,8 +378,52 @@ impl JwtKeyPair {
             realm_id,
             encoding_key,
             decoding_key,
+            private_key: private_pem.to_string(),
             public_key: public_pem.to_string(),
+            certificate: certificate_pem.to_string(),
         })
+    }
+
+    pub fn self_signed_certificate(
+        private_pem: &str,
+        common_name: &str,
+    ) -> Result<String, SecurityError> {
+        let signing_key = CertificateKeyPair::from_pem(private_pem)
+            .map_err(|e| SecurityError::InvalidKey(e.to_string()))?;
+
+        let mut params = CertificateParams::new(vec![common_name.to_string()])
+            .or_else(|_| CertificateParams::new(Vec::new()))
+            .map_err(|e| SecurityError::GenerationError(e.to_string()))?;
+
+        let mut distinguished_name = DistinguishedName::new();
+        distinguished_name.push(DnType::CommonName, common_name);
+        params.distinguished_name = distinguished_name;
+
+        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+
+        let current_year = Utc::now().year();
+        params.not_before = date_time_ymd(current_year - 1, 1, 1);
+        params.not_after = date_time_ymd(current_year + CERTIFICATE_VALIDITY_YEARS, 1, 1);
+
+        let certificate = params
+            .self_signed(&signing_key)
+            .map_err(|e| SecurityError::GenerationError(e.to_string()))?;
+
+        Ok(certificate.pem())
+    }
+
+    pub fn certificate_base64_der(&self) -> Result<String, SecurityError> {
+        let body = self
+            .certificate
+            .lines()
+            .filter(|line| !line.starts_with("-----"))
+            .collect::<String>();
+
+        BASE64_STANDARD
+            .decode(&body)
+            .map_err(|e| SecurityError::ParsingError(e.to_string()))?;
+
+        Ok(body)
     }
 
     pub fn generate() -> Result<(String, String), SecurityError> {
@@ -415,7 +471,110 @@ impl JwtKeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rsa::pkcs8::EncodePublicKey;
     use uuid::Uuid;
+    use x509_parser::pem::parse_x509_pem;
+
+    #[test]
+    fn certificate_binds_the_existing_realm_key() {
+        let (private_pem, public_pem) = JwtKeyPair::generate().expect("generate realm key");
+        let certificate_pem = JwtKeyPair::self_signed_certificate(&private_pem, "master")
+            .expect("derive certificate");
+
+        let (_, pem) =
+            parse_x509_pem(certificate_pem.as_bytes()).expect("certificate is valid PEM");
+        assert_eq!(pem.label, "CERTIFICATE");
+
+        let certificate = pem.parse_x509().expect("certificate is valid X.509");
+
+        let expected_spki = RsaPublicKey::from_public_key_pem(&public_pem)
+            .expect("realm public key")
+            .to_public_key_der()
+            .expect("realm public key DER");
+
+        assert_eq!(certificate.public_key().raw, expected_spki.as_bytes());
+    }
+
+    #[test]
+    fn certificate_is_self_issued_to_the_realm_and_currently_valid() {
+        let (private_pem, _) = JwtKeyPair::generate().expect("generate realm key");
+        let certificate_pem = JwtKeyPair::self_signed_certificate(&private_pem, "acme-realm")
+            .expect("derive certificate");
+
+        let (_, pem) =
+            parse_x509_pem(certificate_pem.as_bytes()).expect("certificate is valid PEM");
+        let certificate = pem.parse_x509().expect("certificate is valid X.509");
+
+        assert_eq!(certificate.subject().to_string(), "CN=acme-realm");
+        assert_eq!(
+            certificate.subject().to_string(),
+            certificate.issuer().to_string()
+        );
+        assert!(certificate.validity().is_valid());
+    }
+
+    #[test]
+    fn certificate_survives_a_realm_name_that_is_not_a_dns_name() {
+        let (private_pem, _) = JwtKeyPair::generate().expect("generate realm key");
+        let certificate_pem = JwtKeyPair::self_signed_certificate(&private_pem, "réalm dé test")
+            .expect("derive certificate");
+
+        let (_, pem) =
+            parse_x509_pem(certificate_pem.as_bytes()).expect("certificate is valid PEM");
+        let certificate = pem.parse_x509().expect("certificate is valid X.509");
+
+        assert_eq!(certificate.subject().to_string(), "CN=réalm dé test");
+    }
+
+    #[test]
+    fn key_pair_carries_its_private_key_and_certificate() {
+        let (private_pem, public_pem) = JwtKeyPair::generate().expect("generate realm key");
+        let certificate_pem = JwtKeyPair::self_signed_certificate(&private_pem, "master")
+            .expect("derive certificate");
+
+        let key_pair = JwtKeyPair::from_pem(
+            &private_pem,
+            &public_pem,
+            &certificate_pem,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .expect("build key pair");
+
+        assert_eq!(key_pair.private_key, private_pem);
+        assert_eq!(key_pair.public_key, public_pem);
+        assert_eq!(key_pair.certificate, certificate_pem);
+    }
+
+    #[test]
+    fn certificate_der_is_the_unarmored_base64_body() {
+        let (private_pem, public_pem) = JwtKeyPair::generate().expect("generate realm key");
+        let certificate_pem = JwtKeyPair::self_signed_certificate(&private_pem, "master")
+            .expect("derive certificate");
+
+        let key_pair = JwtKeyPair::from_pem(
+            &private_pem,
+            &public_pem,
+            &certificate_pem,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .expect("build key pair");
+
+        let encoded = key_pair
+            .certificate_base64_der()
+            .expect("encode certificate for metadata");
+
+        assert!(!encoded.contains("-----"));
+        assert!(!encoded.contains('\n'));
+
+        let (_, pem) =
+            parse_x509_pem(certificate_pem.as_bytes()).expect("certificate is valid PEM");
+        assert_eq!(
+            BASE64_STANDARD.decode(&encoded).expect("decode"),
+            pem.contents
+        );
+    }
 
     #[test]
     fn refresh_claims_keep_scope() {


### PR DESCRIPTION
Closes #1262. Part of #1260. **Stacked on #1273** — review that one first; this diff is only meaningful on top of it.

SAML metadata publishes `<ds:X509Certificate>`, and FerrisKey had no certificate anywhere. This derives one per realm from the RSA key already in `jwt_keys`; no second key is created.

## Read this first: the migration deletes rows, and here is why that is safe

`jwt_keys` has no `UNIQUE(realm_id)` and `get_or_generate_key` is a non-atomic read-then-insert, so a realm can end up with several key rows. That ambiguity has to go before a certificate is pinned by relying parties — otherwise the advertised certificate can change between requests.

**The survivor is chosen by `ORDER BY ctid` — physical heap order — not by `created_at`.** `find().one()` compiles to `SELECT … WHERE realm_id = $1 LIMIT 1` with no `ORDER BY`, against a table with no index on `realm_id` (Postgres does not index the referencing side of a foreign key), so `EXPLAIN` confirms a sequential scan and the row actually in use is the physically first one.

Ordering by age would have been wrong, and not theoretically: realm deletion cascades into `jwt_keys`, and a freed heap slot is reused by a later insert. After that the physically-first row is the newest, so `ORDER BY created_at` would have archived the key that is currently signing tokens.

Residual risk, stated plainly: this holds while no index on `realm_id` exists and while the table stays far too small for `synchronize_seqscans` to begin a scan mid-heap. Both hold at migration time.

**And the choice is not a one-way door.** Displaced rows are archived in `jwt_keys_superseded`, not deleted, and `down` restores them. The archive-and-delete is one statement whose `RETURNING` yields only rows the insert actually wrote, so a row that fails to archive is never deleted — the failure mode is a loud error when the unique index is created, not silent loss of key material. `up` → `down` → `up` was verified against a seeded database; the restored rows match the originals by md5.

## Also fixed here

`JwtKeyPair` discarded the private PEM, keeping only an opaque `jsonwebtoken::EncodingKey`. XML-DSig needs the raw key, so the struct now carries it alongside the certificate.

## Choices worth knowing

- **CN and SAN come from the realm name**, not a host: the port hands the adapter only a `realm_id`, and no host exists at that layer. This matches Keycloak, which issues realm IdP certificates as `CN=<realm>`. A realm name that is not a valid DNS name falls back to no SAN.
- **Validity is computed** (last year → +10 years) rather than hard-coded, so a realm created in 2037 does not receive an already-expired certificate. rcgen defaults to 1975→4096, which would have read as nonsense to anyone decoding the blob.
- **`rcgen` uses the `ring` backend**, already present transitively via rustls, so no new build requirement.
- **`x5c` was deliberately not added to `JwkKey`.** That type is `ToSchema` and part of the published OpenAPI contract; extending it is its own change.

## Verification

15 `ferriskey-security` tests including `certificate_binds_the_existing_realm_key`, which asserts the certificate SPKI is byte-for-byte the realm public key. 4 DB-backed keystore tests covering generation, stability, cross-realm isolation and the lazy backfill of pre-existing keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic self-signed certificate generation for JWT keys.
  * JWT key pairs now retain and expose certificate data.
  * Added support for certificate migration and backfilling for existing keys.
  * Ensured each realm maintains a single active JWT key while preserving superseded keys.

* **Bug Fixes**
  * Improved key generation to preserve existing keys and certificates.
  * Added handling for legacy keys without certificates.
  * Enhanced support for realm names that are not DNS-compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->