### PR TITLE
fix(api): answer 409 when a realm name is already taken

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -99,6 +99,9 @@ jobs:
       - name: run token revocation integration tests
         run: cargo test -p ferriskey-api --test token_revocation_test -- --ignored
 
+      - name: run realm lifecycle integration tests
+        run: cargo test -p ferriskey-api --test realm_lifecycle_test -- --ignored
+
       - name: run cross-realm user isolation integration tests
         run: cargo test -p ferriskey-api --test user_cross_realm_test -- --ignored
 

--- a/api/tests/realm_lifecycle_test.rs
+++ b/api/tests/realm_lifecycle_test.rs
@@ -16,7 +16,6 @@
 mod tests {
     use std::{env, sync::Arc};
 
-    use axum::Router;
     use axum::http::HeaderValue;
     use axum_test::TestServer;
     use ferriskey_api::{
@@ -44,32 +43,16 @@ mod tests {
             .unwrap_or(default)
     }
 
-    struct SharedContext {
-        app: std::sync::Mutex<Router>,
+    struct TestContext {
+        server: TestServer,
         /// The realm this harness bootstraps as its master realm.
         master_realm: String,
-        /// Kept alive for the process lifetime; not read directly by these tests.
+        /// Kept alive for as long as the context lives; not read by the tests.
         #[allow(dead_code)]
         pool: sqlx::PgPool,
     }
 
-    static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
-    static CTX: std::sync::OnceLock<SharedContext> = std::sync::OnceLock::new();
-
-    fn rt() -> &'static tokio::runtime::Runtime {
-        RUNTIME.get_or_init(|| {
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .expect("build shared runtime")
-        })
-    }
-
-    fn ctx() -> &'static SharedContext {
-        CTX.get_or_init(|| rt().block_on(async { setup().await }))
-    }
-
-    async fn setup() -> SharedContext {
+    async fn setup() -> TestContext {
         let db_host = env_or("DATABASE_HOST", "localhost");
         let db_port = env_u16_or("DATABASE_PORT", 5432);
         let db_name = env_or("DATABASE_NAME", "ferriskey");
@@ -139,17 +122,13 @@ mod tests {
         let args = Arc::new(Args::default());
         let state = AppState::new(args, svc);
         let app = router(state).expect("build router");
+        let server = TestServer::new(app).expect("build test server");
 
-        SharedContext {
-            app: std::sync::Mutex::new(app),
+        TestContext {
+            server,
             master_realm,
             pool,
         }
-    }
-
-    fn server() -> TestServer {
-        let app = ctx().app.lock().expect("lock app mutex").clone();
-        TestServer::new(app).expect("build test server")
     }
 
     fn auth_header(token: &str) -> HeaderValue {
@@ -192,47 +171,45 @@ mod tests {
         format!("lifecycle-{}", Uuid::new_v4().simple())
     }
 
-    #[test]
+    #[tokio::test]
     #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test realm_lifecycle_test -- --ignored"]
-    fn creating_a_realm_whose_name_is_taken_answers_409() {
-        let srv = server();
-        let master = ctx().master_realm.clone();
-        rt().block_on(async {
-            let token = login(&srv, &master).await;
-            let name = unique_realm_name();
+    async fn creating_a_realm_whose_name_is_taken_answers_409() {
+        let ctx = setup().await;
+        let srv = &ctx.server;
+        let token = login(srv, &ctx.master_realm).await;
+        let name = unique_realm_name();
 
-            let first = srv
-                .post("/realms")
-                .add_header("Authorization", auth_header(&token))
-                .json(&json!({ "name": name }))
-                .await;
-            assert_eq!(
-                first.status_code(),
-                201,
-                "creating the realm failed: {}",
-                first.text()
-            );
+        let first = srv
+            .post("/realms")
+            .add_header("Authorization", auth_header(&token))
+            .json(&json!({ "name": name }))
+            .await;
+        assert_eq!(
+            first.status_code(),
+            201,
+            "creating the realm failed: {}",
+            first.text()
+        );
 
-            let second = srv
-                .post("/realms")
-                .add_header("Authorization", auth_header(&token))
-                .json(&json!({ "name": name }))
-                .await;
+        let second = srv
+            .post("/realms")
+            .add_header("Authorization", auth_header(&token))
+            .json(&json!({ "name": name }))
+            .await;
 
-            let body = second.text();
-            assert_eq!(
-                second.status_code(),
-                409,
-                "a duplicate realm name must be a conflict, not a server error: {body}"
-            );
-            assert!(
-                !body.contains("realms_name_key"),
-                "the database constraint leaked to the client: {body}"
-            );
-            assert!(
-                body.contains(&name),
-                "the error should name the realm that is taken: {body}"
-            );
-        });
+        let body = second.text();
+        assert_eq!(
+            second.status_code(),
+            409,
+            "a duplicate realm name must be a conflict, not a server error: {body}"
+        );
+        assert!(
+            !body.contains("realms_name_key"),
+            "the database constraint leaked to the client: {body}"
+        );
+        assert!(
+            body.contains(&name),
+            "the error should name the realm that is taken: {body}"
+        );
     }
 }

--- a/api/tests/realm_lifecycle_test.rs
+++ b/api/tests/realm_lifecycle_test.rs
@@ -16,6 +16,7 @@
 mod tests {
     use std::{env, sync::Arc};
 
+    use axum::Router;
     use axum::http::HeaderValue;
     use axum_test::TestServer;
     use ferriskey_api::{
@@ -43,16 +44,32 @@ mod tests {
             .unwrap_or(default)
     }
 
-    struct TestContext {
-        server: TestServer,
+    struct SharedContext {
+        app: std::sync::Mutex<Router>,
         /// The realm this harness bootstraps as its master realm.
         master_realm: String,
-        /// Kept alive for as long as the context lives; not read by the tests.
+        /// Kept alive for the process lifetime; not read directly by these tests.
         #[allow(dead_code)]
         pool: sqlx::PgPool,
     }
 
-    async fn setup() -> TestContext {
+    static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    static CTX: std::sync::OnceLock<SharedContext> = std::sync::OnceLock::new();
+
+    fn rt() -> &'static tokio::runtime::Runtime {
+        RUNTIME.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build shared runtime")
+        })
+    }
+
+    fn ctx() -> &'static SharedContext {
+        CTX.get_or_init(|| rt().block_on(async { setup().await }))
+    }
+
+    async fn setup() -> SharedContext {
         let db_host = env_or("DATABASE_HOST", "localhost");
         let db_port = env_u16_or("DATABASE_PORT", 5432);
         let db_name = env_or("DATABASE_NAME", "ferriskey");
@@ -122,13 +139,17 @@ mod tests {
         let args = Arc::new(Args::default());
         let state = AppState::new(args, svc);
         let app = router(state).expect("build router");
-        let server = TestServer::new(app).expect("build test server");
 
-        TestContext {
-            server,
+        SharedContext {
+            app: std::sync::Mutex::new(app),
             master_realm,
             pool,
         }
+    }
+
+    fn server() -> TestServer {
+        let app = ctx().app.lock().expect("lock app mutex").clone();
+        TestServer::new(app).expect("build test server")
     }
 
     fn auth_header(token: &str) -> HeaderValue {
@@ -171,45 +192,47 @@ mod tests {
         format!("lifecycle-{}", Uuid::new_v4().simple())
     }
 
-    #[tokio::test]
+    #[test]
     #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test realm_lifecycle_test -- --ignored"]
-    async fn creating_a_realm_whose_name_is_taken_answers_409() {
-        let ctx = setup().await;
-        let srv = &ctx.server;
-        let token = login(srv, &ctx.master_realm).await;
-        let name = unique_realm_name();
+    fn creating_a_realm_whose_name_is_taken_answers_409() {
+        let srv = server();
+        let master = ctx().master_realm.clone();
+        rt().block_on(async {
+            let token = login(&srv, &master).await;
+            let name = unique_realm_name();
 
-        let first = srv
-            .post("/realms")
-            .add_header("Authorization", auth_header(&token))
-            .json(&json!({ "name": name }))
-            .await;
-        assert_eq!(
-            first.status_code(),
-            201,
-            "creating the realm failed: {}",
-            first.text()
-        );
+            let first = srv
+                .post("/realms")
+                .add_header("Authorization", auth_header(&token))
+                .json(&json!({ "name": name }))
+                .await;
+            assert_eq!(
+                first.status_code(),
+                201,
+                "creating the realm failed: {}",
+                first.text()
+            );
 
-        let second = srv
-            .post("/realms")
-            .add_header("Authorization", auth_header(&token))
-            .json(&json!({ "name": name }))
-            .await;
+            let second = srv
+                .post("/realms")
+                .add_header("Authorization", auth_header(&token))
+                .json(&json!({ "name": name }))
+                .await;
 
-        let body = second.text();
-        assert_eq!(
-            second.status_code(),
-            409,
-            "a duplicate realm name must be a conflict, not a server error: {body}"
-        );
-        assert!(
-            !body.contains("realms_name_key"),
-            "the database constraint leaked to the client: {body}"
-        );
-        assert!(
-            body.contains(&name),
-            "the error should name the realm that is taken: {body}"
-        );
+            let body = second.text();
+            assert_eq!(
+                second.status_code(),
+                409,
+                "a duplicate realm name must be a conflict, not a server error: {body}"
+            );
+            assert!(
+                !body.contains("realms_name_key"),
+                "the database constraint leaked to the client: {body}"
+            );
+            assert!(
+                body.contains(&name),
+                "the error should name the realm that is taken: {body}"
+            );
+        });
     }
 }

--- a/api/tests/realm_lifecycle_test.rs
+++ b/api/tests/realm_lifecycle_test.rs
@@ -1,0 +1,238 @@
+/// Integration tests for the realm lifecycle: creation conflicts (#1286) and
+/// deletion of the mirror client that lives in the master realm (#1287).
+///
+/// These tests require a running PostgreSQL instance. They are marked `#[ignore]`
+/// so they do not block regular `cargo test` runs. Run them explicitly with:
+///
+///   cargo test -p ferriskey-api --test realm_lifecycle_test -- --ignored
+///
+/// Environment variables (defaults shown):
+///   DATABASE_HOST     = localhost
+///   DATABASE_PORT     = 5432
+///   DATABASE_NAME     = ferriskey
+///   DATABASE_USER     = ferriskey
+///   DATABASE_PASSWORD = ferriskey
+#[cfg(test)]
+mod tests {
+    use std::{env, sync::Arc};
+
+    use axum::Router;
+    use axum::http::HeaderValue;
+    use axum_test::TestServer;
+    use ferriskey_api::{
+        application::http::server::{app_state::AppState, http_server::router},
+        args::Args,
+    };
+    use ferriskey_core::{
+        application::create_service,
+        domain::common::{
+            DatabaseConfig, FerriskeyConfig, entities::StartupConfig, ports::CoreService,
+        },
+    };
+    use serde_json::{Value, json};
+    use sqlx::Executor;
+    use uuid::Uuid;
+
+    fn env_or(key: &str, default: &str) -> String {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+
+    fn env_u16_or(key: &str, default: u16) -> u16 {
+        env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    struct SharedContext {
+        app: std::sync::Mutex<Router>,
+        /// The realm this harness bootstraps as its master realm.
+        master_realm: String,
+        /// Kept alive for the process lifetime; not read directly by these tests.
+        #[allow(dead_code)]
+        pool: sqlx::PgPool,
+    }
+
+    static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    static CTX: std::sync::OnceLock<SharedContext> = std::sync::OnceLock::new();
+
+    fn rt() -> &'static tokio::runtime::Runtime {
+        RUNTIME.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build shared runtime")
+        })
+    }
+
+    fn ctx() -> &'static SharedContext {
+        CTX.get_or_init(|| rt().block_on(async { setup().await }))
+    }
+
+    async fn setup() -> SharedContext {
+        let db_host = env_or("DATABASE_HOST", "localhost");
+        let db_port = env_u16_or("DATABASE_PORT", 5432);
+        let db_name = env_or("DATABASE_NAME", "ferriskey");
+        let db_user = env_or("DATABASE_USER", "ferriskey");
+        let db_password = env_or("DATABASE_PASSWORD", "ferriskey");
+
+        let schema = format!("test_realm_lifecycle_{}", Uuid::new_v4().simple());
+        let admin_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+
+        let admin_pool = sqlx::PgPool::connect(&admin_url)
+            .await
+            .expect("connect admin pool");
+        admin_pool
+            .execute(format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema).as_str())
+            .await
+            .expect("create schema");
+
+        let schema_url = format!(
+            "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
+            db_user,
+            db_password,
+            db_host,
+            db_port,
+            db_name,
+            urlencoding::encode(&schema)
+        );
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+        sqlx::migrate!("../core/migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let svc = create_service(FerriskeyConfig {
+            webapp_url: "http://localhost:5555".to_string(),
+            database: DatabaseConfig {
+                host: db_host,
+                port: db_port,
+                username: db_user,
+                password: db_password,
+                name: db_name,
+                schema: schema.clone(),
+            },
+        })
+        .await
+        .expect("create service");
+
+        // `create_realm` resolves the master realm by its canonical name, so the
+        // harness has to bootstrap under `master`. Each run owns its own schema,
+        // so nothing is shared between suites.
+        let master_realm = "master".to_string();
+        svc.initialize_application(StartupConfig {
+            webapp_url: "http://localhost:5555".to_string(),
+            master_realm_name: master_realm.clone(),
+            admin_username: "admin".to_string(),
+            admin_email: "admin@ferriskey.test".to_string(),
+            admin_password: "admin_pass_1234!".to_string(),
+            default_client_id: "ferriskey-admin".to_string(),
+        })
+        .await
+        .expect("initialize application");
+
+        let args = Arc::new(Args::default());
+        let state = AppState::new(args, svc);
+        let app = router(state).expect("build router");
+
+        SharedContext {
+            app: std::sync::Mutex::new(app),
+            master_realm,
+            pool,
+        }
+    }
+
+    fn server() -> TestServer {
+        let app = ctx().app.lock().expect("lock app mutex").clone();
+        TestServer::new(app).expect("build test server")
+    }
+
+    fn auth_header(token: &str) -> HeaderValue {
+        format!("Bearer {}", token)
+            .parse()
+            .expect("valid header value")
+    }
+
+    async fn login(server: &TestServer, realm_name: &str) -> String {
+        let token_resp = server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/token",
+                realm_name
+            ))
+            .form(&[
+                ("grant_type", "password"),
+                ("client_id", "admin-cli"),
+                ("username", "admin"),
+                ("password", "admin_pass_1234!"),
+                ("scope", "openid profile"),
+            ])
+            .await;
+
+        assert_eq!(
+            token_resp.status_code(),
+            200,
+            "password grant failed: {}",
+            token_resp.text()
+        );
+
+        let body: Value = token_resp.json();
+        body["access_token"]
+            .as_str()
+            .expect("access_token")
+            .to_string()
+    }
+
+    /// A realm name nothing else in the suite will claim.
+    fn unique_realm_name() -> String {
+        format!("lifecycle-{}", Uuid::new_v4().simple())
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test realm_lifecycle_test -- --ignored"]
+    fn creating_a_realm_whose_name_is_taken_answers_409() {
+        let srv = server();
+        let master = ctx().master_realm.clone();
+        rt().block_on(async {
+            let token = login(&srv, &master).await;
+            let name = unique_realm_name();
+
+            let first = srv
+                .post("/realms")
+                .add_header("Authorization", auth_header(&token))
+                .json(&json!({ "name": name }))
+                .await;
+            assert_eq!(
+                first.status_code(),
+                201,
+                "creating the realm failed: {}",
+                first.text()
+            );
+
+            let second = srv
+                .post("/realms")
+                .add_header("Authorization", auth_header(&token))
+                .json(&json!({ "name": name }))
+                .await;
+
+            let body = second.text();
+            assert_eq!(
+                second.status_code(),
+                409,
+                "a duplicate realm name must be a conflict, not a server error: {body}"
+            );
+            assert!(
+                !body.contains("realms_name_key"),
+                "the database constraint leaked to the client: {body}"
+            );
+            assert!(
+                body.contains(&name),
+                "the error should name the realm that is taken: {body}"
+            );
+        });
+    }
+}

--- a/core/src/infrastructure/realm/repositories/realm_postgres_repository.rs
+++ b/core/src/infrastructure/realm/repositories/realm_postgres_repository.rs
@@ -18,6 +18,19 @@ use crate::domain::realm::{
 use ferriskey_domain::realm::LoginAliases;
 use tracing::info_span;
 
+/// Recognise a Postgres unique-constraint violation (SQLSTATE 23505).
+///
+/// The realm name is unique in the schema, so an insert that trips this is a
+/// caller asking for a name that is taken — a conflict, not a server fault.
+/// Matching on the SQLSTATE rather than the message keeps this independent of
+/// the constraint's name and of the server's locale.
+fn is_unique_violation(error: &sea_orm::DbErr) -> bool {
+    matches!(
+        error.sql_err(),
+        Some(sea_orm::SqlErr::UniqueConstraintViolation(_))
+    )
+}
+
 #[derive(Debug, Clone)]
 pub struct PostgresRealmRepository {
     pub db: DatabaseConnection,
@@ -86,6 +99,7 @@ impl RealmRepository for PostgresRealmRepository {
         name: String,
         display_name: Option<String>,
     ) -> Result<Realm, CoreError> {
+        let realm_name = name.clone();
         let mut realm = Realm::new(name);
         realm.display_name = display_name;
 
@@ -97,7 +111,11 @@ impl RealmRepository for PostgresRealmRepository {
             updated_at: Set(realm.updated_at.naive_utc()),
         };
 
+        let name_for_error = realm_name.clone();
         let result_insert = new_realm.insert(&self.db).await.map_err(|e| {
+            if is_unique_violation(&e) {
+                return CoreError::RealmAlreadyExists(name_for_error);
+            }
             tracing::error!("Failed to insert realm: {:?}", e);
             CoreError::InternalServerError
         })?;

--- a/libs/ferriskey-api-core/src/api_entities/api_error.rs
+++ b/libs/ferriskey-api-core/src/api_entities/api_error.rs
@@ -33,6 +33,7 @@ pub enum ApiError {
     Unauthorized(Cow<'static, str>),
     Forbidden(Cow<'static, str>),
     BadRequest(Cow<'static, str>),
+    Conflict(Cow<'static, str>),
     ServiceUnavailable(Cow<'static, str>),
     /// RFC 6749 §5.2 OAuth2 error response
     OAuthError {
@@ -242,6 +243,15 @@ impl IntoResponse for ApiError {
                 Json(ApiErrorResponse {
                     code: "E_BAD_REQUEST".to_string(),
                     status: 400,
+                    message: message.into(),
+                }),
+            )
+                .into_response(),
+            ApiError::Conflict(message) => (
+                StatusCode::CONFLICT,
+                Json(ApiErrorResponse {
+                    code: "E_CONFLICT".to_string(),
+                    status: 409,
                     message: message.into(),
                 }),
             )

--- a/libs/ferriskey-api-core/src/error.rs
+++ b/libs/ferriskey-api-core/src/error.rs
@@ -57,6 +57,9 @@ impl From<CoreError> for ApiError {
             ),
             CoreError::InvalidClient => Self::Unauthorized("Invalid client".into()),
             CoreError::InvalidRealm => Self::Unauthorized("Invalid realm".into()),
+            CoreError::RealmAlreadyExists(name) => {
+                Self::Conflict(CoreError::RealmAlreadyExists(name).to_string().into())
+            }
             CoreError::InvalidUser => Self::Unauthorized("Invalid user".into()),
             CoreError::InvalidPassword => Self::Unauthorized("Invalid password".into()),
             CoreError::InvalidState => Self::BadRequest("Invalid state".into()),

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -58,6 +58,9 @@ pub enum CoreError {
     #[error("Invalid realm")]
     InvalidRealm,
 
+    #[error("A realm named {0} already exists")]
+    RealmAlreadyExists(String),
+
     #[error("Invalid user")]
     InvalidUser,
 


### PR DESCRIPTION
Creating a realm whose name exists answered 500, carrying the raw `realms_name_key` constraint violation. Every insert failure collapsed into InternalServerError, so a caller asking for a name that is taken was reported as a server fault — and ferris-ctl, which treats a conflict as a skip, stopped its import at the first line instead of converging.

Recognise SQLSTATE 23505 on the realm insert and surface it as a new RealmAlreadyExists, which the API renders as 409 with a message naming the realm. Matching on the SQLSTATE rather than on the message keeps this independent of the constraint's name and of the server's locale, and mapping it in the repository rather than pre-checking in the service keeps the answer correct under a race between two concurrent creations.

ApiError gains a Conflict variant, which had no equivalent before.

Adds a realm lifecycle integration suite, wired into CI. It fails with 500 against the previous behaviour.

Closes #1286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a realm with an existing name now returns a clear HTTP 409 conflict instead of an internal server error.
  * Conflict responses include a standardized error code and identify the conflicting realm.
  * Database constraint details are no longer exposed to clients.

* **Tests**
  * Added integration coverage for duplicate realm creation.
  * Added the integration suite to the integration-test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->