### PR TITLE
feat(core): answer invalid_grant when a refresh names a revoked session

### DIFF
--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -197,15 +197,30 @@ fn validate_session_binding(
 
     let Some(session) = session else {
         warn!(session_id = %sid, "Rejecting token: the session it names no longer exists");
-        return Err(CoreError::InvalidToken);
+        return Err(CoreError::SessionRevoked);
     };
 
     if session.expires_at < now {
         warn!(session_id = %sid, "Rejecting token: the session it names has expired");
-        return Err(CoreError::InvalidToken);
+        return Err(CoreError::SessionRevoked);
     }
 
     Ok(())
+}
+
+/// Translate a revoked-session rejection into the token endpoint's vocabulary.
+///
+/// `verify_token` speaks in authentication terms (`SessionRevoked` -> 401) because
+/// most of its callers guard protected resources. The token endpoint answers with
+/// the OAuth2 error shape instead, where a grant that can no longer be honoured is
+/// `invalid_grant` with HTTP 400.
+fn revoked_session_is_an_invalid_grant(error: CoreError) -> CoreError {
+    match error {
+        CoreError::SessionRevoked => CoreError::InvalidGrant(
+            "The session backing this refresh token has been revoked or has expired.".to_string(),
+        ),
+        other => other,
+    }
 }
 
 /// Re-derive the required actions that gate the token-refresh path (FK-003).
@@ -2296,7 +2311,11 @@ where
 
         let (claims, stored) = self
             .verify_refresh_token(token_str, params.realm_id)
-            .await?;
+            .await
+            // A refresh presented against a revoked or expired session is a
+            // grant failure, not an authentication failure: RFC 6749 §5.2 asks
+            // the token endpoint for `400 invalid_grant`.
+            .map_err(revoked_session_is_an_invalid_grant)?;
 
         if claims.typ != ClaimsTyp::Refresh {
             return Err(CoreError::InvalidToken);
@@ -5006,7 +5025,7 @@ mod tests {
         assert!(
             matches!(
                 validate_session_binding(Some(Uuid::new_v4()), None, now),
-                Err(CoreError::InvalidToken)
+                Err(CoreError::SessionRevoked)
             ),
             "a token naming a session that no longer exists must not validate"
         );
@@ -5020,9 +5039,31 @@ mod tests {
         assert!(
             matches!(
                 validate_session_binding(Some(session.id), Some(&session), now),
-                Err(CoreError::InvalidToken)
+                Err(CoreError::SessionRevoked)
             ),
             "a token naming an expired session must not validate"
+        );
+    }
+
+    #[test]
+    fn a_revoked_session_becomes_invalid_grant_on_the_token_endpoint() {
+        assert!(
+            matches!(
+                super::revoked_session_is_an_invalid_grant(CoreError::SessionRevoked),
+                CoreError::InvalidGrant(_)
+            ),
+            "refreshing against a revoked session must answer 400 invalid_grant"
+        );
+    }
+
+    #[test]
+    fn other_refresh_failures_keep_their_own_error() {
+        assert!(
+            matches!(
+                super::revoked_session_is_an_invalid_grant(CoreError::ExpiredToken),
+                CoreError::ExpiredToken
+            ),
+            "only the revoked-session case is rewritten"
         );
     }
 

--- a/libs/ferriskey-api-core/src/error.rs
+++ b/libs/ferriskey-api-core/src/error.rs
@@ -51,6 +51,16 @@ impl From<CoreError> for ApiError {
             CoreError::InvalidRefreshToken => {
                         Self::Unauthorized("Invalid refresh token".into())
                     }
+            // Presenting a token whose session was revoked to a protected
+            // resource is an authentication failure. The token endpoint maps
+            // this to `invalid_grant` itself (RFC 6749 §5.2) before it gets here.
+            CoreError::SessionRevoked => {
+                        Self::Unauthorized("Session revoked".into())
+                    }
+            CoreError::InvalidGrant(description) => Self::OAuthError {
+                error: "invalid_grant".into(),
+                error_description: description.into(),
+            },
             CoreError::InvalidClientSecret => {
                         Self::Unauthorized("Invalid client secret".into())
                     }

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -58,6 +58,12 @@ pub enum CoreError {
     #[error("Invalid refresh token")]
     InvalidRefreshToken,
 
+    #[error("The session backing this token no longer exists or has expired")]
+    SessionRevoked,
+
+    #[error("{0}")]
+    InvalidGrant(String),
+
     #[error("Invalid client secret")]
     InvalidClientSecret,
 


### PR DESCRIPTION
Session binding was already enforced inside verify_token, so a refresh token whose session had been revoked or had expired was rejected. It was rejected as an authentication failure though: 401 with a plain "Invalid token" body, where RFC 6749 section 5.2 asks the token endpoint for 400 and an invalid_grant error code. Clients that follow the spec read the 401 as "retry with different credentials" instead of "this grant is dead, start a new authorization".

Split the two vocabularies. validate_session_binding now returns SessionRevoked, which keeps mapping to 401 for the middleware guarding protected resources, and the refresh_token grant rewrites it into InvalidGrant, which renders as the OAuth2 error shape with 400.

Refs #1146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Revoked or expired sessions are now correctly detected during token validation.
  * Refresh-token requests now return the standard OAuth2 `invalid_grant` error when the associated session is unavailable.
  * Session revocation is reported as an unauthorized response.
  * Other refresh-token errors continue to preserve their existing error details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->