### PR TITLE
fix: send users back to the console origin they started from

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "url",
  "urlencoding",
  "utoipa",
  "uuid",

--- a/libs/ferriskey-api-authentication/Cargo.toml
+++ b/libs/ferriskey-api-authentication/Cargo.toml
@@ -14,6 +14,7 @@ base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 urlencoding = { workspace = true }
 utoipa = { workspace = true }
 uuid = { workspace = true }

--- a/libs/ferriskey-api-authentication/src/handlers/auth.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/auth.rs
@@ -16,6 +16,7 @@ use ferriskey_core::domain::authentication::value_objects::CodeChallengeMethod;
 use ferriskey_core::domain::common::entities::app_errors::CoreError;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
+use url::Url;
 use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
 
@@ -25,6 +26,14 @@ use ferriskey_api_core::{api_entities::api_error::ApiError, app_state::AppState}
 
 const AUTH_SESSION_COOKIE: &str = "FERRISKEY_SESSION";
 const IDENTITY_COOKIE: &str = "FERRISKEY_IDENTITY";
+
+fn console_origin(validated_redirect_uri: &str, webapp_url: &str) -> String {
+    Url::parse(validated_redirect_uri)
+        .ok()
+        .filter(|parsed| parsed.host_str().is_some())
+        .map(|parsed| parsed.origin().ascii_serialization())
+        .unwrap_or_else(|| webapp_url.trim_end_matches('/').to_string())
+}
 
 fn webapp_login_url(webapp_url: &str, realm_name: &str, login_url: &str) -> String {
     format!(
@@ -172,7 +181,8 @@ pub async fn auth_handler(
         }
     }
 
-    let full_url = webapp_login_url(&state.args.webapp_url, &realm_name, &result.login_url);
+    let console = console_origin(&params.redirect_uri, &state.args.webapp_url);
+    let full_url = webapp_login_url(&console, &realm_name, &result.login_url);
 
     let mut session_cookie = Cookie::build((AUTH_SESSION_COOKIE, result.session.id.to_string()))
         .path("/")
@@ -224,7 +234,41 @@ pub async fn auth_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::webapp_login_url;
+    use super::{console_origin, webapp_login_url};
+
+    #[test]
+    fn the_login_page_is_served_from_the_origin_the_flow_started_on() {
+        assert_eq!(
+            console_origin(
+                "https://app.example.com/realms/master/authentication/callback",
+                "https://auth.example.com"
+            ),
+            "https://app.example.com"
+        );
+    }
+
+    #[test]
+    fn a_port_is_part_of_the_origin_and_must_survive() {
+        assert_eq!(
+            console_origin(
+                "http://localhost:5555/realms/master/callback",
+                "https://auth.example.com"
+            ),
+            "http://localhost:5555"
+        );
+    }
+
+    #[test]
+    fn an_unusable_redirect_uri_falls_back_to_the_configured_console() {
+        assert_eq!(
+            console_origin("not a url", "https://auth.example.com"),
+            "https://auth.example.com"
+        );
+        assert_eq!(
+            console_origin("", "https://auth.example.com"),
+            "https://auth.example.com"
+        );
+    }
 
     #[test]
     fn joins_webapp_login_url_without_double_slashes() {


### PR DESCRIPTION
Closes #1291.

With two hostnames serving the console, a login started on one of them landed the user on the other. Reported from a live deployment: signed in as admin on `auth.…`, navigating to `app.…` ended up back on `auth.…` after a visible flicker.

## What was happening

`WEBAPP_URL` is a single global value, and `auth_handler` used it verbatim to send the browser to the login page — regardless of which origin the flow started from. A login begun on `app.…` was therefore redirected to whatever single origin `WEBAPP_URL` names.

If the user was already authenticated there, the console immediately re-entered the OAuth flow, and the front-end overwrote `redirect_uri` with `window.location.origin` for the `security-admin-console` client. The original destination was discarded at that point. The flow then completed correctly — on the wrong host.

Nothing errored, which is why the symptom is easy to misread. It is not a CORS problem and not a cookie problem: every request succeeds. The redirect chain simply walks away from where the user asked to go.

## The fix

`auth_handler` already holds the right value. `params.redirect_uri` **has just been validated** against the client's registered redirect URIs (`core/src/domain/authentication/services.rs:3290`) before the login URL is built, so at that point it is not untrusted input — it is a value the server has already agreed to redirect to.

The login page origin is now derived from it. `WEBAPP_URL` remains the fallback for an unparseable value, and — deliberately — stays in use on the **error** path, where `redirect_uri` is precisely what failed validation and must not be trusted.

The origin is taken through `Url::origin().ascii_serialization()` rather than string surgery, so a port survives and userinfo or an IPv6 host cannot smuggle anything into the redirect.

## What the user sees now

Starting from `app.…` lands on `app.…`'s login page. There is no silent SSO across the two hosts, because `FERRISKEY_IDENTITY` is a host-scoped cookie — so a sign-in is required per console origin. That is correct behaviour rather than a regression: previously the cross-host case did not sign you in either, it moved you to the other host.

## Scope

Server-side only. The front-end rewrite of `redirect_uri` is no longer load-bearing for this bug once the redirect lands on the right origin, so narrowing it is left out rather than bundled in — it still silently discards a validated value and is worth its own change.

Tracked separately as #1292: the server clears `FERRISKEY_IDENTITY` when silent SSO fails while the console keeps its tokens in `localStorage`, and the login page has two effects that both navigate back to `/auth`. That divergence does not cause this bug, but it would turn the next SSO failure into a genuine infinite loop.

## Verification

Three unit tests on the resolution: a cross-origin `redirect_uri` yields its own origin, a port survives, and an unusable value falls back to the configured console. 19 tests in the crate, 381 in `ferriskey-core`; `cargo fmt` and the CI clippy invocation clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login flows now return users to the correct login-page origin based on the validated redirect URI.
  * Custom ports in redirect addresses are preserved.
  * A safe fallback is used when the redirect URI cannot be parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->