### PR TITLE
fix: open popular identity providers at configuration

### DIFF
--- a/front/src/pages/identity-providers/components/providers-empty-state.tsx
+++ b/front/src/pages/identity-providers/components/providers-empty-state.tsx
@@ -5,7 +5,7 @@ import { PROVIDER_TEMPLATES } from '@/constants/identity-provider-templates'
 import ProviderIcon from './provider-icon'
 
 interface ProvidersEmptyStateProps {
-  onCreateProvider: () => void
+  onCreateProvider: (providerId?: string) => void
 }
 
 // Show top 4 popular providers
@@ -26,7 +26,7 @@ export default function ProvidersEmptyState({ onCreateProvider }: ProvidersEmpty
           Connect external authentication providers to allow users to sign in with their existing accounts from Google, Discord, GitHub, and more.
         </p>
 
-        <Button size='lg' onClick={onCreateProvider} className='mb-6'>
+        <Button size='lg' onClick={() => onCreateProvider()} className='mb-6'>
           <Plus className='h-4 w-4 mr-2' />
           Add Your First Provider
         </Button>
@@ -37,7 +37,7 @@ export default function ProvidersEmptyState({ onCreateProvider }: ProvidersEmpty
             {popularProviders.map((provider) => (
               <button
                 key={provider.id}
-                onClick={onCreateProvider}
+                onClick={() => onCreateProvider(provider.id)}
                 className='flex flex-col items-center gap-1.5 p-2.5 rounded-lg hover:bg-muted transition-colors'
               >
                 <div className='h-9 w-9 flex items-center justify-center'>

--- a/front/src/pages/identity-providers/feature/page-create-feature.tsx
+++ b/front/src/pages/identity-providers/feature/page-create-feature.tsx
@@ -40,6 +40,13 @@ export default function PageCreateFeature() {
   const [selectedTemplate, setSelectedTemplate] = useState<ProviderTemplate | null>(
     initialTemplate ?? null
   )
+  const [previousProviderId, setPreviousProviderId] = useState(providerId)
+
+  if (providerId !== previousProviderId) {
+    setPreviousProviderId(providerId)
+    setSelectedTemplate(initialTemplate ?? null)
+    setCurrentStep(initialTemplate ? 2 : 1)
+  }
 
   const {
     mutate: createProvider,

--- a/front/src/pages/identity-providers/feature/page-create-feature.tsx
+++ b/front/src/pages/identity-providers/feature/page-create-feature.tsx
@@ -1,6 +1,9 @@
 import { useCreateIdentityProvider, type CreateProviderInput } from '@/api/identity-providers.api'
 import { Form } from '@/components/ui/form'
-import type { ProviderTemplate } from '@/constants/identity-provider-templates'
+import {
+  getTemplateById,
+  type ProviderTemplate,
+} from '@/constants/identity-provider-templates'
 import {
   IDENTITY_PROVIDERS_URL,
   IDENTITY_PROVIDER_OVERVIEW_URL,
@@ -8,7 +11,7 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { useNavigate, useParams } from 'react-router'
+import { useNavigate, useParams, useSearchParams } from 'react-router'
 import { toast } from 'sonner'
 import { z } from 'zod'
 import PageCreate from '../ui/page-create'
@@ -28,10 +31,15 @@ type ProviderFormValues = z.infer<typeof formSchema>
 export default function PageCreateFeature() {
   const { realm_name } = useParams<{ realm_name: string }>()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const realm = realm_name || 'master'
+  const providerId = searchParams.get('provider')
+  const initialTemplate = providerId ? getTemplateById(providerId) : undefined
 
-  const [currentStep, setCurrentStep] = useState(1)
-  const [selectedTemplate, setSelectedTemplate] = useState<ProviderTemplate | null>(null)
+  const [currentStep, setCurrentStep] = useState(initialTemplate ? 2 : 1)
+  const [selectedTemplate, setSelectedTemplate] = useState<ProviderTemplate | null>(
+    initialTemplate ?? null
+  )
 
   const {
     mutate: createProvider,

--- a/front/src/pages/identity-providers/feature/page-overview-feature.tsx
+++ b/front/src/pages/identity-providers/feature/page-overview-feature.tsx
@@ -62,8 +62,9 @@ export default function PageOverviewFeature() {
     })
   }
 
-  const handleCreateProvider = () => {
-    navigate(`${IDENTITY_PROVIDERS_URL(realm_name)}${IDENTITY_PROVIDER_CREATE_URL}`)
+  const handleCreateProvider = (providerId?: string) => {
+    const createUrl = `${IDENTITY_PROVIDERS_URL(realm_name)}${IDENTITY_PROVIDER_CREATE_URL}`
+    navigate(providerId ? `${createUrl}?provider=${encodeURIComponent(providerId)}` : createUrl)
   }
 
   const handleDeleteProvider = (providerId: string, providerName: string) => {

--- a/front/src/pages/identity-providers/ui/page-overview.tsx
+++ b/front/src/pages/identity-providers/ui/page-overview.tsx
@@ -31,7 +31,7 @@ export interface PageOverviewProps {
   onConfirmClose: () => void
   handleDeleteSelected: (items: IdentityProviderListItem[]) => void
   handleClickRow: (providerId: string) => void
-  handleCreateProvider: () => void
+  handleCreateProvider: (providerId?: string) => void
   onRowDelete: (provider: IdentityProviderListItem) => void
 }
 


### PR DESCRIPTION
## Summary

Popular identity provider shortcuts now open the configuration step with the selected provider prefilled, instead of sending users back through provider selection. Direct visits to the create page still start at provider selection, and unknown provider parameters safely fall back to that step.

## Validation

- `pnpm run lint` (passes with existing warnings)
- `pnpm run build`
- Browser-checked the Google shortcut, the direct create URL, and an unknown provider parameter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added popular identity-provider shortcuts when creating a provider.
  * Selecting a popular provider now preselects its configuration and advances directly to the setup step.
  * Generic provider creation remains available without a preselected provider.
  * Provider selections update correctly when changing or removing the provider parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->