### PR TITLE
feat: make the interactive login flow protocol agnostic

### DIFF
--- a/core/migrations/20260826120000_add_protocol_to_auth_sessions.down.sql
+++ b/core/migrations/20260826120000_add_protocol_to_auth_sessions.down.sql
@@ -1,0 +1,15 @@
+DROP INDEX IF EXISTS idx_auth_sessions_protocol;
+
+DELETE FROM auth_sessions WHERE response_type IS NULL OR scope IS NULL;
+
+ALTER TABLE auth_sessions
+    ALTER COLUMN response_type SET NOT NULL;
+
+ALTER TABLE auth_sessions
+    ALTER COLUMN scope SET NOT NULL;
+
+ALTER TABLE auth_sessions
+    DROP CONSTRAINT IF EXISTS auth_sessions_protocol_check;
+
+ALTER TABLE auth_sessions
+    DROP COLUMN IF EXISTS protocol;

--- a/core/migrations/20260826120000_add_protocol_to_auth_sessions.up.sql
+++ b/core/migrations/20260826120000_add_protocol_to_auth_sessions.up.sql
@@ -1,0 +1,19 @@
+ALTER TABLE auth_sessions
+    ADD COLUMN IF NOT EXISTS protocol VARCHAR(32) NOT NULL DEFAULT 'openid-connect';
+
+UPDATE auth_sessions SET protocol = 'openid-connect' WHERE protocol IS NULL;
+
+ALTER TABLE auth_sessions
+    DROP CONSTRAINT IF EXISTS auth_sessions_protocol_check;
+
+ALTER TABLE auth_sessions
+    ADD CONSTRAINT auth_sessions_protocol_check
+    CHECK (protocol IN ('openid-connect', 'saml'));
+
+ALTER TABLE auth_sessions
+    ALTER COLUMN response_type DROP NOT NULL;
+
+ALTER TABLE auth_sessions
+    ALTER COLUMN scope DROP NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_protocol ON auth_sessions (protocol);

--- a/core/src/domain/abyss/broker_services.rs
+++ b/core/src/domain/abyss/broker_services.rs
@@ -18,7 +18,7 @@ use crate::domain::abyss::identity_provider::broker::{
     OAuthClient, OAuthProviderConfig, OAuthTokenResponse,
 };
 use crate::domain::abyss::identity_provider::{IdentityProvider, IdentityProviderRepository};
-use crate::domain::authentication::entities::{AuthSession, AuthSessionParams};
+use crate::domain::authentication::entities::{AuthProtocol, AuthSession, AuthSessionParams};
 use crate::domain::authentication::ports::AuthSessionRepository;
 use crate::domain::authentication::value_objects::CodeChallengeMethod;
 use crate::domain::client::ports::{ClientRepository, RedirectUriRepository};
@@ -769,9 +769,10 @@ where
             let auth_session = AuthSession::new(AuthSessionParams {
                 realm_id: realm.id,
                 client_id: broker_session.client_id,
+                protocol: AuthProtocol::OpenIdConnect,
                 redirect_uri: broker_session.redirect_uri.clone(),
-                response_type: broker_session.response_type.clone(),
-                scope: broker_session.scope.clone(),
+                response_type: Some(broker_session.response_type.clone()),
+                scope: Some(broker_session.scope.clone()),
                 state: broker_session.state.clone(),
                 nonce: broker_session.nonce.clone(),
                 user_id: Some(user.id),

--- a/core/src/domain/authentication/entities.rs
+++ b/core/src/domain/authentication/entities.rs
@@ -16,9 +16,10 @@ use crate::domain::realm::entities::RealmId;
 // `ferriskey-security` (AuthorizeRequestInput's JwtClaim) stay in `core` — moving them would
 // pull a heavy crypto crate / an internal crate into the leaf `ferriskey-domain`.
 pub use ferriskey_domain::authentication::entities::{
-    AuthInput, AuthenticateInput, AuthenticateOutput, AuthenticationError, AuthenticationMethod,
-    AuthenticationStepStatus, AuthorizeRequestOutput, CredentialsAuthParams, ExchangeTokenInput,
-    GrantType, JwtToken, RefreshClaims, TokenIntrospectionResponse,
+    AuthCompletion, AuthInput, AuthProtocol, AuthenticateInput, AuthenticateOutput,
+    AuthenticationError, AuthenticationMethod, AuthenticationStepStatus, AuthorizeRequestOutput,
+    CredentialsAuthParams, ExchangeTokenInput, GrantType, JwtToken, RefreshClaims,
+    TokenIntrospectionResponse,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,9 +35,10 @@ pub struct AuthSession {
     pub id: Uuid,
     pub realm_id: RealmId,
     pub client_id: Uuid,
+    pub protocol: AuthProtocol,
     pub redirect_uri: String,
-    pub response_type: String,
-    pub scope: String,
+    pub response_type: Option<String>,
+    pub scope: Option<String>,
     pub state: Option<String>,
     pub nonce: Option<String>,
     pub user_id: Option<Uuid>,
@@ -55,9 +57,10 @@ pub struct AuthSession {
 pub struct AuthSessionParams {
     pub realm_id: RealmId,
     pub client_id: Uuid,
+    pub protocol: AuthProtocol,
     pub redirect_uri: String,
-    pub response_type: String,
-    pub scope: String,
+    pub response_type: Option<String>,
+    pub scope: Option<String>,
     pub state: Option<String>,
     pub nonce: Option<String>,
     pub user_id: Option<Uuid>,
@@ -79,6 +82,7 @@ impl AuthSession {
             id: Uuid::new_v7(timestamp),
             realm_id: params.realm_id,
             client_id: params.client_id,
+            protocol: params.protocol,
             redirect_uri: params.redirect_uri,
             response_type: params.response_type,
             scope: params.scope,

--- a/core/src/domain/authentication/ports.rs
+++ b/core/src/domain/authentication/ports.rs
@@ -8,8 +8,8 @@ use crate::domain::realm::entities::RealmId;
 use crate::domain::{
     authentication::{
         entities::{
-            AuthInput, AuthOutput, AuthSession, AuthenticateInput, AuthenticateOutput,
-            AuthenticationError, AuthorizeRequestInput, AuthorizeRequestOutput,
+            AuthCompletion, AuthInput, AuthOutput, AuthSession, AuthenticateInput,
+            AuthenticateOutput, AuthenticationError, AuthorizeRequestInput, AuthorizeRequestOutput,
             CredentialsAuthParams, ExchangeTokenInput, JwtToken, TokenIntrospectionResponse,
             WebAuthnChallenge,
         },
@@ -207,11 +207,11 @@ pub trait AuthenticatePort: Send + Sync {
         auth_session: AuthSession,
     ) -> impl Future<Output = Result<AuthenticateOutput, CoreError>> + Send;
 
-    fn build_redirect_url(
+    fn build_auth_completion(
         &self,
         auth_session: &AuthSession,
         authorization_code: &str,
-    ) -> Result<String, CoreError>;
+    ) -> Result<AuthCompletion, CoreError>;
 
     fn using_session_code(
         &self,

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -30,9 +30,9 @@ use crate::domain::{
     authentication::{
         OidcScope,
         entities::{
-            AuthInput, AuthOutput, AuthSession, AuthSessionParams, AuthenticateOutput,
-            AuthenticationMethod, AuthorizeRequestInput, AuthorizeRequestOutput,
-            CredentialsAuthParams, ExchangeTokenInput, GrantType, JwtToken,
+            AuthCompletion, AuthInput, AuthOutput, AuthProtocol, AuthSession, AuthSessionParams,
+            AuthenticateOutput, AuthenticationMethod, AuthorizeRequestInput,
+            AuthorizeRequestOutput, CredentialsAuthParams, ExchangeTokenInput, GrantType, JwtToken,
             TokenIntrospectionResponse,
         },
         mapper_engine::{MapperContext, MapperEngine, TokenType},
@@ -136,6 +136,27 @@ fn format_authorization_redirect_url(
             format!("{url}&state={}", urlencoding::encode(state))
         }
         _ => url,
+    }
+}
+
+pub(crate) fn format_auth_completion(
+    auth_session: &AuthSession,
+    authorization_code: &str,
+) -> Result<AuthCompletion, CoreError> {
+    match auth_session.protocol {
+        AuthProtocol::OpenIdConnect => Ok(AuthCompletion::Redirect {
+            url: format_authorization_redirect_url(auth_session, authorization_code),
+        }),
+        AuthProtocol::Saml => {
+            error!(
+                auth_session_id = %auth_session.id,
+                "no assertion delivery is wired for a saml auth session yet"
+            );
+
+            Err(CoreError::ServiceUnavailable(
+                "saml assertion delivery is not available".to_string(),
+            ))
+        }
     }
 }
 
@@ -1974,7 +1995,7 @@ where
         }
 
         let final_scope = self
-            .resolve_scopes_for_client(auth_session.client_id, Some(auth_session.scope.clone()))
+            .resolve_scopes_for_client(auth_session.client_id, auth_session.scope.clone())
             .await?;
 
         info!("Final scope for authorization code grant: {}", final_scope);
@@ -2601,12 +2622,12 @@ where
                 CoreError::SessionNotFound
             })?;
 
-        let redirect_uri = self.build_redirect_url(&auth_session, &authorization_code)?;
+        let completion = self.build_auth_completion(&auth_session, &authorization_code)?;
 
-        Ok(AuthenticateOutput::complete_with_redirect(
+        Ok(AuthenticateOutput::complete(
             user_id,
             authorization_code,
-            redirect_uri,
+            completion,
         ))
     }
 
@@ -2866,7 +2887,7 @@ This is a server error that should be investigated. Do not forward back this mes
             ClaimsTyp::Temporary,
             client_id.clone(),
             user.email.clone(),
-            Some(auth_session.scope),
+            auth_session.scope,
             temporary_lifetime,
         );
         jwt_claim.additional_claims.insert(
@@ -3053,15 +3074,12 @@ This is a server error that should be investigated. Do not forward back this mes
             .await
     }
 
-    fn build_redirect_url(
+    fn build_auth_completion(
         &self,
         auth_session: &AuthSession,
         authorization_code: &str,
-    ) -> Result<String, CoreError> {
-        Ok(format_authorization_redirect_url(
-            auth_session,
-            authorization_code,
-        ))
+    ) -> Result<AuthCompletion, CoreError> {
+        format_auth_completion(auth_session, authorization_code)
     }
 
     fn claims_to_introspection_response(
@@ -3243,6 +3261,26 @@ where
             .get_by_client_id(input.client_id.clone(), realm.id)
             .await?;
 
+        let protocol = client.protocol.parse::<AuthProtocol>().map_err(|reason| {
+            warn!(
+                client_id = %input.client_id,
+                %reason,
+                "rejecting an authorization request for a client whose protocol is unknown"
+            );
+
+            CoreError::InvalidClient
+        })?;
+
+        if protocol != AuthProtocol::OpenIdConnect {
+            warn!(
+                client_id = %input.client_id,
+                %protocol,
+                "rejecting an authorization request: this endpoint only serves openid-connect clients"
+            );
+
+            return Err(CoreError::InvalidClient);
+        }
+
         let redirect_uri = input.redirect_uri.clone();
 
         let client_redirect_uris = self
@@ -3286,9 +3324,10 @@ where
         let params = AuthSessionParams {
             realm_id: realm.id,
             client_id: client.id,
+            protocol,
             redirect_uri,
-            response_type: input.response_type,
-            scope: input.scope.unwrap_or_default(),
+            response_type: Some(input.response_type),
+            scope: Some(input.scope.unwrap_or_default()),
             state: input.state.clone(),
             nonce: input.nonce,
             user_id: None,
@@ -4252,13 +4291,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        auth_session_can_resume, format_authorization_redirect_url, lockout_compute_locked_until,
-        validate_authorization_code_request,
+        auth_session_can_resume, format_auth_completion, format_authorization_redirect_url,
+        lockout_compute_locked_until, validate_authorization_code_request,
     };
     use chrono::{Duration, Utc};
     use uuid::Uuid;
 
-    use crate::domain::authentication::entities::AuthSession;
+    use crate::domain::authentication::entities::{AuthCompletion, AuthProtocol, AuthSession};
     use crate::domain::client::entities::{Client, ClientType, MaintenanceSessionStrategy};
     use crate::domain::common::entities::app_errors::CoreError;
     use crate::domain::realm::entities::RealmId;
@@ -4276,9 +4315,10 @@ mod tests {
             id: Uuid::new_v4(),
             realm_id: RealmId::from(Uuid::new_v4()),
             client_id: Uuid::new_v4(),
+            protocol: AuthProtocol::OpenIdConnect,
             redirect_uri: redirect_uri.to_string(),
-            response_type: "code".to_string(),
-            scope: "openid".to_string(),
+            response_type: Some("code".to_string()),
+            scope: Some("openid".to_string()),
             state: state.map(str::to_string),
             nonce: None,
             user_id,
@@ -4396,6 +4436,46 @@ mod tests {
         assert_eq!(
             format_authorization_redirect_url(&session, "C"),
             "https://client.example/callback?code=C&state=a%20b%26next%3Dhttps%3A%2F%2Fevil.example"
+        );
+    }
+
+    #[test]
+    fn an_openid_connect_session_completes_with_the_untouched_redirect_url() {
+        let session = auth_session(
+            Some("xyz-state"),
+            "https://client.example/callback",
+            Utc::now(),
+            None,
+            false,
+        );
+
+        assert_eq!(
+            format_auth_completion(&session, "AUTH_CODE").expect("openid-connect must complete"),
+            AuthCompletion::Redirect {
+                url: format_authorization_redirect_url(&session, "AUTH_CODE"),
+            }
+        );
+    }
+
+    #[test]
+    fn a_saml_session_is_never_completed_as_an_openid_connect_redirect() {
+        let session = AuthSession {
+            protocol: AuthProtocol::Saml,
+            ..auth_session(
+                Some("relay"),
+                "https://sp.example/acs",
+                Utc::now(),
+                None,
+                false,
+            )
+        };
+
+        assert!(
+            matches!(
+                format_auth_completion(&session, "AUTH_CODE"),
+                Err(CoreError::ServiceUnavailable(_))
+            ),
+            "a saml session must not borrow the authorization-code redirect"
         );
     }
 

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -16,8 +16,9 @@ use webauthn_rs::prelude::*;
 use crate::{
     domain::{
         authentication::{
-            entities::{AuthSession, WebAuthnChallenge},
+            entities::{AuthCompletion, AuthSession, WebAuthnChallenge},
             ports::AuthSessionRepository,
+            services::format_auth_completion,
             value_objects::Identity,
         },
         common::{
@@ -89,6 +90,16 @@ const OTP_ENROLLMENT_TTL_MINUTES: i64 = 5;
 /// How long a WebAuthn registration challenge stays usable. The challenge was already
 /// stamped with `webauthn_challenge_issued_at` but nothing ever read it back.
 const WEBAUTHN_CHALLENGE_TTL_MINUTES: i64 = 5;
+
+fn login_url_from(completion: AuthCompletion) -> Result<String, CoreError> {
+    completion.into_redirect_url().ok_or_else(|| {
+        error!("this login step can only hand back a redirect url, not a form post");
+
+        CoreError::ServiceUnavailable(
+            "this login step cannot deliver the requested response".to_string(),
+        )
+    })
+}
 
 fn generate_secret() -> Result<TotpSecret, CoreError> {
     let mut bytes = [0u8; 20];
@@ -393,6 +404,19 @@ where
         user_id: Uuid,
         actions_satisfied_by_path: &[RequiredAction],
     ) -> Result<String, CoreError> {
+        let completion = self
+            .issue_auth_completion(auth_session, user_id, actions_satisfied_by_path)
+            .await?;
+
+        login_url_from(completion)
+    }
+
+    async fn issue_auth_completion(
+        &self,
+        auth_session: &AuthSession,
+        user_id: Uuid,
+        actions_satisfied_by_path: &[RequiredAction],
+    ) -> Result<AuthCompletion, CoreError> {
         if let Some(step) = self
             .pending_auth_step_for(user_id, actions_satisfied_by_path)
             .await?
@@ -415,15 +439,7 @@ where
             .await
             .map_err(|_| CoreError::AuthorizationCodeStorageFailed)?;
 
-        let current_state = auth_session
-            .state
-            .as_ref()
-            .ok_or(CoreError::AuthSessionExpectedState)?;
-
-        Ok(format!(
-            "{}?code={}&state={}",
-            auth_session.redirect_uri, authorization_code, current_state
-        ))
+        format_auth_completion(auth_session, &authorization_code)
     }
 
     async fn render_email_template(
@@ -666,14 +682,8 @@ where
             .await
             .map_err(|e| CoreError::TotpVerificationFailed(e.to_string()))?;
 
-        let current_state = auth_session.state.ok_or(CoreError::RecoveryCodeBurnError(
-            "Invalid session state".to_string(),
-        ))?;
-
-        let login_url = format!(
-            "{}?code={}&state={}",
-            auth_session.redirect_uri, authorization_code, current_state
-        );
+        let login_url =
+            login_url_from(format_auth_completion(&auth_session, &authorization_code)?)?;
 
         Ok(BurnRecoveryCodeOutput { login_url })
     }
@@ -1171,14 +1181,8 @@ where
             .await
             .map_err(|e| CoreError::TotpVerificationFailed(e.to_string()))?;
 
-        let current_state = auth_session.state.ok_or(CoreError::TotpVerificationFailed(
-            "invalid session state".to_string(),
-        ))?;
-
-        let login_url = format!(
-            "{}?code={}&state={}",
-            auth_session.redirect_uri, authorization_code, current_state
-        );
+        let login_url =
+            login_url_from(format_auth_completion(&auth_session, &authorization_code)?)?;
 
         Ok(ChallengeOtpOutput {
             login_url: Some(login_url),
@@ -2134,7 +2138,10 @@ where
 mod tests {
     use super::*;
     use crate::domain::{
-        authentication::{entities::AuthenticationError, ports::MockAuthSessionRepository},
+        authentication::{
+            entities::{AuthProtocol, AuthenticationError},
+            ports::MockAuthSessionRepository,
+        },
         common::{email::MockEmailPort, services::tests::create_test_realm_with_name},
         credential::{entities::CredentialError, ports::MockCredentialRepository},
         email_template::ports::MockEmailTemplateRepository,
@@ -3339,9 +3346,10 @@ mod tests {
             id: session_code,
             realm_id: realm.id,
             client_id: Uuid::new_v4(),
+            protocol: AuthProtocol::OpenIdConnect,
             redirect_uri: "https://app.example/callback".to_string(),
-            response_type: "code".to_string(),
-            scope: "openid".to_string(),
+            response_type: Some("code".to_string()),
+            scope: Some("openid".to_string()),
             state: Some("state".to_string()),
             nonce: None,
             user_id: None,
@@ -3354,6 +3362,16 @@ mod tests {
             compass_flow_id: None,
             code_challenge: None,
             code_challenge_method: None,
+        }
+    }
+
+    fn auth_session_without_state(
+        realm: &crate::domain::realm::entities::Realm,
+        session_code: Uuid,
+    ) -> AuthSession {
+        AuthSession {
+            state: None,
+            ..auth_session_with_challenge_issued_at(realm, session_code, None)
         }
     }
 
@@ -3951,6 +3969,74 @@ mod tests {
         assert!(
             matches!(result, Err(CoreError::Forbidden(_))),
             "the VerifyEmail waiver belongs to the magic link path only: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_authorization_code_is_issued_when_the_session_carries_no_state() {
+        let mut builder = TridentTestBuilder::new();
+        let realm = create_test_realm_with_name("test-realm");
+        let user = create_test_user_with_email(&realm, "user@example.com");
+        let session = auth_session_without_state(&realm, Uuid::new_v4());
+
+        let user_id = user.id;
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            Vec::new(),
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_authorization_code(&mut builder, session.clone());
+
+        let service = builder.build();
+        let login_url = service
+            .store_auth_code_and_generate_login_url(&session, user_id, &[])
+            .await
+            .expect("an absent state must not block the authorization code");
+
+        assert!(
+            login_url.contains("code="),
+            "expected an authorization code in {login_url}"
+        );
+        assert!(
+            !login_url.contains("state="),
+            "nothing was requested to be relayed back, so no state may be echoed: {login_url}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_mfa_path_hands_back_the_same_url_the_password_path_would() {
+        let mut builder = TridentTestBuilder::new();
+        let realm = create_test_realm_with_name("test-realm");
+        let user = create_test_user_with_email(&realm, "user@example.com");
+        let session = AuthSession {
+            redirect_uri: "https://app.example/callback?tenant=acme".to_string(),
+            state: Some("a b&next=https://evil.example".to_string()),
+            ..auth_session_with_challenge_issued_at(&realm, Uuid::new_v4(), None)
+        };
+
+        let user_id = user.id;
+        expect_pending_step_lookups(
+            &mut builder,
+            user,
+            Vec::new(),
+            create_test_realm_setting(realm.id, false),
+        );
+        expect_authorization_code(&mut builder, session.clone());
+
+        let service = builder.build();
+        let login_url = service
+            .store_auth_code_and_generate_login_url(&session, user_id, &[])
+            .await
+            .expect("a user owing nothing must get an authorization code");
+
+        assert!(
+            login_url.starts_with("https://app.example/callback?tenant=acme&code="),
+            "an existing query string must be extended, not clobbered: {login_url}"
+        );
+        assert!(
+            login_url.ends_with("&state=a%20b%26next%3Dhttps%3A%2F%2Fevil.example"),
+            "state must be echoed back percent-encoded: {login_url}"
         );
     }
 }

--- a/core/src/entity/auth_sessions.rs
+++ b/core/src/entity/auth_sessions.rs
@@ -17,8 +17,8 @@ pub struct Model {
     pub realm_id: Uuid,
     pub client_id: Uuid,
     pub redirect_uri: String,
-    pub response_type: String,
-    pub scope: String,
+    pub response_type: Option<String>,
+    pub scope: Option<String>,
     pub state: Option<String>,
     pub nonce: Option<String>,
     pub user_id: Option<Uuid>,
@@ -31,6 +31,7 @@ pub struct Model {
     pub compass_flow_id: Option<Uuid>,
     pub code_challenge: Option<String>,
     pub code_challenge_method: Option<String>,
+    pub protocol: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -53,6 +54,7 @@ pub enum Column {
     CompassFlowId,
     CodeChallenge,
     CodeChallengeMethod,
+    Protocol,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -84,8 +86,9 @@ impl ColumnTrait for Column {
             Self::RealmId => ColumnType::Uuid.def(),
             Self::ClientId => ColumnType::Uuid.def(),
             Self::RedirectUri => ColumnType::String(StringLen::N(255u32)).def(),
-            Self::ResponseType => ColumnType::String(StringLen::N(255u32)).def(),
-            Self::Scope => ColumnType::String(StringLen::N(255u32)).def(),
+            Self::Protocol => ColumnType::String(StringLen::N(32u32)).def(),
+            Self::ResponseType => ColumnType::String(StringLen::N(255u32)).def().null(),
+            Self::Scope => ColumnType::String(StringLen::N(255u32)).def().null(),
             Self::State => ColumnType::Text.def().null(),
             Self::Nonce => ColumnType::Text.def().null(),
             Self::UserId => ColumnType::Uuid.def().null(),

--- a/core/src/infrastructure/repositories/auth_session_repository.rs
+++ b/core/src/infrastructure/repositories/auth_session_repository.rs
@@ -7,13 +7,15 @@ use tracing::error;
 use uuid::Uuid;
 
 use crate::domain::authentication::{
-    entities::{AuthSession, AuthenticationError, WebAuthnChallenge},
+    entities::{AuthProtocol, AuthSession, AuthenticationError, WebAuthnChallenge},
     ports::AuthSessionRepository,
     value_objects::CodeChallengeMethod,
 };
 
-impl From<crate::entity::auth_sessions::Model> for AuthSession {
-    fn from(model: crate::entity::auth_sessions::Model) -> Self {
+impl TryFrom<crate::entity::auth_sessions::Model> for AuthSession {
+    type Error = AuthenticationError;
+
+    fn try_from(model: crate::entity::auth_sessions::Model) -> Result<Self, Self::Error> {
         let created_at = Utc.from_utc_datetime(&model.created_at);
         let expires_at = Utc.from_utc_datetime(&model.expires_at);
         let webauthn_challenge_issued_at = model
@@ -31,10 +33,20 @@ impl From<crate::entity::auth_sessions::Model> for AuthSession {
             .as_deref()
             .and_then(|s| s.parse::<CodeChallengeMethod>().ok());
 
-        AuthSession {
+        let protocol = model.protocol.parse::<AuthProtocol>().map_err(|reason| {
+            error!(
+                auth_session_id = %model.id,
+                %reason,
+                "stored auth session carries a protocol this build cannot serve"
+            );
+            AuthenticationError::InternalServerError
+        })?;
+
+        Ok(AuthSession {
             id: model.id,
             realm_id: model.realm_id.into(),
             client_id: model.client_id,
+            protocol,
             redirect_uri: model.redirect_uri,
             response_type: model.response_type,
             scope: model.scope,
@@ -50,7 +62,7 @@ impl From<crate::entity::auth_sessions::Model> for AuthSession {
             compass_flow_id: model.compass_flow_id,
             code_challenge: model.code_challenge,
             code_challenge_method,
-        }
+        })
     }
 }
 
@@ -76,6 +88,7 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
             id: Set(session.id),
             realm_id: Set(session.realm_id.into()),
             client_id: Set(session.client_id),
+            protocol: Set(session.protocol.to_string()),
             redirect_uri: Set(session.redirect_uri.clone()),
             response_type: Set(session.response_type.clone()),
             scope: Set(session.scope.clone()),
@@ -100,7 +113,7 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
                 error!("Error creating session: {:?}", e);
                 AuthenticationError::InternalServerError
             })?
-            .into();
+            .try_into()?;
 
         Ok(t)
     }
@@ -118,7 +131,7 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
                 AuthenticationError::NotFound
             })?;
 
-        let session = session.ok_or(AuthenticationError::NotFound)?.into();
+        let session = session.ok_or(AuthenticationError::NotFound)?.try_into()?;
 
         Ok(session)
     }
@@ -133,7 +146,7 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
                 AuthenticationError::NotFound
             })?;
 
-        let session: Option<AuthSession> = session.map(|s| s.into());
+        let session = session.map(AuthSession::try_from).transpose()?;
 
         Ok(session)
     }
@@ -167,7 +180,7 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
             .into_iter()
             .next()
             .ok_or(AuthenticationError::NotFound)?
-            .into();
+            .try_into()?;
 
         Ok(session)
     }
@@ -201,7 +214,7 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
             .into_iter()
             .next()
             .ok_or(AuthenticationError::NotFound)?
-            .into();
+            .try_into()?;
 
         Ok(session)
     }
@@ -263,7 +276,7 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
             .into_iter()
             .next()
             .ok_or(AuthenticationError::NotFound)?
-            .into();
+            .try_into()?;
 
         Ok(session)
     }
@@ -324,7 +337,7 @@ impl AuthSessionRepository for PostgresAuthSessionRepository {
             .into_iter()
             .next()
             .ok_or(AuthenticationError::NotFound)?
-            .into();
+            .try_into()?;
 
         Ok(session)
     }
@@ -454,9 +467,10 @@ mod tests {
         AuthSession::new(AuthSessionParams {
             realm_id: RealmId::new(realm_id),
             client_id,
+            protocol: AuthProtocol::OpenIdConnect,
             redirect_uri: "http://localhost/callback".into(),
-            response_type: "code".into(),
-            scope: "openid".into(),
+            response_type: Some("code".into()),
+            scope: Some("openid".into()),
             state: None,
             nonce: None,
             user_id: None,

--- a/libs/ferriskey-api-core/src/error.rs
+++ b/libs/ferriskey-api-core/src/error.rs
@@ -149,7 +149,9 @@ impl From<CoreError> for ApiError {
             CoreError::AuthorizationCodeStorageFailed => {
                 Self::InternalServerError("".into())
             },
-            CoreError::AuthSessionExpectedState => Self::InternalServerError("".into()),
+            CoreError::ProtocolNotSupported(protocol) => {
+                Self::BadRequest(CoreError::ProtocolNotSupported(protocol).to_string().into())
+            }
             CoreError::WebAuthnMissingChallenge => {
                 Self::BadRequest("There is no current webauthn challenge for this session. Make sure you request one from the server before attempting an authentication.".into())
             },

--- a/libs/ferriskey-domain/src/authentication/entities.rs
+++ b/libs/ferriskey-domain/src/authentication/entities.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -195,6 +196,73 @@ impl Display for GrantType {
     }
 }
 
+pub const OPENID_CONNECT_PROTOCOL: &str = "openid-connect";
+pub const SAML_PROTOCOL: &str = "saml";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum AuthProtocol {
+    #[default]
+    #[serde(rename = "openid-connect")]
+    OpenIdConnect,
+    #[serde(rename = "saml")]
+    Saml,
+}
+
+impl AuthProtocol {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AuthProtocol::OpenIdConnect => OPENID_CONNECT_PROTOCOL,
+            AuthProtocol::Saml => SAML_PROTOCOL,
+        }
+    }
+}
+
+impl Display for AuthProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for AuthProtocol {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            OPENID_CONNECT_PROTOCOL => Ok(AuthProtocol::OpenIdConnect),
+            SAML_PROTOCOL => Ok(AuthProtocol::Saml),
+            other => Err(format!("unsupported authentication protocol: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthCompletion {
+    Redirect {
+        url: String,
+    },
+    FormPost {
+        action_url: String,
+        body: String,
+        relay_state: Option<String>,
+    },
+}
+
+impl AuthCompletion {
+    pub fn redirect_url(&self) -> Option<&str> {
+        match self {
+            AuthCompletion::Redirect { url } => Some(url),
+            AuthCompletion::FormPost { .. } => None,
+        }
+    }
+
+    pub fn into_redirect_url(self) -> Option<String> {
+        match self {
+            AuthCompletion::Redirect { url } => Some(url),
+            AuthCompletion::FormPost { .. } => None,
+        }
+    }
+}
+
 pub struct AuthInput {
     pub client_id: String,
     pub realm_name: String,
@@ -291,23 +359,21 @@ pub struct AuthenticateOutput {
     pub temporary_token: Option<String>,
     pub required_actions: Vec<RequiredAction>,
     pub redirect_url: Option<String>,
+    pub completion: Option<AuthCompletion>,
     pub session_state: Option<String>,
     pub email: Option<String>,
 }
 
 impl AuthenticateOutput {
-    pub fn complete_with_redirect(
-        user_id: Uuid,
-        authorization_code: String,
-        redirect_url: String,
-    ) -> Self {
+    pub fn complete(user_id: Uuid, authorization_code: String, completion: AuthCompletion) -> Self {
         Self {
             user_id,
             status: AuthenticationStepStatus::Success,
             authorization_code: Some(authorization_code),
             temporary_token: None,
             required_actions: Vec::new(),
-            redirect_url: Some(redirect_url),
+            redirect_url: completion.redirect_url().map(str::to_string),
+            completion: Some(completion),
             session_state: None,
             email: None,
         }
@@ -325,6 +391,7 @@ impl AuthenticateOutput {
             temporary_token: Some(temporary_token),
             required_actions,
             redirect_url: None,
+            completion: None,
             session_state: None,
             email: None,
         }
@@ -342,6 +409,7 @@ impl AuthenticateOutput {
             temporary_token: Some(temporary_token),
             required_actions: Vec::new(),
             redirect_url: None,
+            completion: None,
             session_state: None,
             email,
         }
@@ -392,5 +460,50 @@ mod grant_type_tests {
         let parsed: GrantType = serde_json::from_str(&json)
             .expect("token-exchange URN should deserialize into GrantType");
         assert_eq!(parsed.to_string(), TOKEN_EXCHANGE_URN);
+    }
+}
+
+#[cfg(test)]
+mod auth_protocol_tests {
+    use super::*;
+
+    #[test]
+    fn auth_protocol_round_trips_through_the_value_stored_in_the_client_row() {
+        for protocol in [AuthProtocol::OpenIdConnect, AuthProtocol::Saml] {
+            assert_eq!(
+                protocol.to_string().parse::<AuthProtocol>(),
+                Ok(protocol),
+                "{protocol} must survive a database round trip"
+            );
+        }
+    }
+
+    #[test]
+    fn auth_protocol_defaults_to_the_value_every_existing_row_carries() {
+        assert_eq!(AuthProtocol::default().as_str(), "openid-connect");
+    }
+
+    #[test]
+    fn an_unknown_protocol_is_rejected_rather_than_treated_as_openid_connect() {
+        assert!("ws-federation".parse::<AuthProtocol>().is_err());
+    }
+
+    #[test]
+    fn only_a_redirect_completion_yields_a_redirect_url() {
+        let redirect = AuthCompletion::Redirect {
+            url: "https://client.example/cb?code=C".to_string(),
+        };
+        assert_eq!(
+            redirect.redirect_url(),
+            Some("https://client.example/cb?code=C")
+        );
+
+        let form_post = AuthCompletion::FormPost {
+            action_url: "https://sp.example/acs".to_string(),
+            body: "PHNhbWxwOlJlc3BvbnNlLz4=".to_string(),
+            relay_state: Some("relay".to_string()),
+        };
+        assert_eq!(form_post.redirect_url(), None);
+        assert_eq!(form_post.into_redirect_url(), None);
     }
 }

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -181,8 +181,8 @@ pub enum CoreError {
     #[error("Authorization code storage failed")]
     AuthorizationCodeStorageFailed,
 
-    #[error("Expected an auth session state")]
-    AuthSessionExpectedState,
+    #[error("Protocol not supported for this operation: {0}")]
+    ProtocolNotSupported(String),
 
     #[error("Missing webauthn challenge")]
     WebAuthnMissingChallenge,


### PR DESCRIPTION
Closes #1265. Part of #1260. **Stacked on #1275 → #1274 → #1273.**

The login flow was OIDC-shaped down to the database. This opens a seam so a second protocol can reuse it. **No SAML code is added here.**

## Read this first: MFA redirect URLs change

Three code-issuance sites each carried their own inline copy of the OIDC redirect formatting. Consolidating them into one formatter means the MFA, passkey, magic-link and password-reset paths now percent-encode `state` and handle a redirect URI that already carries a query string.

Those paths did neither before. A redirect URI like `https://app.example.com/cb?tenant=acme` produced `…?tenant=acme?code=…` — two `?` in one URL. So this is a bug fix, but it is **not** byte-identical behaviour on those paths, which the chantier had frozen as a requirement. Preserving the bug inside a shared formatter would have meant deliberately writing wrong code, so it is fixed and called out here instead. The password-only OIDC path is unchanged, and `the_mfa_path_hands_back_the_same_url_the_password_path_would` pins the two together.

## The seam

```rust
pub enum AuthCompletion {
    Redirect { url: String },
    FormPost { action_url: String, body: String, relay_state: Option<String> },
}
```

`AuthenticatePort::build_redirect_url` becomes `build_auth_completion`. The old signature returned a `String`, which cannot express what SAML needs — an auto-submitting HTML form POST rather than a 302. `libs/ferriskey-api-authentication` needs no change: `AuthenticateOutput.redirect_url` is still populated for `Redirect`. The SAML HTTP lot will read `completion` instead.

## The bug that would have blocked SAML behind MFA

`trident/services.rs` did `auth_session.state.as_ref().ok_or(CoreError::AuthSessionExpectedState)?`. SAML `RelayState` is optional, so any SAML login going through MFA would have failed. The OIDC path already tolerated an absent `state` — the asymmetry was the bug, not a design choice. The regression test was written first and watched fail with exactly that error.

A **third** issuance site turned up that the issue did not mention: `burn_recovery_code` had its own inline copy and its own `state.ok_or(...)`. Same bug, same fix, routed through the same seam.

## Other decisions

- **`From` → `TryFrom` on the auth-session mapper.** An unrecognised `protocol` string must not be silently read as OIDC, and `From` cannot fail. Seven conversion sites became `.try_into()?`.
- **`auth()` now rejects non-OIDC clients** with `InvalidClient` rather than serving them through the OIDC validator. Invisible to `openid-connect` clients, which is every client today.
- **`scope` still persists as `""` when absent**, so token and scope-resolution reads are bit-identical. The column is nullable only so SAML can leave it `NULL`.
- **`CoreError::AuthSessionExpectedState` is deleted.** Its only two producers were the bug above. `ProtocolNotSupported(String)` replaces it, mapped to 400 rather than the previous empty 500.

## Verification

318 `ferriskey-core` library tests green, including 200 on the authentication module and 28 on trident. Workspace builds; `cargo fmt` and the CI clippy invocation clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication protocol support for OpenID Connect and SAML.
  * Authentication results can now support redirects and form-post completions.
  * Authentication sessions now retain protocol information and support optional request parameters.

* **Bug Fixes**
  * Improved login and recovery redirects by preserving existing query parameters and safely encoding values.
  * Unsupported authentication protocols now return a clear bad-request error.
  * Added validation for invalid or unsupported protocol values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->