### PR TITLE
feat: configure a saml service provider from the console

### DIFF
--- a/core/src/domain/saml/entities.rs
+++ b/core/src/domain/saml/entities.rs
@@ -178,10 +178,12 @@ pub fn derive_name_id(
 ) -> Result<SubjectNameId, SamlSsoError> {
     let (value, format) = match format {
         NameIdFormat::EmailAddress => (
-            non_empty(user.email.as_deref()).ok_or(SamlSsoError::MissingNameIdSource {
-                format: "emailAddress",
-                requirement: "verified email address",
-            })?,
+            non_empty(user.email.as_deref())
+                .filter(|_| user.email_verified)
+                .ok_or(SamlSsoError::MissingNameIdSource {
+                    format: "emailAddress",
+                    requirement: "verified email address",
+                })?,
             AssertionNameIdFormat::EmailAddress,
         ),
         NameIdFormat::Persistent => (user.id.to_string(), AssertionNameIdFormat::Persistent),
@@ -531,6 +533,20 @@ mod tests {
     fn an_email_name_id_is_refused_rather_than_emitted_empty_for_a_user_without_an_address() {
         let mut user = user(RealmId::default());
         user.email = None;
+
+        assert_eq!(
+            derive_name_id(NameIdFormat::EmailAddress, &user, "session"),
+            Err(SamlSsoError::MissingNameIdSource {
+                format: "emailAddress",
+                requirement: "verified email address",
+            })
+        );
+    }
+
+    #[test]
+    fn an_unverified_address_cannot_become_an_email_name_id() {
+        let mut user = user(RealmId::default());
+        user.email_verified = false;
 
         assert_eq!(
             derive_name_id(NameIdFormat::EmailAddress, &user, "session"),

--- a/core/src/domain/saml/services.rs
+++ b/core/src/domain/saml/services.rs
@@ -154,6 +154,19 @@ where
             ));
         }
 
+        if config.want_authn_requests_signed {
+            warn!(
+                client_id = %client.client_id,
+                "rejecting a saml authn request: this service provider requires signed requests and no verification is implemented yet"
+            );
+
+            return Err(RejectedAuthnRequest::against(
+                &client,
+                CoreError::InvalidRequest,
+                "this service provider requires signed authn requests, which are not verified yet",
+            ));
+        }
+
         resolve_assertion_consumer_service_url(
             request
                 .assertion_consumer_service_url
@@ -887,6 +900,28 @@ pub(crate) mod tests {
             self
         }
 
+        fn demanding_signed_authn_requests(mut self) -> Self {
+            let mut config = saml_config(self.realm.id, self.client.id, NameIdFormat::EmailAddress);
+            config.want_authn_requests_signed = true;
+            let by_entity_id = config.clone();
+
+            self.service_provider_repository
+                .expect_get_by_entity_id()
+                .returning(move |_, _| {
+                    let config = by_entity_id.clone();
+                    Box::pin(async move { Ok(Some(config)) })
+                });
+
+            self.service_provider_repository
+                .expect_get_by_client_id()
+                .returning(move |_| {
+                    let config = config.clone();
+                    Box::pin(async move { Ok(Some(config)) })
+                });
+
+            self
+        }
+
         fn with_registered_service_provider(mut self, name_id_format: NameIdFormat) -> Self {
             let config = saml_config(self.realm.id, self.client.id, name_id_format);
             let by_entity_id = config.clone();
@@ -1121,6 +1156,24 @@ pub(crate) mod tests {
         assert!(
             matches!(rejection, CoreError::InvalidRedirectUri),
             "the session must never be created, or the assertion would later be delivered"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_service_provider_demanding_signed_requests_is_refused_rather_than_served_unsigned() {
+        let harness = Harness::new()
+            .with_realm()
+            .with_client()
+            .demanding_signed_authn_requests();
+
+        let rejection = refusal(
+            harness.build().start_sso(start_input(None, None)).await,
+            "a signature we cannot verify must not be silently waived",
+        );
+
+        assert!(
+            matches!(rejection, CoreError::InvalidRequest),
+            "the administrator asked for signed requests, so serving an unsigned one is a lie"
         );
     }
 

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -1103,6 +1103,49 @@ export namespace Schemas {
     value: WebOriginValue;
   };
   export type CreateWebOriginValidator = Partial<{ value: string }>;
+  export type SamlNameIdFormat =
+    | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+    | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+    | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+    | "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+  export type SamlAttributeNameFormat =
+    | "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
+    | "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    | "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified";
+  export type ClientSamlConfig = {
+    acs_url: string;
+    client_id: string;
+    created_at: string;
+    name_id_format: SamlNameIdFormat;
+    realm_id: RealmId;
+    sign_assertions: boolean;
+    sign_documents: boolean;
+    sp_entity_id: string;
+    updated_at: string;
+    want_authn_requests_signed: boolean;
+  };
+  export type SetClientSamlConfigValidator = {
+    acs_url: string;
+    name_id_format?: string | undefined;
+    sign_assertions?: boolean | undefined;
+    sign_documents?: boolean | undefined;
+    sp_entity_id: string;
+    want_authn_requests_signed?: boolean | undefined;
+  };
+  export type SamlAttributeMapper = {
+    client_id: string;
+    created_at: string;
+    id: string;
+    name: string;
+    name_format: SamlAttributeNameFormat;
+    source: string;
+    updated_at: string;
+  };
+  export type CreateSamlAttributeMapperValidator = {
+    name: string;
+    name_format?: string | undefined;
+    source: string;
+  };
 
   // </Schemas>
 }
@@ -1732,6 +1775,87 @@ export namespace Endpoints {
     requestFormat: "json";
     parameters: {
       path: { realm_name: string; client_id: string; web_origin_id: string };
+    };
+    responses: {
+      200: unknown;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type get_Get_client_saml_config = {
+    method: "GET";
+    path: "/realms/{realm_name}/clients/{client_id}/saml-config";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+    };
+    responses: {
+      200: Schemas.ClientSamlConfig;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type put_Set_client_saml_config = {
+    method: "PUT";
+    path: "/realms/{realm_name}/clients/{client_id}/saml-config";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+
+      body: Schemas.SetClientSamlConfigValidator;
+    };
+    responses: {
+      201: Schemas.ClientSamlConfig;
+      400: Schemas.ApiErrorResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type get_Get_saml_attribute_mappers = {
+    method: "GET";
+    path: "/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+    };
+    responses: {
+      200: Array<Schemas.SamlAttributeMapper>;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type post_Create_saml_attribute_mapper = {
+    method: "POST";
+    path: "/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+
+      body: Schemas.CreateSamlAttributeMapperValidator;
+    };
+    responses: {
+      201: Schemas.SamlAttributeMapper;
+      400: Schemas.ApiErrorResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type delete_Delete_saml_attribute_mapper = {
+    method: "DELETE";
+    path: "/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers/{mapper_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string; mapper_id: string };
     };
     responses: {
       200: unknown;
@@ -3835,6 +3959,8 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/{client_id}/post-logout-redirects": Endpoints.get_Get_post_logout_redirect_uris;
     "/realms/{realm_name}/clients/{client_id}/redirects": Endpoints.get_Get_redirect_uris;
     "/realms/{realm_name}/clients/{client_id}/roles": Endpoints.get_Get_client_roles;
+    "/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers": Endpoints.get_Get_saml_attribute_mappers;
+    "/realms/{realm_name}/clients/{client_id}/saml-config": Endpoints.get_Get_client_saml_config;
     "/realms/{realm_name}/clients/{client_id}/web-origins": Endpoints.get_Get_web_origins;
     "/realms/{realm_name}/compass/v1/activity/daily": Endpoints.get_Get_daily_activity_stats;
     "/realms/{realm_name}/compass/v1/flows": Endpoints.get_Get_flows;
@@ -3904,6 +4030,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/{client_id}/post-logout-redirects": Endpoints.post_Create_post_logout_redirect_uri;
     "/realms/{realm_name}/clients/{client_id}/redirects": Endpoints.post_Create_redirect_uri;
     "/realms/{realm_name}/clients/{client_id}/roles": Endpoints.post_Create_client_role;
+    "/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers": Endpoints.post_Create_saml_attribute_mapper;
     "/realms/{realm_name}/clients/{client_id}/web-origins": Endpoints.post_Create_web_origin;
     "/realms/{realm_name}/device/verify": Endpoints.post_Device_verify;
     "/realms/{realm_name}/email-templates": Endpoints.post_Create_template;
@@ -3958,6 +4085,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/{client_id}/optional-client-scopes/{scope_id}": Endpoints.put_Assign_optional_scope;
     "/realms/{realm_name}/clients/{client_id}/post-logout-redirects/{uri_id}": Endpoints.put_Update_post_logout_redirect_uri;
     "/realms/{realm_name}/clients/{client_id}/redirects/{uri_id}": Endpoints.put_Update_redirect_uri;
+    "/realms/{realm_name}/clients/{client_id}/saml-config": Endpoints.put_Set_client_saml_config;
     "/realms/{realm_name}/email-templates/{template_id}": Endpoints.put_Update_template;
     "/realms/{realm_name}/federation/providers/{id}": Endpoints.put_Update_provider;
     "/realms/{realm_name}/identity-providers/{alias}": Endpoints.put_Update_identity_provider;
@@ -3989,6 +4117,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/{client_id}/optional-client-scopes/{scope_id}": Endpoints.delete_Unassign_optional_scope;
     "/realms/{realm_name}/clients/{client_id}/post-logout-redirects/{uri_id}": Endpoints.delete_Delete_post_logout_redirect_uri;
     "/realms/{realm_name}/clients/{client_id}/redirects/{uri_id}": Endpoints.delete_Delete_redirect_uri;
+    "/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers/{mapper_id}": Endpoints.delete_Delete_saml_attribute_mapper;
     "/realms/{realm_name}/clients/{client_id}/web-origins/{web_origin_id}": Endpoints.delete_Delete_web_origin;
     "/realms/{realm_name}/email-templates/{template_id}": Endpoints.delete_Delete_template;
     "/realms/{realm_name}/federation/providers/{id}": Endpoints.delete_Delete_provider;

--- a/front/src/api/saml.api.ts
+++ b/front/src/api/saml.api.ts
@@ -1,0 +1,145 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { Schemas } from './api.client'
+
+export const samlConfigQueryKey = (realmName: string, clientId: string) => [
+  'saml-config',
+  realmName,
+  clientId,
+]
+
+export const samlAttributeMappersQueryKey = (realmName: string, clientId: string) => [
+  'saml-attribute-mappers',
+  realmName,
+  clientId,
+]
+
+function isNotConfigured(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    (error as { status?: number }).status === 404
+  )
+}
+
+export const useGetSamlConfig = ({
+  realmName,
+  clientId,
+}: {
+  realmName?: string
+  clientId?: string
+}) => {
+  return useQuery({
+    queryKey: samlConfigQueryKey(realmName ?? '', clientId ?? ''),
+    queryFn: async (): Promise<Schemas.ClientSamlConfig | null> => {
+      try {
+        return (await window.tanstackApi.client.get(
+          '/realms/{realm_name}/clients/{client_id}/saml-config',
+          { path: { realm_name: realmName!, client_id: clientId! } }
+        )) as Schemas.ClientSamlConfig
+      } catch (error) {
+        if (isNotConfigured(error)) return null
+        throw error
+      }
+    },
+    enabled: !!realmName && !!clientId,
+  })
+}
+
+export interface UpsertSamlConfigMutate {
+  realmName: string
+  clientId: string
+  payload: Schemas.SetClientSamlConfigValidator
+}
+
+export const useUpsertSamlConfig = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ realmName, clientId, payload }: UpsertSamlConfigMutate) => {
+      return window.tanstackApi.client.put(
+        '/realms/{realm_name}/clients/{client_id}/saml-config',
+        {
+          path: { realm_name: realmName, client_id: clientId },
+          body: payload,
+        }
+      ) as Promise<Schemas.ClientSamlConfig>
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: samlConfigQueryKey(variables.realmName, variables.clientId),
+      })
+    },
+  })
+}
+
+export const useGetSamlAttributeMappers = ({
+  realmName,
+  clientId,
+}: {
+  realmName?: string
+  clientId?: string
+}) => {
+  return useQuery({
+    queryKey: samlAttributeMappersQueryKey(realmName ?? '', clientId ?? ''),
+    queryFn: async () =>
+      window.tanstackApi.client.get(
+        '/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers',
+        { path: { realm_name: realmName!, client_id: clientId! } }
+      ) as Promise<Schemas.SamlAttributeMapper[]>,
+    enabled: !!realmName && !!clientId,
+  })
+}
+
+export interface CreateSamlAttributeMapperMutate {
+  realmName: string
+  clientId: string
+  payload: Schemas.CreateSamlAttributeMapperValidator
+}
+
+export const useCreateSamlAttributeMapper = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ realmName, clientId, payload }: CreateSamlAttributeMapperMutate) => {
+      return window.tanstackApi.client.post(
+        '/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers',
+        {
+          path: { realm_name: realmName, client_id: clientId },
+          body: payload,
+        }
+      ) as Promise<Schemas.SamlAttributeMapper>
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: samlAttributeMappersQueryKey(variables.realmName, variables.clientId),
+      })
+    },
+  })
+}
+
+export interface DeleteSamlAttributeMapperMutate {
+  realmName: string
+  clientId: string
+  mapperId: string
+}
+
+export const useDeleteSamlAttributeMapper = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ realmName, clientId, mapperId }: DeleteSamlAttributeMapperMutate) => {
+      return window.tanstackApi.client.delete(
+        '/realms/{realm_name}/clients/{client_id}/saml-attribute-mappers/{mapper_id}',
+        {
+          path: { realm_name: realmName, client_id: clientId, mapper_id: mapperId },
+        }
+      )
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: samlAttributeMappersQueryKey(variables.realmName, variables.clientId),
+      })
+    },
+  })
+}

--- a/front/src/hooks/use-saml-service-provider.ts
+++ b/front/src/hooks/use-saml-service-provider.ts
@@ -1,0 +1,100 @@
+import type { Schemas } from '@/api/api.client'
+import {
+  useCreateSamlAttributeMapper,
+  useDeleteSamlAttributeMapper,
+  useGetSamlAttributeMappers,
+  useGetSamlConfig,
+  useUpsertSamlConfig,
+} from '@/api/saml.api'
+import { apiErrorMessage } from '@/lib/api-error'
+import { AttributeMapperDraft, DEFAULT_ATTRIBUTE_NAME_FORMAT } from '@/lib/saml'
+import { toast } from 'sonner'
+
+export interface SamlAttributeMapperInput extends AttributeMapperDraft {
+  nameFormat?: string
+}
+
+export function useSamlServiceProvider(realmName?: string, clientId?: string) {
+  const { data: config, isLoading: isLoadingConfig } = useGetSamlConfig({ realmName, clientId })
+  const { data: mappers = [], isLoading: isLoadingMappers } = useGetSamlAttributeMappers({
+    realmName,
+    clientId,
+  })
+
+  const { mutateAsync: upsertConfig, isPending: isSavingConfig } = useUpsertSamlConfig()
+  const { mutateAsync: createMapper, isPending: isCreatingMapper } = useCreateSamlAttributeMapper()
+  const { mutateAsync: removeMapper, isPending: isDeletingMapper } = useDeleteSamlAttributeMapper()
+
+  const isConfigured = config != null
+
+  const saveConfig = async (
+    payload: Schemas.SetClientSamlConfigValidator,
+  ): Promise<boolean> => {
+    if (!realmName || !clientId) return false
+
+    try {
+      await upsertConfig({ realmName, clientId, payload })
+      toast.success(
+        isConfigured ? 'Service provider updated' : 'Service provider configured',
+      )
+      return true
+    } catch (error) {
+      toast.error(apiErrorMessage(error, 'Could not save the service provider'))
+      return false
+    }
+  }
+
+  const addAttributeMapper = async (input: SamlAttributeMapperInput): Promise<boolean> => {
+    if (!realmName || !clientId) return false
+
+    try {
+      await createMapper({
+        realmName,
+        clientId,
+        payload: {
+          name: input.name.trim(),
+          source: input.source,
+          name_format: input.nameFormat ?? DEFAULT_ATTRIBUTE_NAME_FORMAT,
+        },
+      })
+      toast.success(`Attribute ${input.name.trim()} mapped`)
+      return true
+    } catch (error) {
+      toast.error(apiErrorMessage(error, 'Could not map the attribute'))
+      return false
+    }
+  }
+
+  const deleteAttributeMapper = async (mapperId: string): Promise<boolean> => {
+    if (!realmName || !clientId) return false
+
+    try {
+      await removeMapper({ realmName, clientId, mapperId })
+      toast.success('Attribute mapping removed')
+      return true
+    } catch (error) {
+      toast.error(apiErrorMessage(error, 'Could not remove the attribute mapping'))
+      return false
+    }
+  }
+
+  const addCommonProfileMappers = async (drafts: AttributeMapperDraft[]): Promise<void> => {
+    for (const draft of drafts) {
+      await addAttributeMapper(draft)
+    }
+  }
+
+  return {
+    config: config ?? null,
+    mappers,
+    isConfigured,
+    isLoading: isLoadingConfig || isLoadingMappers,
+    isSavingConfig,
+    isCreatingMapper,
+    isDeletingMapper,
+    saveConfig,
+    addAttributeMapper,
+    deleteAttributeMapper,
+    addCommonProfileMappers,
+  }
+}

--- a/front/src/lib/api-error.ts
+++ b/front/src/lib/api-error.ts
@@ -1,0 +1,19 @@
+interface FieldValidationError {
+  field: string
+  message: string
+}
+
+export function apiErrorMessage(error: unknown, fallback: string): string {
+  const data = (error as { data?: { errors?: FieldValidationError[] } } | null)?.data
+  const fieldErrors = data?.errors
+
+  if (Array.isArray(fieldErrors) && fieldErrors.length > 0) {
+    return fieldErrors.map((fieldError) => fieldError.message).join(' — ')
+  }
+
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message
+  }
+
+  return fallback
+}

--- a/front/src/lib/saml.ts
+++ b/front/src/lib/saml.ts
@@ -1,0 +1,117 @@
+import type { Schemas } from '@/api/api.client'
+
+export interface SamlOption<TValue extends string> {
+  value: TValue
+  label: string
+  description: string
+}
+
+const NAME_ID_FORMATS: Record<Schemas.SamlNameIdFormat, Omit<SamlOption<string>, 'value'>> = {
+  'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress': {
+    label: 'Email address',
+    description: 'The user is identified by their email address. What most applications expect.',
+  },
+  'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent': {
+    label: 'Persistent',
+    description: 'A stable opaque identifier that stays the same across sessions.',
+  },
+  'urn:oasis:names:tc:SAML:2.0:nameid-format:transient': {
+    label: 'Transient',
+    description: 'A throwaway identifier, regenerated at every sign-in.',
+  },
+  'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified': {
+    label: 'Unspecified',
+    description: 'Let the application decide how to read the identifier.',
+  },
+}
+
+const ATTRIBUTE_NAME_FORMATS: Record<
+  Schemas.SamlAttributeNameFormat,
+  Omit<SamlOption<string>, 'value'>
+> = {
+  'urn:oasis:names:tc:SAML:2.0:attrname-format:basic': {
+    label: 'Basic',
+    description: 'Plain attribute names such as email. The usual choice.',
+  },
+  'urn:oasis:names:tc:SAML:2.0:attrname-format:uri': {
+    label: 'URI',
+    description: 'Attribute names written as full URIs.',
+  },
+  'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified': {
+    label: 'Unspecified',
+    description: 'Send no format hint to the application.',
+  },
+}
+
+function toOptions<TValue extends string>(
+  formats: Record<TValue, Omit<SamlOption<string>, 'value'>>,
+): SamlOption<TValue>[] {
+  return (Object.keys(formats) as TValue[]).map((value) => ({ value, ...formats[value] }))
+}
+
+export const NAME_ID_FORMAT_OPTIONS = toOptions<Schemas.SamlNameIdFormat>(NAME_ID_FORMATS)
+
+export const ATTRIBUTE_NAME_FORMAT_OPTIONS =
+  toOptions<Schemas.SamlAttributeNameFormat>(ATTRIBUTE_NAME_FORMATS)
+
+export const DEFAULT_NAME_ID_FORMAT: Schemas.SamlNameIdFormat =
+  'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+
+export const DEFAULT_ATTRIBUTE_NAME_FORMAT: Schemas.SamlAttributeNameFormat =
+  'urn:oasis:names:tc:SAML:2.0:attrname-format:basic'
+
+const CUSTOM_ATTRIBUTE_PREFIX = 'attribute:'
+
+export const CUSTOM_ATTRIBUTE_SOURCE = 'custom'
+
+const BUILT_IN_SOURCES = {
+  'user:email': 'Email',
+  'user:username': 'Username',
+  'user:first_name': 'First name',
+  'user:last_name': 'Last name',
+  'user:id': 'User ID',
+} as const
+
+export type BuiltInAttributeSource = keyof typeof BUILT_IN_SOURCES
+
+export const BUILT_IN_SOURCE_OPTIONS = (
+  Object.keys(BUILT_IN_SOURCES) as BuiltInAttributeSource[]
+).map((value) => ({ value, label: BUILT_IN_SOURCES[value] }))
+
+export function isCustomAttributeSource(source: string): boolean {
+  return source.startsWith(CUSTOM_ATTRIBUTE_PREFIX)
+}
+
+export function customAttributeKey(source: string): string {
+  return isCustomAttributeSource(source) ? source.slice(CUSTOM_ATTRIBUTE_PREFIX.length) : ''
+}
+
+export function toCustomAttributeSource(key: string): string {
+  return `${CUSTOM_ATTRIBUTE_PREFIX}${key.trim()}`
+}
+
+export function describeAttributeSource(source: string): string {
+  if (isCustomAttributeSource(source)) {
+    return `Custom attribute ${customAttributeKey(source)}`
+  }
+  return BUILT_IN_SOURCES[source as BuiltInAttributeSource] ?? source
+}
+
+export function describeNameIdFormat(format: string): string {
+  return NAME_ID_FORMATS[format as Schemas.SamlNameIdFormat]?.label ?? format
+}
+
+export function describeAttributeNameFormat(format: string): string {
+  return ATTRIBUTE_NAME_FORMATS[format as Schemas.SamlAttributeNameFormat]?.label ?? format
+}
+
+export interface AttributeMapperDraft {
+  name: string
+  source: string
+}
+
+export const COMMON_PROFILE_MAPPERS: AttributeMapperDraft[] = [
+  { name: 'email', source: 'user:email' },
+  { name: 'first_name', source: 'user:first_name' },
+  { name: 'last_name', source: 'user:last_name' },
+]

--- a/front/src/pages/client/components/manage-saml-attribute-mappers.tsx
+++ b/front/src/pages/client/components/manage-saml-attribute-mappers.tsx
@@ -1,0 +1,234 @@
+import { Button } from '@/components/ui/button'
+import { ConfirmDeleteAlert } from '@/components/confirm-delete-alert'
+import { Form, FormField, FormItem, FormLabel, FormControl } from '@/components/ui/form'
+import { InputText } from '@/components/ui/input-text'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useConfirmDeleteAlert } from '@/hooks/use-confirm-delete-alert.ts'
+import {
+  ATTRIBUTE_NAME_FORMAT_OPTIONS,
+  AttributeMapperDraft,
+  BUILT_IN_SOURCE_OPTIONS,
+  COMMON_PROFILE_MAPPERS,
+  CUSTOM_ATTRIBUTE_SOURCE,
+  DEFAULT_ATTRIBUTE_NAME_FORMAT,
+  describeAttributeNameFormat,
+  describeAttributeSource,
+  toCustomAttributeSource,
+} from '@/lib/saml'
+import type { Schemas } from '@/api/api.client'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Trash2 } from 'lucide-react'
+import { useForm, useWatch } from 'react-hook-form'
+import {
+  samlAttributeMapperSchema,
+  SamlAttributeMapperSchema,
+} from '../schemas/saml-service-provider.schema'
+import { SamlAttributeMapperInput } from '@/hooks/use-saml-service-provider'
+
+export interface ManageSamlAttributeMappersProps {
+  mappers: Schemas.SamlAttributeMapper[]
+  isCreating: boolean
+  isDeleting: boolean
+  onAdd: (input: SamlAttributeMapperInput) => Promise<boolean>
+  onDelete: (mapperId: string) => Promise<boolean>
+  onAddCommonProfile: (drafts: AttributeMapperDraft[]) => Promise<void>
+}
+
+export default function ManageSamlAttributeMappers({
+  mappers,
+  isCreating,
+  isDeleting,
+  onAdd,
+  onDelete,
+  onAddCommonProfile,
+}: ManageSamlAttributeMappersProps) {
+  const { confirm, ask, close } = useConfirmDeleteAlert()
+
+  const form = useForm<SamlAttributeMapperSchema>({
+    resolver: zodResolver(samlAttributeMapperSchema),
+    defaultValues: {
+      name: '',
+      source: BUILT_IN_SOURCE_OPTIONS[0].value,
+      customKey: '',
+      nameFormat: DEFAULT_ATTRIBUTE_NAME_FORMAT,
+    },
+  })
+
+  const source = useWatch({ control: form.control, name: 'source' })
+  const isCustomSource = source === CUSTOM_ATTRIBUTE_SOURCE
+
+  const handleDelete = (mapper: Schemas.SamlAttributeMapper) => {
+    ask({
+      title: `Stop sending ${mapper.name}?`,
+      description:
+        'The application will no longer receive this attribute on the next sign-in. Anything relying on it may break.',
+      onConfirm: async () => {
+        if (await onDelete(mapper.id)) {
+          close()
+        }
+      },
+    })
+  }
+
+  const onSubmit = async (values: SamlAttributeMapperSchema) => {
+    const added = await onAdd({
+      name: values.name,
+      source: isCustomSource ? toCustomAttributeSource(values.customKey) : values.source,
+      nameFormat: values.nameFormat,
+    })
+
+    if (added) {
+      form.reset({
+        name: '',
+        source: values.source,
+        customKey: '',
+        nameFormat: values.nameFormat,
+      })
+    }
+  }
+
+  return (
+    <>
+      <div className='flex flex-col gap-4'>
+        {mappers.length === 0 && (
+          <div className='flex flex-col gap-3 rounded-md border border-dashed p-4'>
+            <p className='text-sm text-muted-foreground'>
+              No attributes are sent yet. Most applications need at least an email address.
+            </p>
+            <Button
+              type='button'
+              variant='outline'
+              className='self-start'
+              disabled={isCreating}
+              onClick={() => void onAddCommonProfile(COMMON_PROFILE_MAPPERS)}
+            >
+              Add email, first_name and last_name
+            </Button>
+          </div>
+        )}
+
+        {mappers.map((mapper) => (
+          <div key={mapper.id} className='flex items-center gap-3 rounded-md border px-3 py-2'>
+            <span className='text-sm font-mono truncate'>{mapper.name}</span>
+            <span className='text-xs text-muted-foreground shrink-0'>from</span>
+            <span className='flex-1 text-sm truncate'>
+              {describeAttributeSource(mapper.source)}
+            </span>
+            <span className='text-xs text-muted-foreground shrink-0'>
+              {describeAttributeNameFormat(mapper.name_format)}
+            </span>
+            <Button
+              className='text-red-500 shrink-0'
+              variant='ghost'
+              size='icon'
+              disabled={isDeleting}
+              aria-label={`Remove the ${mapper.name} attribute mapping`}
+              onClick={() => handleDelete(mapper)}
+            >
+              <Trash2 size={14} />
+            </Button>
+          </div>
+        ))}
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className='flex flex-col gap-4'>
+            <FormField
+              control={form.control}
+              name='name'
+              render={({ field }) => (
+                <InputText
+                  {...field}
+                  label='Attribute name'
+                  error={form.formState.errors.name?.message}
+                />
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='source'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>User detail to send</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select a user detail' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {BUILT_IN_SOURCE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                      <SelectItem value={CUSTOM_ATTRIBUTE_SOURCE}>
+                        Custom user attribute
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+
+            {isCustomSource && (
+              <FormField
+                control={form.control}
+                name='customKey'
+                render={({ field }) => (
+                  <InputText
+                    {...field}
+                    label='Attribute key'
+                    error={form.formState.errors.customKey?.message}
+                  />
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name='nameFormat'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name format</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select a name format' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {ATTRIBUTE_NAME_FORMAT_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+
+            <Button type='submit' disabled={isCreating}>
+              Add attribute
+            </Button>
+          </form>
+        </Form>
+      </div>
+
+      <ConfirmDeleteAlert
+        title={confirm.title}
+        description={confirm.description}
+        open={confirm.open}
+        onConfirm={confirm.onConfirm}
+        onCancel={close}
+      />
+    </>
+  )
+}

--- a/front/src/pages/client/feature/page-client-saml-feature.tsx
+++ b/front/src/pages/client/feature/page-client-saml-feature.tsx
@@ -1,0 +1,90 @@
+import { Form } from '@/components/ui/form'
+import { useFormChanges } from '@/hooks/use-form-changes'
+import { useSamlServiceProvider } from '@/hooks/use-saml-service-provider'
+import { DEFAULT_NAME_ID_FORMAT } from '@/lib/saml'
+import { RouterParams } from '@/routes/router'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useEffect, useMemo } from 'react'
+import { useForm } from 'react-hook-form'
+import { useParams } from 'react-router'
+import {
+  samlServiceProviderSchema,
+  SamlServiceProviderSchema,
+} from '../schemas/saml-service-provider.schema'
+import PageClientSaml from '../ui/page-client-saml'
+
+export default function PageClientSamlFeature() {
+  const { realm_name, client_id } = useParams<RouterParams>()
+
+  const {
+    config,
+    mappers,
+    isConfigured,
+    isLoading,
+    isSavingConfig,
+    isCreatingMapper,
+    isDeletingMapper,
+    saveConfig,
+    addAttributeMapper,
+    deleteAttributeMapper,
+    addCommonProfileMappers,
+  } = useSamlServiceProvider(realm_name, client_id)
+
+  const values = useMemo<SamlServiceProviderSchema>(
+    () => ({
+      spEntityId: config?.sp_entity_id ?? '',
+      acsUrl: config?.acs_url ?? '',
+      nameIdFormat: config?.name_id_format ?? DEFAULT_NAME_ID_FORMAT,
+      signAssertions: config?.sign_assertions ?? true,
+      signDocuments: config?.sign_documents ?? false,
+      wantAuthnRequestsSigned: config?.want_authn_requests_signed ?? false,
+    }),
+    [config]
+  )
+
+  const form = useForm<SamlServiceProviderSchema>({
+    resolver: zodResolver(samlServiceProviderSchema),
+    defaultValues: values,
+  })
+
+  const hasChanges = useFormChanges(form, values)
+
+  useEffect(() => {
+    form.reset(values)
+  }, [values, form])
+
+  const handleSubmit = form.handleSubmit(async (submitted) => {
+    await saveConfig({
+      sp_entity_id: submitted.spEntityId.trim(),
+      acs_url: submitted.acsUrl.trim(),
+      name_id_format: submitted.nameIdFormat,
+      sign_assertions: submitted.signAssertions,
+      sign_documents: submitted.signDocuments,
+      want_authn_requests_signed: submitted.wantAuthnRequestsSigned,
+    })
+  })
+
+  if (isLoading) {
+    return <p className='text-sm text-muted-foreground'>Loading the SAML configuration…</p>
+  }
+
+  return (
+    <Form {...form}>
+      <PageClientSaml
+        form={form}
+        isConfigured={isConfigured}
+        isSaving={isSavingConfig}
+        hasChanges={hasChanges}
+        handleSubmit={handleSubmit}
+        mapperProps={{
+          mappers,
+          isCreating: isCreatingMapper,
+          isDeleting: isDeletingMapper,
+          onAdd: addAttributeMapper,
+          onDelete: deleteAttributeMapper,
+          onAddCommonProfile: addCommonProfileMappers,
+        }}
+      />
+    </Form>
+  )
+}

--- a/front/src/pages/client/layout/client-layout.tsx
+++ b/front/src/pages/client/layout/client-layout.tsx
@@ -24,6 +24,7 @@ export default function ClientLayout() {
       : []),
     { key: 'roles', label: 'Roles', path: `${baseUrl}/roles` },
     { key: 'client-scopes', label: 'Client Scopes', path: `${baseUrl}/scopes` },
+    { key: 'saml', label: 'SAML', path: `${baseUrl}/saml` },
     { key: 'maintenance', label: 'Maintenance', path: `${baseUrl}/maintenance` },
   ]
 

--- a/front/src/pages/client/page-client.tsx
+++ b/front/src/pages/client/page-client.tsx
@@ -8,6 +8,7 @@ import PageCreateClientFeature from '@/pages/client/feature/page-create-client-f
 import PageClientRolesFeature from './feature/page-client-roles-feature'
 import PageClientScopesFeature from './feature/page-client-scopes-feature'
 import PageClientMaintenanceFeature from './feature/page-client-maintenance-feature'
+import PageClientSamlFeature from './feature/page-client-saml-feature'
 
 export default function PageClient() {
   return (
@@ -22,6 +23,7 @@ export default function PageClient() {
         <Route path='/:client_id/credentials' element={<PageClientCredentialsFeature />} />
         <Route path='/:client_id/roles' element={<PageClientRolesFeature />} />
         <Route path='/:client_id/scopes' element={<PageClientScopesFeature />} />
+        <Route path='/:client_id/saml' element={<PageClientSamlFeature />} />
         <Route path='/:client_id/maintenance' element={<PageClientMaintenanceFeature />} />
       </Route>
     </Routes>

--- a/front/src/pages/client/schemas/saml-service-provider.schema.ts
+++ b/front/src/pages/client/schemas/saml-service-provider.schema.ts
@@ -1,0 +1,28 @@
+import { CUSTOM_ATTRIBUTE_SOURCE } from '@/lib/saml'
+import { z } from 'zod'
+
+export const samlServiceProviderSchema = z.object({
+  spEntityId: z.string().min(1, { message: 'Entity ID is required' }),
+  acsUrl: z.string().min(1, { message: 'Assertion Consumer Service URL is required' }),
+  nameIdFormat: z.string().min(1, { message: 'Name ID format is required' }),
+  signAssertions: z.boolean(),
+  signDocuments: z.boolean(),
+  wantAuthnRequestsSigned: z.boolean(),
+})
+
+export type SamlServiceProviderSchema = z.infer<typeof samlServiceProviderSchema>
+
+export const samlAttributeMapperSchema = z
+  .object({
+    name: z.string().min(1, { message: 'Attribute name is required' }),
+    source: z.string().min(1, { message: 'Pick which user detail to send' }),
+    customKey: z.string(),
+    nameFormat: z.string().min(1, { message: 'Name format is required' }),
+  })
+  .refine(
+    (values) =>
+      values.source !== CUSTOM_ATTRIBUTE_SOURCE || values.customKey.trim().length > 0,
+    { message: 'Attribute key is required', path: ['customKey'] }
+  )
+
+export type SamlAttributeMapperSchema = z.infer<typeof samlAttributeMapperSchema>

--- a/front/src/pages/client/ui/page-client-saml.tsx
+++ b/front/src/pages/client/ui/page-client-saml.tsx
@@ -1,0 +1,247 @@
+import { InputText } from '@/components/ui/input-text'
+import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/form'
+import { Switch } from '@/components/ui/switch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import FloatingActionBar from '@/components/ui/floating-action-bar'
+import { Button } from '@/components/ui/button'
+import { NAME_ID_FORMAT_OPTIONS } from '@/lib/saml'
+import { UseFormReturn } from 'react-hook-form'
+import { SamlServiceProviderSchema } from '../schemas/saml-service-provider.schema'
+import ManageSamlAttributeMappers, {
+  ManageSamlAttributeMappersProps,
+} from '../components/manage-saml-attribute-mappers'
+
+export interface PageClientSamlProps {
+  form: UseFormReturn<SamlServiceProviderSchema>
+  isConfigured: boolean
+  isSaving: boolean
+  hasChanges: boolean
+  handleSubmit: () => void
+  mapperProps: ManageSamlAttributeMappersProps
+}
+
+export default function PageClientSaml({
+  form,
+  isConfigured,
+  isSaving,
+  hasChanges,
+  handleSubmit,
+  mapperProps,
+}: PageClientSamlProps) {
+  return (
+    <div className='flex flex-col gap-8'>
+      {!isConfigured && (
+        <div className='rounded-md border bg-muted/40 p-4'>
+          <p className='text-sm font-medium'>This client does not use SAML yet</p>
+          <p className='text-sm text-muted-foreground mt-1'>
+            Fill in the two values the application shows on its SAML settings page, then save.
+            FerrisKey will start answering SAML sign-in requests for it.
+          </p>
+        </div>
+      )}
+
+      <div className='flex flex-col gap-1'>
+        <div className='mb-4'>
+          <p className='text-xs text-muted-foreground mb-0.5'>SAML 2.0</p>
+          <h2 className='text-base font-semibold'>Service Provider</h2>
+          <p className='text-sm text-muted-foreground mt-1'>
+            Identifies the application and tells FerrisKey where to send the assertion.
+          </p>
+        </div>
+
+        <FormField
+          control={form.control}
+          name='spEntityId'
+          render={({ field }) => (
+            <div className='flex items-start justify-between py-4 border-t'>
+              <div className='w-1/3'>
+                <p className='text-sm font-medium'>Entity ID</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>
+                  The unique identifier the application publishes for itself, for example{' '}
+                  <code>https://chat.acme.com/saml/sp/1</code>.
+                </p>
+              </div>
+              <div className='w-1/2'>
+                <InputText
+                  label='Entity ID'
+                  name='sp_entity_id'
+                  value={field.value}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  error={form.formState.errors.spEntityId?.message}
+                />
+              </div>
+            </div>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='acsUrl'
+          render={({ field }) => (
+            <div className='flex items-start justify-between py-4 border-t'>
+              <div className='w-1/3'>
+                <p className='text-sm font-medium'>Assertion Consumer Service URL</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>
+                  Where the signed assertion is posted after the user signs in.
+                </p>
+              </div>
+              <div className='w-1/2'>
+                <InputText
+                  label='ACS URL'
+                  name='acs_url'
+                  value={field.value}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  error={form.formState.errors.acsUrl?.message}
+                />
+              </div>
+            </div>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='nameIdFormat'
+          render={({ field }) => (
+            <div className='flex items-start justify-between py-4 border-t'>
+              <div className='w-1/3'>
+                <p className='text-sm font-medium'>Name ID Format</p>
+                <p className='text-sm text-muted-foreground mt-0.5'>
+                  How the user is identified inside the assertion.
+                </p>
+              </div>
+              <div className='w-1/2'>
+                <FormItem>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select a name ID format' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {NAME_ID_FORMAT_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              </div>
+            </div>
+          )}
+        />
+      </div>
+
+      <div className='flex flex-col gap-1'>
+        <div className='mb-4'>
+          <p className='text-xs text-muted-foreground mb-0.5'>Assertion security</p>
+          <h2 className='text-base font-semibold'>Signatures</h2>
+        </div>
+
+        <SignatureToggle
+          form={form}
+          name='signAssertions'
+          title='Sign Assertions'
+          description='Sign the assertion itself. Almost every application expects this.'
+        />
+
+        <SignatureToggle
+          form={form}
+          name='signDocuments'
+          title='Sign Documents'
+          description='Sign the whole SAML response in addition to the assertion.'
+        />
+
+        <SignatureToggle
+          form={form}
+          name='wantAuthnRequestsSigned'
+          title='Require Signed Authentication Requests'
+          description='Reject sign-in requests from this application unless they carry a valid signature.'
+        />
+      </div>
+
+      {!isConfigured && (
+        <div>
+          <Button type='button' disabled={isSaving} onClick={handleSubmit}>
+            Enable SAML
+          </Button>
+        </div>
+      )}
+
+      {isConfigured && (
+        <div className='flex flex-col gap-1'>
+          <div className='mb-4'>
+            <p className='text-xs text-muted-foreground mb-0.5'>Sent with every assertion</p>
+            <h2 className='text-base font-semibold'>Attribute Mappings</h2>
+            <p className='text-sm text-muted-foreground mt-1'>
+              User details sent alongside the assertion. Match the attribute names the application
+              asks for.
+            </p>
+          </div>
+
+          <div className='py-4 border-t'>
+            <ManageSamlAttributeMappers {...mapperProps} />
+          </div>
+        </div>
+      )}
+
+      {isConfigured && (
+        <FloatingActionBar
+          show={hasChanges}
+          title='Save Changes'
+          actions={[
+            {
+              label: 'Save',
+              variant: 'default',
+              onClick: handleSubmit,
+            },
+          ]}
+          description='Save the SAML service provider settings for this client.'
+          onCancel={() => form.reset()}
+        />
+      )}
+    </div>
+  )
+}
+
+interface SignatureToggleProps {
+  form: UseFormReturn<SamlServiceProviderSchema>
+  name: 'signAssertions' | 'signDocuments' | 'wantAuthnRequestsSigned'
+  title: string
+  description: string
+}
+
+function SignatureToggle({ form, name, title, description }: SignatureToggleProps) {
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <div className='flex items-center justify-between py-4 border-t'>
+          <div className='w-1/3'>
+            <p className='text-sm font-medium'>{title}</p>
+            <p className='text-sm text-muted-foreground mt-0.5'>{description}</p>
+          </div>
+          <div className='w-1/2'>
+            <FormItem className='flex flex-row items-center gap-3'>
+              <FormControl>
+                <Switch checked={field.value} onCheckedChange={field.onChange} />
+              </FormControl>
+              <FormLabel className='!mt-0 font-normal text-muted-foreground'>
+                {field.value ? 'Enabled' : 'Disabled'}
+              </FormLabel>
+            </FormItem>
+          </div>
+        </div>
+      )}
+    />
+  )
+}

--- a/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
+++ b/front/src/pages/console-applications/feature/page-application-detail-feature.tsx
@@ -14,6 +14,7 @@ import ApiAccessTab from '../ui/tabs/api-access-tab'
 import ComingSoonTab from '../ui/tabs/coming-soon-tab'
 import CredentialsTab from '../ui/tabs/credentials-tab'
 import QuickstartTab from '../ui/tabs/quickstart-tab'
+import SamlTab from '../ui/tabs/saml-tab'
 import SettingsTab, { ApplicationSettingsValues } from '../ui/tabs/settings-tab'
 import { inferApplicationType } from '../types'
 
@@ -155,6 +156,7 @@ export default function PageApplicationDetailFeature() {
     { id: 'credentials', label: 'Credentials' },
     ...(isInteractive ? [{ id: 'connections', label: 'Connections', soon: true } as TabDef] : []),
     { id: 'api-access', label: 'API Access' },
+    ...(isInteractive ? [{ id: 'saml', label: 'SAML' } as TabDef] : []),
     ...(isInteractive ? [{ id: 'addons', label: 'Addons', soon: true } as TabDef] : []),
     ...(isInteractive
       ? [{ id: 'login-experience', label: 'Login Experience', soon: true } as TabDef]
@@ -204,6 +206,8 @@ export default function PageApplicationDetailFeature() {
         return <CredentialsTab client={client} realm={realm} />
       case 'api-access':
         return <ApiAccessTab realm={realm} clientId={client.id} />
+      case 'saml':
+        return <SamlTab realm={realm} clientId={client.id} />
       case 'maintenance':
         return <PageClientMaintenanceFeature />
       case 'connections':
@@ -235,8 +239,8 @@ export default function PageApplicationDetailFeature() {
           <ComingSoonTab
             icon={Puzzle}
             title='Addons'
-            description='Enable protocol addons such as SAML and WS-Federation for this application.'
-            points={['SAML 2.0 service provider', 'WS-Federation', 'Token customization addons']}
+            description='Enable further protocol addons for this application. SAML 2.0 now has its own tab.'
+            points={['WS-Federation', 'Token customization addons']}
           />
         )
       default:

--- a/front/src/pages/console-applications/ui/application-detail-shell.tsx
+++ b/front/src/pages/console-applications/ui/application-detail-shell.tsx
@@ -11,6 +11,7 @@ export type AppTab =
   | 'api-access'
   | 'connections'
   | 'login-experience'
+  | 'saml'
   | 'addons'
   | 'maintenance'
 

--- a/front/src/pages/console-applications/ui/tabs/saml-tab.tsx
+++ b/front/src/pages/console-applications/ui/tabs/saml-tab.tsx
@@ -1,0 +1,408 @@
+import { Schemas } from '@/api/api.client'
+import { Switch } from '@/components/ui/switch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useSamlServiceProvider } from '@/hooks/use-saml-service-provider'
+import {
+  ATTRIBUTE_NAME_FORMAT_OPTIONS,
+  BUILT_IN_SOURCE_OPTIONS,
+  COMMON_PROFILE_MAPPERS,
+  CUSTOM_ATTRIBUTE_SOURCE,
+  DEFAULT_ATTRIBUTE_NAME_FORMAT,
+  DEFAULT_NAME_ID_FORMAT,
+  NAME_ID_FORMAT_OPTIONS,
+  describeAttributeNameFormat,
+  describeAttributeSource,
+  toCustomAttributeSource,
+} from '@/lib/saml'
+import { Loader2, Plus, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Field, Section } from './primitives'
+
+import ClientSamlConfig = Schemas.ClientSamlConfig
+
+interface ServiceProviderValues {
+  spEntityId: string
+  acsUrl: string
+  nameIdFormat: string
+  signAssertions: boolean
+  signDocuments: boolean
+  wantAuthnRequestsSigned: boolean
+}
+
+const BLANK_SERVICE_PROVIDER: ServiceProviderValues = {
+  spEntityId: '',
+  acsUrl: '',
+  nameIdFormat: DEFAULT_NAME_ID_FORMAT,
+  signAssertions: true,
+  signDocuments: false,
+  wantAuthnRequestsSigned: false,
+}
+
+function valuesFromConfig(config: ClientSamlConfig | null): ServiceProviderValues {
+  if (!config) return BLANK_SERVICE_PROVIDER
+  return {
+    spEntityId: config.sp_entity_id,
+    acsUrl: config.acs_url,
+    nameIdFormat: config.name_id_format,
+    signAssertions: config.sign_assertions,
+    signDocuments: config.sign_documents,
+    wantAuthnRequestsSigned: config.want_authn_requests_signed,
+  }
+}
+
+interface Props {
+  realm: string
+  clientId: string
+}
+
+export default function SamlTab({ realm, clientId }: Props) {
+  const {
+    config,
+    mappers,
+    isConfigured,
+    isLoading,
+    isSavingConfig,
+    isCreatingMapper,
+    isDeletingMapper,
+    saveConfig,
+    addAttributeMapper,
+    deleteAttributeMapper,
+    addCommonProfileMappers,
+  } = useSamlServiceProvider(realm, clientId)
+
+  const baseline = useMemo(() => valuesFromConfig(config), [config])
+  const [values, setValues] = useState<ServiceProviderValues>(baseline)
+
+  useEffect(() => {
+    setValues(baseline)
+  }, [baseline])
+
+  const [mapperName, setMapperName] = useState('')
+  const [mapperSource, setMapperSource] = useState<string>(BUILT_IN_SOURCE_OPTIONS[0].value)
+  const [mapperCustomKey, setMapperCustomKey] = useState('')
+  const [mapperNameFormat, setMapperNameFormat] = useState<string>(DEFAULT_ATTRIBUTE_NAME_FORMAT)
+
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(baseline)
+  const canSave =
+    values.spEntityId.trim().length > 0 &&
+    values.acsUrl.trim().length > 0 &&
+    (hasChanges || !isConfigured)
+
+  const set = <K extends keyof ServiceProviderValues>(key: K, value: ServiceProviderValues[K]) =>
+    setValues((prev) => ({ ...prev, [key]: value }))
+
+  const resolvedSource =
+    mapperSource === CUSTOM_ATTRIBUTE_SOURCE ? toCustomAttributeSource(mapperCustomKey) : mapperSource
+
+  const canAddMapper =
+    mapperName.trim().length > 0 &&
+    (mapperSource !== CUSTOM_ATTRIBUTE_SOURCE || mapperCustomKey.trim().length > 0)
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!canSave || isSavingConfig) return
+
+    await saveConfig({
+      sp_entity_id: values.spEntityId.trim(),
+      acs_url: values.acsUrl.trim(),
+      name_id_format: values.nameIdFormat,
+      sign_assertions: values.signAssertions,
+      sign_documents: values.signDocuments,
+      want_authn_requests_signed: values.wantAuthnRequestsSigned,
+    })
+  }
+
+  const handleAddMapper = async () => {
+    if (!canAddMapper || isCreatingMapper) return
+
+    const added = await addAttributeMapper({
+      name: mapperName,
+      source: resolvedSource,
+      nameFormat: mapperNameFormat,
+    })
+
+    if (added) {
+      setMapperName('')
+      setMapperCustomKey('')
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+        <Loader2 className='h-4 w-4 animate-spin' />
+        Loading the SAML configuration…
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-6'>
+      {!isConfigured && (
+        <div className='rounded-md border border-border bg-muted/40 p-4'>
+          <p className='text-sm font-medium'>This application does not use SAML yet</p>
+          <p className='text-xs text-muted-foreground mt-1'>
+            Fill in the two values your application shows on its SAML settings page, then save.
+            FerrisKey will start answering SAML sign-in requests for it.
+          </p>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className='flex flex-col gap-6'>
+        <Section
+          title='Service provider'
+          description='Identifies the application and tells FerrisKey where to send the assertion.'
+        >
+          <Field
+            label='Entity ID'
+            hint='The unique identifier the application publishes for itself, for example https://chat.acme.com/saml/sp/1.'
+          >
+            <input
+              type='text'
+              value={values.spEntityId}
+              onChange={(e) => set('spEntityId', e.target.value)}
+              placeholder='https://chat.acme.com/saml/sp/1'
+              className='w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
+            />
+          </Field>
+
+          <Field
+            label='Assertion Consumer Service URL'
+            hint='Where the signed assertion is posted after the user signs in.'
+          >
+            <input
+              type='text'
+              value={values.acsUrl}
+              onChange={(e) => set('acsUrl', e.target.value)}
+              placeholder='https://chat.acme.com/omniauth/saml/callback?account_id=1'
+              className='w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
+            />
+          </Field>
+
+          <SelectRow
+            label='Name ID format'
+            hint='How the user is identified inside the assertion.'
+            value={values.nameIdFormat}
+            onChange={(value) => set('nameIdFormat', value)}
+            options={NAME_ID_FORMAT_OPTIONS}
+          />
+        </Section>
+
+        <Section title='Signatures' description='How assertions and requests are signed.'>
+          <ToggleRow
+            label='Sign assertions'
+            description='Sign the assertion itself. Almost every application expects this.'
+            checked={values.signAssertions}
+            onChange={(v) => set('signAssertions', v)}
+          />
+          <ToggleRow
+            label='Sign documents'
+            description='Sign the whole SAML response in addition to the assertion.'
+            checked={values.signDocuments}
+            onChange={(v) => set('signDocuments', v)}
+          />
+          <ToggleRow
+            label='Require signed authentication requests'
+            description='Reject sign-in requests from this application unless they carry a valid signature.'
+            checked={values.wantAuthnRequestsSigned}
+            onChange={(v) => set('wantAuthnRequestsSigned', v)}
+          />
+        </Section>
+
+        <div className='sticky bottom-0 -mx-8 md:-mx-12 px-8 md:px-12 py-4 border-t border-border bg-background/80 backdrop-blur flex items-center justify-end gap-3'>
+          {hasChanges && isConfigured && (
+            <button
+              type='button'
+              onClick={() => setValues(baseline)}
+              className='rounded-md border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-muted transition-colors'
+            >
+              Discard
+            </button>
+          )}
+          <button
+            type='submit'
+            disabled={!canSave || isSavingConfig}
+            className='inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+          >
+            {isSavingConfig && <Loader2 className='h-3.5 w-3.5 animate-spin' />}
+            {isConfigured ? 'Save changes' : 'Enable SAML'}
+          </button>
+        </div>
+      </form>
+
+      {isConfigured && (
+        <Section
+          title='Attribute mappings'
+          description='User details sent alongside the assertion. Match the attribute names the application asks for.'
+        >
+          <div className='flex flex-col gap-2'>
+            {mappers.length === 0 && (
+              <div className='flex flex-col gap-3 rounded-md border border-dashed border-border p-4'>
+                <p className='text-xs text-muted-foreground'>
+                  No attributes are sent yet. Most applications need at least an email address.
+                </p>
+                <button
+                  type='button'
+                  onClick={() => void addCommonProfileMappers(COMMON_PROFILE_MAPPERS)}
+                  disabled={isCreatingMapper}
+                  className='self-start inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-40'
+                >
+                  {isCreatingMapper ? (
+                    <Loader2 className='h-3.5 w-3.5 animate-spin' />
+                  ) : (
+                    <Plus className='h-3.5 w-3.5' />
+                  )}
+                  Add email, first_name and last_name
+                </button>
+              </div>
+            )}
+
+            {mappers.map((mapper) => (
+              <div
+                key={mapper.id}
+                className='flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2'
+              >
+                <span className='text-sm font-mono truncate'>{mapper.name}</span>
+                <span className='text-xs text-muted-foreground shrink-0'>from</span>
+                <span className='flex-1 text-sm truncate'>
+                  {describeAttributeSource(mapper.source)}
+                </span>
+                <span className='text-xs text-muted-foreground shrink-0'>
+                  {describeAttributeNameFormat(mapper.name_format)}
+                </span>
+                <button
+                  type='button'
+                  onClick={() => void deleteAttributeMapper(mapper.id)}
+                  disabled={isDeletingMapper}
+                  className='inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-red-500 hover:bg-muted transition-colors disabled:opacity-40 shrink-0'
+                  aria-label={`Remove the ${mapper.name} attribute mapping`}
+                >
+                  <X className='h-3.5 w-3.5' />
+                </button>
+              </div>
+            ))}
+
+            <div className='mt-2 grid grid-cols-1 sm:grid-cols-2 gap-4 rounded-md border border-border p-4'>
+              <Field label='Attribute name' hint='The name the application looks for, e.g. email.'>
+                <input
+                  type='text'
+                  value={mapperName}
+                  onChange={(e) => setMapperName(e.target.value)}
+                  placeholder='email'
+                  className='w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
+                />
+              </Field>
+
+              <SelectRow
+                label='User detail to send'
+                value={mapperSource}
+                onChange={setMapperSource}
+                options={[
+                  ...BUILT_IN_SOURCE_OPTIONS.map((option) => ({
+                    value: option.value as string,
+                    label: option.label,
+                    description: '',
+                  })),
+                  { value: CUSTOM_ATTRIBUTE_SOURCE, label: 'Custom user attribute', description: '' },
+                ]}
+              />
+
+              {mapperSource === CUSTOM_ATTRIBUTE_SOURCE && (
+                <Field label='Attribute key' hint='The key stored on the user profile.'>
+                  <input
+                    type='text'
+                    value={mapperCustomKey}
+                    onChange={(e) => setMapperCustomKey(e.target.value)}
+                    placeholder='department'
+                    className='w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono outline-none placeholder:text-muted-foreground focus:border-primary/40 focus:ring-1 focus:ring-primary/30'
+                  />
+                </Field>
+              )}
+
+              <SelectRow
+                label='Name format'
+                value={mapperNameFormat}
+                onChange={setMapperNameFormat}
+                options={ATTRIBUTE_NAME_FORMAT_OPTIONS}
+              />
+
+              <div className='sm:col-span-2 flex justify-end'>
+                <button
+                  type='button'
+                  onClick={() => void handleAddMapper()}
+                  disabled={!canAddMapper || isCreatingMapper}
+                  className='inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed'
+                >
+                  {isCreatingMapper ? (
+                    <Loader2 className='h-3.5 w-3.5 animate-spin' />
+                  ) : (
+                    <Plus className='h-3.5 w-3.5' />
+                  )}
+                  Add attribute
+                </button>
+              </div>
+            </div>
+          </div>
+        </Section>
+      )}
+    </div>
+  )
+}
+
+interface SelectRowProps {
+  label: string
+  hint?: string
+  value: string
+  onChange: (value: string) => void
+  options: { value: string; label: string; description: string }[]
+}
+
+function SelectRow({ label, hint, value, onChange, options }: SelectRowProps) {
+  const selected = options.find((option) => option.value === value)
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <span className='text-sm font-medium'>{label}</span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger aria-label={label}>
+          <SelectValue placeholder={`Select ${label.toLowerCase()}`} />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {(selected?.description || hint) && (
+        <p className='text-xs text-muted-foreground'>{selected?.description || hint}</p>
+      )}
+    </div>
+  )
+}
+
+interface ToggleRowProps {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}
+
+function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
+  return (
+    <div className='flex items-center justify-between gap-5 rounded-md border border-border p-3'>
+      <div className='space-y-0.5'>
+        <p className='text-sm font-medium'>{label}</p>
+        <p className='text-xs text-muted-foreground'>{description}</p>
+      </div>
+      <Switch checked={checked} onCheckedChange={onChange} />
+    </div>
+  )
+}

--- a/libs/ferriskey-api-saml/src/handlers/descriptor.rs
+++ b/libs/ferriskey-api-saml/src/handlers/descriptor.rs
@@ -4,7 +4,6 @@ use axum::http::header::CONTENT_TYPE;
 use axum::response::{IntoResponse, Response};
 use ferriskey_api_core::api_entities::api_error::ApiError;
 use ferriskey_api_core::app_state::AppState;
-use ferriskey_api_core::url::FullUrl;
 use ferriskey_core::domain::common::entities::app_errors::CoreError;
 use ferriskey_core::domain::saml::ports::SamlService;
 use tracing::warn;
@@ -12,6 +11,9 @@ use tracing::warn;
 use crate::html::error_page;
 use crate::metadata::{SAML_METADATA_CONTENT_TYPE, idp_metadata_document};
 use crate::origin::saml_public_base_url;
+
+const MISCONFIGURED: &str =
+    "Single sign-on is not configured on this server. Set SERVER_PUBLIC_URL.";
 
 const UNKNOWN_REALM: &str = "This realm does not publish SAML metadata.";
 const UNAVAILABLE: &str = "SAML metadata is not available for this realm.";
@@ -32,13 +34,14 @@ const UNAVAILABLE: &str = "SAML metadata is not available for this realm.";
 pub async fn saml_descriptor(
     Path(realm_name): Path<String>,
     State(state): State<AppState>,
-    FullUrl(_, base_url): FullUrl,
 ) -> Result<Response, ApiError> {
-    let public_base_url = saml_public_base_url(
+    let Some(public_base_url) = saml_public_base_url(
         state.args.server.public_url.as_deref(),
-        &base_url,
         &state.args.server.root_path,
-    );
+    ) else {
+        warn!("refusing a saml request: SERVER_PUBLIC_URL is not configured");
+        return Ok(error_page(StatusCode::INTERNAL_SERVER_ERROR, MISCONFIGURED));
+    };
 
     let certificate = match state
         .service
@@ -49,11 +52,13 @@ pub async fn saml_descriptor(
         Err(error) => return Ok(refusal(&realm_name, error)),
     };
 
-    let document =
-        idp_metadata_document(&public_base_url, &realm_name, certificate).map_err(|error| {
+    let document = match idp_metadata_document(&public_base_url, &realm_name, certificate) {
+        Ok(document) => document,
+        Err(error) => {
             warn!(realm = %realm_name, %error, "the realm entity descriptor could not be rendered");
-            ApiError::InternalServerError("saml metadata could not be rendered".into())
-        })?;
+            return Ok(error_page(StatusCode::INTERNAL_SERVER_ERROR, UNAVAILABLE));
+        }
+    };
 
     Ok(([(CONTENT_TYPE, SAML_METADATA_CONTENT_TYPE)], document).into_response())
 }

--- a/libs/ferriskey-api-saml/src/handlers/sso.rs
+++ b/libs/ferriskey-api-saml/src/handlers/sso.rs
@@ -6,7 +6,6 @@ use axum::response::Response;
 use axum_extra::extract::cookie::{Cookie, SameSite};
 use ferriskey_api_core::api_entities::api_error::ApiError;
 use ferriskey_api_core::app_state::AppState;
-use ferriskey_api_core::url::FullUrl;
 use ferriskey_core::domain::common::entities::app_errors::CoreError;
 use ferriskey_core::domain::saml::entities::StartSsoInput;
 use ferriskey_core::domain::saml::ports::SamlService;
@@ -17,6 +16,9 @@ use utoipa::{IntoParams, ToSchema};
 
 use crate::html::error_page;
 use crate::origin::{saml_public_base_url, webapp_login_url};
+
+const MISCONFIGURED: &str =
+    "Single sign-on is not configured on this server. Set SERVER_PUBLIC_URL.";
 
 const AUTH_SESSION_COOKIE: &str = "FERRISKEY_SESSION";
 
@@ -67,10 +69,9 @@ impl Binding {
 pub async fn saml_sso_redirect(
     Path(realm_name): Path<String>,
     State(state): State<AppState>,
-    FullUrl(_, base_url): FullUrl,
     Query(params): Query<SamlAuthnRequestParams>,
 ) -> Result<Response, ApiError> {
-    begin_sso(state, realm_name, base_url, Binding::HttpRedirect, params).await
+    begin_sso(state, realm_name, Binding::HttpRedirect, params).await
 }
 
 #[utoipa::path(
@@ -90,16 +91,14 @@ pub async fn saml_sso_redirect(
 pub async fn saml_sso_post(
     Path(realm_name): Path<String>,
     State(state): State<AppState>,
-    FullUrl(_, base_url): FullUrl,
     Form(params): Form<SamlAuthnRequestParams>,
 ) -> Result<Response, ApiError> {
-    begin_sso(state, realm_name, base_url, Binding::HttpPost, params).await
+    begin_sso(state, realm_name, Binding::HttpPost, params).await
 }
 
 async fn begin_sso(
     state: AppState,
     realm_name: String,
-    base_url: String,
     binding: Binding,
     params: SamlAuthnRequestParams,
 ) -> Result<Response, ApiError> {
@@ -116,11 +115,13 @@ async fn begin_sso(
         }
     };
 
-    let public_base_url = saml_public_base_url(
+    let Some(public_base_url) = saml_public_base_url(
         state.args.server.public_url.as_deref(),
-        &base_url,
         &state.args.server.root_path,
-    );
+    ) else {
+        warn!("refusing a saml request: SERVER_PUBLIC_URL is not configured");
+        return Ok(error_page(StatusCode::INTERNAL_SERVER_ERROR, MISCONFIGURED));
+    };
 
     let output = match state
         .service

--- a/libs/ferriskey-api-saml/src/handlers/sso_continue.rs
+++ b/libs/ferriskey-api-saml/src/handlers/sso_continue.rs
@@ -3,7 +3,6 @@ use axum::http::StatusCode;
 use axum::response::Response;
 use ferriskey_api_core::api_entities::api_error::ApiError;
 use ferriskey_api_core::app_state::AppState;
-use ferriskey_api_core::url::FullUrl;
 use ferriskey_core::domain::common::entities::app_errors::CoreError;
 use ferriskey_core::domain::saml::entities::FinishSsoInput;
 use ferriskey_core::domain::saml::ports::SamlService;
@@ -14,6 +13,9 @@ use utoipa::{IntoParams, ToSchema};
 
 use crate::html::{auto_submit_form, error_page, html_page};
 use crate::origin::saml_public_base_url;
+
+const MISCONFIGURED: &str =
+    "Single sign-on is not configured on this server. Set SERVER_PUBLIC_URL.";
 
 const EXPIRED_CONTINUATION: &str =
     "This sign-in link is no longer valid. Start again from your application.";
@@ -45,14 +47,15 @@ pub struct SamlContinueParams {
 pub async fn saml_continue(
     Path(realm_name): Path<String>,
     State(state): State<AppState>,
-    FullUrl(_, base_url): FullUrl,
     Query(params): Query<SamlContinueParams>,
 ) -> Result<Response, ApiError> {
-    let public_base_url = saml_public_base_url(
+    let Some(public_base_url) = saml_public_base_url(
         state.args.server.public_url.as_deref(),
-        &base_url,
         &state.args.server.root_path,
-    );
+    ) else {
+        warn!("refusing a saml request: SERVER_PUBLIC_URL is not configured");
+        return Ok(error_page(StatusCode::INTERNAL_SERVER_ERROR, MISCONFIGURED));
+    };
 
     let delivery = match state
         .service

--- a/libs/ferriskey-api-saml/src/origin.rs
+++ b/libs/ferriskey-api-saml/src/origin.rs
@@ -2,13 +2,16 @@ use ferriskey_api_core::url::{public_base_url, root_scoped_base_url};
 
 pub fn saml_public_base_url(
     configured_public_url: Option<&str>,
-    request_base_url: &str,
     root_path: &str,
-) -> String {
-    root_scoped_base_url(
-        &public_base_url(configured_public_url, request_base_url),
+) -> Option<String> {
+    let configured = configured_public_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+
+    Some(root_scoped_base_url(
+        &public_base_url(Some(configured), ""),
         root_path,
-    )
+    ))
 }
 
 pub fn webapp_login_url(webapp_url: &str, realm_name: &str, login_url: &str) -> String {
@@ -25,42 +28,32 @@ mod tests {
     use super::{saml_public_base_url, webapp_login_url};
 
     #[test]
-    fn a_configured_public_url_wins_so_the_signed_entity_id_never_follows_the_host_header() {
+    fn a_configured_public_url_is_what_the_signed_entity_id_is_built_from() {
         assert_eq!(
-            saml_public_base_url(
-                Some("https://auth.example.com"),
-                "https://node-7.internal:3333",
-                ""
-            ),
-            "https://auth.example.com"
+            saml_public_base_url(Some("https://auth.example.com"), ""),
+            Some("https://auth.example.com".to_string())
         );
     }
 
     #[test]
-    fn the_request_origin_is_used_when_nothing_is_configured() {
-        assert_eq!(
-            saml_public_base_url(None, "https://node-7.internal:3333", ""),
-            "https://node-7.internal:3333"
-        );
+    fn saml_refuses_to_run_without_a_stable_origin_rather_than_following_the_host_header() {
+        assert_eq!(saml_public_base_url(None, ""), None);
+        assert_eq!(saml_public_base_url(Some("   "), ""), None);
     }
 
     #[test]
     fn the_root_path_is_appended_so_the_continue_url_points_at_a_route_that_exists() {
         assert_eq!(
-            saml_public_base_url(Some("https://auth.example.com"), "http://ignored", "/api"),
-            "https://auth.example.com/api"
-        );
-        assert_eq!(
-            saml_public_base_url(None, "https://auth.example.com", "/api"),
-            "https://auth.example.com/api"
+            saml_public_base_url(Some("https://auth.example.com"), "/api"),
+            Some("https://auth.example.com/api".to_string())
         );
     }
 
     #[test]
     fn a_trailing_slash_on_the_configured_origin_never_doubles_up() {
         assert_eq!(
-            saml_public_base_url(Some("https://auth.example.com/"), "http://ignored", "/api"),
-            "https://auth.example.com/api"
+            saml_public_base_url(Some("https://auth.example.com/"), "/api"),
+            Some("https://auth.example.com/api".to_string())
         );
     }
 


### PR DESCRIPTION
Closes #1268. Part of #1260. **Stacked on #1282 → #1281.**

An administrator can configure a SAML service provider — entity id, ACS URL, NameID format, the three signature toggles — and manage its attribute mappers, **in both consoles**.

The two client consoles coexist (`pages/client/` and `pages/console-applications/`), and shipping only one is a bug that surfaces weeks later. Both are covered: the legacy console gets a SAML tab and a `/:client_id/saml` route, the new one gets a tab between API Access and Addons. Everything non-visual lives in one shared hook, so behaviour and copy stay identical while each console keeps its own form idiom — the same split the web-origins feature already uses.

## Chatwoot in a few clicks

Placeholders are its real URL shapes, and the empty mapper state offers a one-click **"Add email, first_name and last_name"** — the exact three attributes it reads.

## Two findings worth recording

**`TypedStatusError` is dead code in this app.** The custom fetcher throws first, with the server message already on `.message`, so the existing `error.message` idiom is correct. But there is a gap it hides: validator rejections return **422** carrying `{errors:[{field,message}]}` with **no `message` key**, which would have surfaced to the user as *"HTTP 422: Unprocessable Entity"*. Extracted properly now, and Zod covers required-ness client-side so that path is not normally reachable.

**The Addons tab literally promised "SAML 2.0 service provider" as coming soon.** SAML gets its own top-level tab rather than being buried there, and the now-false bullet is removed rather than the whole tab.

## A 404 is not an error here

`GET /saml-config` returns 404 when nothing is configured, which is the empty form, not a failure. The query catches it and resolves to `null`: no error toast, no retry. The user sees "This application does not use SAML yet", the form pre-filled with the server's own defaults, and a submit button reading **Enable SAML**. The mappers section stays hidden until the service provider exists.

## Contract-tied, not hand-written

The NameID format options derive from a `Record` keyed on the schema type rather than a hardcoded list, so if the contract ever gains a URN **the build breaks** until a label is added.

Cache invalidation follows `post_logout_redirect_uris.api.ts`, deliberately not `redirect_uris.api.ts` — the latter invalidates a query key that does not exist, which is why it is littered with manual `refetch()` calls. There are no `refetch()` calls here.

## Out of scope

The IdP-side panel (SSO URL, IdP entity id, certificate download) is the natural companion to this screen but belongs with the endpoints in #1281. The tab is deliberately **not** gated on `client.protocol === "saml"`: that field is a free-form string, the backend accepts a SAML configuration on any client, and gating would hide the feature on every client that exists today.

## Verification

`pnpm run build` is broken locally on a rollup native binding, so the real gates were run instead, and independently re-run rather than taken on trust:

| Gate | Before | After |
|---|---|---|
| `tsc -b` | 0 errors | **0 errors** |
| `eslint .` | 59 problems, 0 errors | **59 problems, 0 errors** |

Zero warnings land in any of the new files. The OpenAPI to TypeScript regeneration is broken repo-wide (a missing `$ref`, plus a Node version floor), so `api.client.ts` was hand-edited following the shapes already there rather than regenerated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SAML configuration for client applications, including entity ID, ACS URL, name ID format, and signing options.
  * Added SAML attribute mapper management, including built-in/custom attributes and common profile mappings.
  * Added dedicated SAML tabs to client and application details.
  * Added validation, save, delete, loading, and error feedback flows.

* **Bug Fixes**
  * Unverified email addresses can no longer be used as SAML email NameIDs.
  * Requests requiring signed authentication are rejected until signature verification is supported.
  * SAML endpoints now require a configured public server URL and provide clearer configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->