### PR TITLE
fix: tell the console when its session is no longer valid

### DIFF
--- a/front/src/hooks/use-auth.ts
+++ b/front/src/hooks/use-auth.ts
@@ -321,5 +321,6 @@ export function useAuth() {
     user,
     refreshAccessToken,
     logout,
+    clearAuthState,
   }
 }

--- a/front/src/pages/authentication/feature/page-login-feature.tsx
+++ b/front/src/pages/authentication/feature/page-login-feature.tsx
@@ -13,12 +13,18 @@ export type { AuthenticateSchema } from '../hooks/use-login-form'
 
 export default function PageLoginFeature() {
   const navigate = useNavigate()
-  const { isAuthenticated } = useAuth()
-  const { realm_name, isAuthInitiated, loginError, getAuthParamsFromUrl, getOAuthParams } =
+  const { isAuthenticated, clearAuthState } = useAuth()
+  const { realm_name, sessionExpired, isAuthInitiated, loginError, getAuthParamsFromUrl, getOAuthParams } =
     useOAuthParams()
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (sessionExpired) {
+      clearAuthState(false)
+    }
+  }, [sessionExpired, clearAuthState])
+
+  useEffect(() => {
+    if (!isAuthenticated || sessionExpired) {
       return
     }
 
@@ -30,7 +36,7 @@ export default function PageLoginFeature() {
     }
 
     navigate(`/realms/${realm_name}/overview`, { replace: true })
-  }, [isAuthenticated, navigate, realm_name, isAuthInitiated, getOAuthParams])
+  }, [isAuthenticated, navigate, realm_name, isAuthInitiated, getOAuthParams, sessionExpired])
 
   const { data: loginSettings } = useGetLoginSettings({ realm: realm_name })
 
@@ -55,7 +61,7 @@ export default function PageLoginFeature() {
     onMagicLinkSubmit,
   } = useMagicLinkAuth({ realm_name })
 
-  const isRedirecting = !isAuthInitiated && !loginError
+  const isRedirecting = !isAuthInitiated && !loginError && !sessionExpired
 
   const { showFloatingActionBar, countdown, cancelAutoRefresh, restartAuthFlow } =
     useSessionRefresh({

--- a/front/src/pages/authentication/hooks/use-oauth-params.ts
+++ b/front/src/pages/authentication/hooks/use-oauth-params.ts
@@ -9,6 +9,7 @@ export function useOAuthParams() {
   const clientId = searchParams.get('client_id')
   const redirectUri = searchParams.get('redirect_uri')
   const loginError = searchParams.get('login_error')
+  const sessionExpired = searchParams.get('session_expired') === '1'
 
   const currentRealm = realm_name ?? 'master'
   const realmCallbackUri = `${window.location.origin}/realms/${currentRealm}/authentication/callback`
@@ -67,6 +68,7 @@ export function useOAuthParams() {
 
   return {
     realm_name,
+    sessionExpired,
     isAuthInitiated,
     loginError,
     getAuthParamsFromUrl,

--- a/libs/ferriskey-api-authentication/src/handlers/auth.rs
+++ b/libs/ferriskey-api-authentication/src/handlers/auth.rs
@@ -26,6 +26,18 @@ use ferriskey_api_core::{api_entities::api_error::ApiError, app_state::AppState}
 const AUTH_SESSION_COOKIE: &str = "FERRISKEY_SESSION";
 const IDENTITY_COOKIE: &str = "FERRISKEY_IDENTITY";
 
+const SESSION_EXPIRED_MARKER: &str = "session_expired=1";
+
+fn mark_session_expired(login_url: &str) -> String {
+    if login_url.contains(SESSION_EXPIRED_MARKER) {
+        return login_url.to_string();
+    }
+
+    let separator = if login_url.contains('?') { '&' } else { '?' };
+
+    format!("{login_url}{separator}{SESSION_EXPIRED_MARKER}")
+}
+
 fn webapp_login_url(webapp_url: &str, realm_name: &str, login_url: &str) -> String {
     format!(
         "{}/realms/{}/authentication/login{}",
@@ -172,7 +184,13 @@ pub async fn auth_handler(
         }
     }
 
-    let full_url = webapp_login_url(&state.args.webapp_url, &realm_name, &result.login_url);
+    let mut full_url = webapp_login_url(&state.args.webapp_url, &realm_name, &result.login_url);
+
+    let identity_cookie_is_stale = cookie.get(IDENTITY_COOKIE).is_some();
+
+    if identity_cookie_is_stale {
+        full_url = mark_session_expired(&full_url);
+    }
 
     let mut session_cookie = Cookie::build((AUTH_SESSION_COOKIE, result.session.id.to_string()))
         .path("/")
@@ -190,7 +208,7 @@ pub async fn auth_handler(
     headers.insert(SET_COOKIE, session_cookie_value);
 
     // Force a fresh login if an existing identity cookie did not result in SSO.
-    if cookie.get(IDENTITY_COOKIE).is_some() {
+    if identity_cookie_is_stale {
         let mut clear_identity_cookie = Cookie::build((IDENTITY_COOKIE, ""))
             .path("/")
             .http_only(true)
@@ -224,7 +242,32 @@ pub async fn auth_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::webapp_login_url;
+    use super::{mark_session_expired, webapp_login_url};
+
+    #[test]
+    fn a_login_url_that_already_carries_parameters_gains_the_marker_as_another_one() {
+        assert_eq!(
+            mark_session_expired(
+                "https://auth.example.com/realms/master/authentication/login?client_id=mestier"
+            ),
+            "https://auth.example.com/realms/master/authentication/login?client_id=mestier&session_expired=1"
+        );
+    }
+
+    #[test]
+    fn a_login_url_without_parameters_opens_its_query_string() {
+        assert_eq!(
+            mark_session_expired("https://auth.example.com/realms/master/authentication/login"),
+            "https://auth.example.com/realms/master/authentication/login?session_expired=1"
+        );
+    }
+
+    #[test]
+    fn the_marker_is_not_repeated_when_the_url_already_carries_it() {
+        let marked = mark_session_expired("https://auth.example.com/login?session_expired=1");
+
+        assert_eq!(marked, "https://auth.example.com/login?session_expired=1");
+    }
 
     #[test]
     fn joins_webapp_login_url_without_double_slashes() {


### PR DESCRIPTION
Closes #1292. Diagnosed from the report in #1291.

An application delegating to FerrisKey could put the login portal into a loop: the browser bounced between the login page and `/protocol/openid-connect/auth` indefinitely, which reads as flickering. Nothing errored, which is what makes it hard to recognise.

## The loop

1. The application redirects to `/auth` with its own `redirect_uri`.
2. `FERRISKEY_IDENTITY` is present, so silent SSO is attempted. It fails, and the handler **clears the cookie** before redirecting to the login page.
3. The login page loads with `client_id` and `redirect_uri` still in the query. A third-party callback carries no `/realms/` segment, so `isRedirectUriStale` is false and `isAuthInitiated` is true.
4. `isAuthenticated` is also true — the console keeps its tokens in `localStorage`, and nothing cleared them.
5. The `isAuthenticated && isAuthInitiated` effect navigates straight back to `/auth`.
6. The cookie is gone now, so SSO fails again. Back to step 2.

Whatever made the first attempt fail is only the trigger. From step 2 onward the loop sustains itself: the server keeps saying "sign in", the console keeps saying "I am signed in", and each defers to the other.

## Why the two sides could not agree

| | Where | Cleared on SSO failure |
|---|---|---|
| `FERRISKEY_IDENTITY` | HttpOnly cookie, per host | **yes**, by the server |
| console tokens | `localStorage`, per origin | **no** |

The cookie is `HttpOnly`, so the console cannot observe that the server dropped it. It had no way to learn its own state was stale.

## The fix

The server already knows — that is precisely why it clears the cookie. It now says so: the redirect to the login page carries `session_expired=1` whenever an identity cookie was present and did not result in SSO.

The console treats that as authoritative, drops its tokens through the existing `clearAuthState`, and — this is what actually breaks the cycle — **both** redirect effects on the login page are guarded on it. Guarding only the state would not have been enough: React effects read `isAuthenticated` from the render closure, so the redirect would still have fired once more before the cleared state was observed.

The user now lands on the login form instead of watching the address bar cycle.

## Scope

No protocol change and no new dependency. `WEBAPP_URL` and the redirect targets are untouched.

Worth noting what this does **not** fix: whatever caused the first silent SSO attempt to fail. That remains worth investigating, but it is now a single failed attempt ending on a login form rather than an unbounded loop — a bad first attempt should not be able to trap the browser.

## On the first attempt at this bug

I initially misread the report and opened #1293, deriving the login page origin from `redirect_uri`. That was wrong: `redirect_uri` belongs to the **relying application**, not to FerrisKey, so the change would have sent users to `https://<the-app>/realms/<realm>/authentication/login` — a page that does not exist there — breaking every third-party integration. It is closed, and #1291 carries the correction.

The tests I wrote for it passed because they encoded the same misunderstanding as the code: they asserted that an origin was extracted correctly, never that it belonged to the right party.

## Verification

Three unit tests on the marker: a login URL that already carries parameters gains it as another one, a bare URL opens its query string, and it is never repeated. 19 tests in the crate. Front-end gates re-run rather than assumed: `tsc` exits 0 and `eslint` reports 59 problems with 0 errors — the unchanged baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired sessions during login.
  * Stale authentication cookies are cleared automatically.
  * Automatic sign-in redirects are prevented when a session has expired.
  * Login links now indicate when a session expired, allowing the app to reset authentication state cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->