### PR TITLE
feat(api): import/export endpoints for branding themes and layouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,6 +1708,7 @@ name = "ferriskey-api-email-template"
 version = "0.7.0"
 dependencies = [
  "axum",
+ "chrono",
  "ferriskey-api-core",
  "ferriskey-core",
  "serde",

--- a/api/src/application/http/server/http_server.rs
+++ b/api/src/application/http/server/http_server.rs
@@ -26,7 +26,9 @@ use ferriskey_api_webhook::router::webhook_routes;
 use super::config::get_config;
 use axum::Router;
 use axum::http::Method;
-use axum::http::header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
+use axum::http::header::{
+    ACCEPT, AUTHORIZATION, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION,
+};
 use axum::routing::get;
 use axum_cookie::prelude::*;
 use axum_prometheus::PrometheusMetricLayer;
@@ -109,6 +111,10 @@ pub fn router(state: AppState) -> Result<Router, anyhow::Error> {
             ACCEPT,
             LOCATION,
         ])
+        // The console reads the filename an export chose out of this header.
+        // A cross-origin response hides every header the server does not name
+        // here, so without it the download falls back to a generic name.
+        .expose_headers([CONTENT_DISPOSITION])
         .allow_credentials(true)
         .max_age(PREFLIGHT_MAX_AGE);
 

--- a/core/src/application/email_template/mod.rs
+++ b/core/src/application/email_template/mod.rs
@@ -7,8 +7,8 @@ use crate::{
             entities::EmailTemplate,
             ports::{
                 CreateEmailTemplateInput, DeleteEmailTemplateInput, EmailTemplateService,
-                GetEmailTemplateInput, GetEmailTemplatesInput, RenderEmailTemplateInput,
-                UpdateEmailTemplateInput,
+                GetEmailTemplateInput, GetEmailTemplatesInput, ImportEmailTemplateInput,
+                RenderEmailTemplateInput, UpdateEmailTemplateInput,
             },
         },
     },
@@ -72,6 +72,16 @@ impl EmailTemplateService for ApplicationService {
     ) -> Result<String, CoreError> {
         self.email_template_service
             .render_template_html(identity, input)
+            .await
+    }
+
+    async fn import_template(
+        &self,
+        identity: Identity,
+        input: ImportEmailTemplateInput,
+    ) -> Result<EmailTemplate, CoreError> {
+        self.email_template_service
+            .import_template(identity, input)
             .await
     }
 }

--- a/core/src/application/portal_layouts/mod.rs
+++ b/core/src/application/portal_layouts/mod.rs
@@ -6,8 +6,8 @@ use crate::{
         portal_layouts::{
             entities::PortalLayout,
             ports::{
-                CreateLayoutInput, GetLayoutInput, ListLayoutsInput, PortalLayoutsService,
-                UpdateLayoutInput,
+                CreateLayoutInput, GetLayoutInput, ImportLayoutInput, ListLayoutsInput,
+                PortalLayoutsService, UpdateLayoutInput,
             },
         },
     },
@@ -88,5 +88,15 @@ impl PortalLayoutsService for ApplicationService {
         input: GetLayoutInput,
     ) -> Result<Option<PortalLayout>, CoreError> {
         self.portal_layouts_service.get_public_layout(input).await
+    }
+
+    async fn import_layout(
+        &self,
+        identity: Identity,
+        input: ImportLayoutInput,
+    ) -> Result<PortalLayout, CoreError> {
+        self.portal_layouts_service
+            .import_layout(identity, input)
+            .await
     }
 }

--- a/core/src/application/portal_theme/mod.rs
+++ b/core/src/application/portal_theme/mod.rs
@@ -3,8 +3,9 @@ use crate::{
     domain::{
         authentication::value_objects::Identity,
         common::entities::app_errors::CoreError,
+        portal_layouts::ports::{ImportLayoutInput, PortalLayoutsService},
         portal_theme::{
-            entities::{PortalTheme, PortalThemeConfig},
+            entities::{PortalPageType, PortalTheme, PortalThemeConfig},
             ports::{
                 CreateThemeInput, GetThemeByIdInput, GetThemeInput, ListThemesInput,
                 PortalThemeService, UpdateThemeInput, UpdateThemeMetadataInput,
@@ -111,4 +112,87 @@ impl PortalThemeService for ApplicationService {
     ) -> Result<Option<PortalTheme>, CoreError> {
         self.portal_theme_service.get_active_theme(input).await
     }
+}
+
+/// Importing a theme spans two domains — the theme and the layout it is framed
+/// by — so it is composed here rather than inside either service: the theme
+/// service has no layout repository, and giving it one to serve an import
+/// would widen it for every other caller.
+impl ApplicationService {
+    pub async fn import_portal_theme(
+        &self,
+        identity: Identity,
+        input: ImportPortalThemeInput,
+    ) -> Result<PortalTheme, CoreError> {
+        // The layout travels inside the file, so it is recreated first and the
+        // theme is bound to the fresh id. A file exported from a theme with no
+        // layout carries none, and the theme keeps the realm's default.
+        let layout_id = match input.layout {
+            Some(layout) => Some(
+                self.import_layout(
+                    identity.clone(),
+                    ImportLayoutInput {
+                        realm_name: input.realm_name.clone(),
+                        name: layout.name,
+                        tree: layout.tree,
+                    },
+                )
+                .await?
+                .id,
+            ),
+            None => None,
+        };
+
+        let theme = self
+            .create_theme(
+                identity.clone(),
+                CreateThemeInput {
+                    realm_name: input.realm_name.clone(),
+                    name: input.name,
+                    layout_id,
+                    config: input.config,
+                },
+            )
+            .await?;
+
+        // Pages are written one by one because that is the only write the
+        // repository exposes. A page that fails leaves the theme created but
+        // incomplete — the caller sees the error, and activation would refuse
+        // it anyway, so nothing half-valid can go live.
+        for (page_type, tree) in input.pages {
+            self.update_theme_page(
+                identity.clone(),
+                UpdateThemePageInput {
+                    realm_name: input.realm_name.clone(),
+                    theme_id: theme.id,
+                    page_type,
+                    tree,
+                },
+            )
+            .await?;
+        }
+
+        self.get_theme_by_id(
+            identity,
+            GetThemeByIdInput {
+                realm_name: input.realm_name,
+                theme_id: theme.id,
+            },
+        )
+        .await
+    }
+}
+
+pub struct ImportPortalThemeLayout {
+    pub name: String,
+    pub tree: serde_json::Value,
+}
+
+pub struct ImportPortalThemeInput {
+    pub realm_name: String,
+    pub name: String,
+    pub config: PortalThemeConfig,
+    /// Every page the file carries, in the order it should be written.
+    pub pages: Vec<(PortalPageType, serde_json::Value)>,
+    pub layout: Option<ImportPortalThemeLayout>,
 }

--- a/core/src/application/portal_theme/mod.rs
+++ b/core/src/application/portal_theme/mod.rs
@@ -5,10 +5,10 @@ use crate::{
         common::entities::app_errors::CoreError,
         portal_layouts::ports::{ImportLayoutInput, PortalLayoutsService},
         portal_theme::{
-            entities::{PortalPageType, PortalTheme, PortalThemeConfig},
+            entities::{PortalTheme, PortalThemeConfig},
             ports::{
-                CreateThemeInput, GetThemeByIdInput, GetThemeInput, ListThemesInput,
-                PortalThemeService, UpdateThemeInput, UpdateThemeMetadataInput,
+                CreateThemeInput, GetThemeByIdInput, GetThemeInput, ImportPortalThemeInput,
+                ListThemesInput, PortalThemeService, UpdateThemeInput, UpdateThemeMetadataInput,
                 UpdateThemePageInput,
             },
         },
@@ -181,18 +181,4 @@ impl ApplicationService {
         )
         .await
     }
-}
-
-pub struct ImportPortalThemeLayout {
-    pub name: String,
-    pub tree: serde_json::Value,
-}
-
-pub struct ImportPortalThemeInput {
-    pub realm_name: String,
-    pub name: String,
-    pub config: PortalThemeConfig,
-    /// Every page the file carries, in the order it should be written.
-    pub pages: Vec<(PortalPageType, serde_json::Value)>,
-    pub layout: Option<ImportPortalThemeLayout>,
 }

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -2180,6 +2180,10 @@ mod tests {
         fn render_to_html(&self, _intermediate: &str) -> Result<String, CoreError> {
             Ok(String::new())
         }
+
+        fn parse_intermediate(&self, _intermediate: &str) -> Result<serde_json::Value, CoreError> {
+            Ok(serde_json::json!({"children": []}))
+        }
     }
 
     type TestTridentService = TridentServiceImpl<

--- a/core/src/infrastructure/email_template/renderer/mjml_renderer.rs
+++ b/core/src/infrastructure/email_template/renderer/mjml_renderer.rs
@@ -466,8 +466,10 @@ mod tests {
     fn test_mjml_to_json_builds_builder_nodes() {
         let mjml = r##"<mjml><mj-body><mj-section background-color="#ffffff"><mj-column><mj-text font-size="16px">Hello {{user.first_name}}</mj-text></mj-column></mj-section></mj-body></mjml>"##;
 
-        let structure = mjml_to_json(mjml).unwrap();
-        let children = structure["children"].as_array().unwrap();
+        let structure = mjml_to_json(mjml).expect("valid markup parses");
+        let children = structure["children"]
+            .as_array()
+            .expect("a parsed body carries its children");
 
         assert_eq!(children.len(), 1);
         let section = &children[0];
@@ -486,7 +488,7 @@ mod tests {
     fn test_mjml_to_json_keeps_inline_html_as_content() {
         let mjml = r#"<mjml><mj-body><mj-section><mj-column><mj-text><p>Hello <b>world</b></p><br /></mj-text></mj-column></mj-section></mj-body></mjml>"#;
 
-        let structure = mjml_to_json(mjml).unwrap();
+        let structure = mjml_to_json(mjml).expect("valid markup parses");
         let text = &structure["children"][0]["children"][0]["children"][0];
 
         assert_eq!(text["type"], "mj-text");
@@ -498,15 +500,20 @@ mod tests {
     fn test_mjml_to_json_roundtrips_through_json_to_mjml() {
         let original = r##"<mjml><mj-body><mj-section><mj-column><mj-text font-size="14px">Hi</mj-text><mj-divider border-color="#eeeeee" /></mj-column></mj-section></mj-body></mjml>"##;
 
-        let structure = mjml_to_json(original).unwrap();
-        let rendered = json_to_mjml(&structure).unwrap();
+        let structure = mjml_to_json(original).expect("valid markup parses");
+        let rendered = json_to_mjml(&structure).expect("a parsed tree renders back");
 
         // Re-parsing the rendered MJML yields the same tree, ids aside.
-        let reparsed = mjml_to_json(&rendered).unwrap();
+        let reparsed = mjml_to_json(&rendered).expect("rendered markup parses again");
         assert_eq!(strip_ids(&structure), strip_ids(&reparsed));
 
         let renderer = MjmlTemplateRenderer::new();
-        assert!(renderer.render_to_html(&rendered).unwrap().contains("Hi"));
+        assert!(
+            renderer
+                .render_to_html(&rendered)
+                .expect("rendered markup compiles to html")
+                .contains("Hi")
+        );
     }
 
     #[test]

--- a/core/src/infrastructure/email_template/renderer/mjml_renderer.rs
+++ b/core/src/infrastructure/email_template/renderer/mjml_renderer.rs
@@ -27,6 +27,152 @@ impl TemplateRenderer for MjmlTemplateRenderer {
             .map_err(|e| CoreError::EmailTemplateRenderError(format!("MJML render error: {e}")))?;
         Ok(html)
     }
+
+    fn parse_intermediate(&self, intermediate: &str) -> Result<serde_json::Value, CoreError> {
+        mjml_to_json(intermediate)
+    }
+}
+
+/// Converts an MJML document into the builder JSON structure, the inverse of
+/// [`json_to_mjml`].
+///
+/// `mrml` parses (and thereby validates) the markup, and its AST serializes to
+/// `{"type": "mj-section", "attributes": {…}, "children": […]}` — one rename away
+/// from a builder node. Only the `<mj-body>` subtree is representable in the
+/// builder, so `<mj-head>` and its global attributes are dropped.
+fn mjml_to_json(mjml: &str) -> Result<serde_json::Value, CoreError> {
+    // The markup is supplied by the caller, so a parse failure is bad input,
+    // not a server fault — `InvalidEmailTemplateStructure` is the 4xx variant.
+    let parsed = mrml::parse(mjml)
+        .map_err(|e| CoreError::InvalidEmailTemplateStructure(format!("MJML parse error: {e}")))?;
+
+    let document = serde_json::to_value(&parsed).map_err(|e| {
+        CoreError::EmailTemplateRenderError(format!("MJML serialization error: {e}"))
+    })?;
+
+    let body = document
+        .get("children")
+        .and_then(|children| children.as_array())
+        .and_then(|children| {
+            children
+                .iter()
+                .find(|child| child.get("type").and_then(|t| t.as_str()) == Some("mj-body"))
+        })
+        .ok_or_else(|| {
+            CoreError::InvalidEmailTemplateStructure("MJML document has no <mj-body>".to_string())
+        })?;
+
+    let children = node_children(body)
+        .iter()
+        .filter_map(mrml_node_to_builder_node)
+        .collect::<Vec<_>>();
+
+    Ok(serde_json::json!({ "children": children }))
+}
+
+fn node_children(node: &serde_json::Value) -> &[serde_json::Value] {
+    node.get("children")
+        .and_then(|children| children.as_array())
+        .map(|children| children.as_slice())
+        .unwrap_or_default()
+}
+
+/// Maps one MJML element onto a builder node. Non-MJML children (raw HTML, bare
+/// text) are folded back into `content`, which is where the builder keeps them.
+fn mrml_node_to_builder_node(node: &serde_json::Value) -> Option<serde_json::Value> {
+    let node_type = node.get("type")?.as_str()?;
+    if !node_type.starts_with("mj-") {
+        return None;
+    }
+
+    let mut children = Vec::new();
+    let mut content = String::new();
+
+    for child in node_children(node) {
+        match child {
+            serde_json::Value::String(text) => content.push_str(text),
+            serde_json::Value::Object(_) => {
+                let child_type = child
+                    .get("type")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or_default();
+                if child_type.starts_with("mj-") {
+                    if let Some(child_node) = mrml_node_to_builder_node(child) {
+                        children.push(child_node);
+                    }
+                } else if child_type != "comment" {
+                    content.push_str(&raw_node_to_html(child));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut builder_node = serde_json::Map::new();
+    builder_node.insert(
+        "id".to_string(),
+        serde_json::Value::String(uuid::Uuid::new_v4().to_string()),
+    );
+    builder_node.insert(
+        "type".to_string(),
+        serde_json::Value::String(node_type.to_string()),
+    );
+    builder_node.insert(
+        "props".to_string(),
+        node.get("attributes")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({})),
+    );
+    builder_node.insert("styles".to_string(), serde_json::json!({}));
+    builder_node.insert("children".to_string(), serde_json::Value::Array(children));
+    if !content.is_empty() {
+        builder_node.insert("content".to_string(), serde_json::Value::String(content));
+    }
+
+    Some(serde_json::Value::Object(builder_node))
+}
+
+/// Re-serializes a raw HTML node from the mrml AST back into markup.
+fn raw_node_to_html(node: &serde_json::Value) -> String {
+    let Some(tag) = node.get("type").and_then(|t| t.as_str()) else {
+        return String::new();
+    };
+
+    let attrs = node
+        .get("attributes")
+        .and_then(|attrs| attrs.as_object())
+        .map(|attrs| {
+            attrs
+                .iter()
+                .map(|(key, value)| match value.as_str() {
+                    Some(value) => format!(" {key}=\"{value}\""),
+                    None => format!(" {key}"),
+                })
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+
+    // `children` is a string for comments, an array for every other node.
+    let inner = match node.get("children") {
+        Some(serde_json::Value::String(text)) => text.clone(),
+        _ => node_children(node)
+            .iter()
+            .map(|child| match child {
+                serde_json::Value::String(text) => text.clone(),
+                serde_json::Value::Object(_) => raw_node_to_html(child),
+                _ => String::new(),
+            })
+            .collect::<String>(),
+    };
+
+    // HTML void elements have no closing tag; emitting one would nest the rest
+    // of the content inside them.
+    const VOID_ELEMENTS: [&str; 6] = ["br", "hr", "img", "input", "meta", "link"];
+    if VOID_ELEMENTS.contains(&tag) {
+        return format!("<{tag}{attrs} />");
+    }
+
+    format!("<{tag}{attrs}>{inner}</{tag}>")
 }
 
 /// Converts a builder JSON structure into an MJML string.
@@ -314,5 +460,77 @@ mod tests {
 
         let html = renderer.render_to_html(&mjml).unwrap();
         assert!(html.contains("Hello {{user.first_name}}"));
+    }
+
+    #[test]
+    fn test_mjml_to_json_builds_builder_nodes() {
+        let mjml = r##"<mjml><mj-body><mj-section background-color="#ffffff"><mj-column><mj-text font-size="16px">Hello {{user.first_name}}</mj-text></mj-column></mj-section></mj-body></mjml>"##;
+
+        let structure = mjml_to_json(mjml).unwrap();
+        let children = structure["children"].as_array().unwrap();
+
+        assert_eq!(children.len(), 1);
+        let section = &children[0];
+        assert_eq!(section["type"], "mj-section");
+        assert_eq!(section["props"]["background-color"], "#ffffff");
+        assert!(section["id"].as_str().is_some_and(|id| !id.is_empty()));
+        assert_eq!(section["styles"], json!({}));
+
+        let text = &section["children"][0]["children"][0];
+        assert_eq!(text["type"], "mj-text");
+        assert_eq!(text["props"]["font-size"], "16px");
+        assert_eq!(text["content"], "Hello {{user.first_name}}");
+    }
+
+    #[test]
+    fn test_mjml_to_json_keeps_inline_html_as_content() {
+        let mjml = r#"<mjml><mj-body><mj-section><mj-column><mj-text><p>Hello <b>world</b></p><br /></mj-text></mj-column></mj-section></mj-body></mjml>"#;
+
+        let structure = mjml_to_json(mjml).unwrap();
+        let text = &structure["children"][0]["children"][0]["children"][0];
+
+        assert_eq!(text["type"], "mj-text");
+        assert_eq!(text["content"], "<p>Hello <b>world</b></p><br />");
+        assert_eq!(text["children"], json!([]));
+    }
+
+    #[test]
+    fn test_mjml_to_json_roundtrips_through_json_to_mjml() {
+        let original = r##"<mjml><mj-body><mj-section><mj-column><mj-text font-size="14px">Hi</mj-text><mj-divider border-color="#eeeeee" /></mj-column></mj-section></mj-body></mjml>"##;
+
+        let structure = mjml_to_json(original).unwrap();
+        let rendered = json_to_mjml(&structure).unwrap();
+
+        // Re-parsing the rendered MJML yields the same tree, ids aside.
+        let reparsed = mjml_to_json(&rendered).unwrap();
+        assert_eq!(strip_ids(&structure), strip_ids(&reparsed));
+
+        let renderer = MjmlTemplateRenderer::new();
+        assert!(renderer.render_to_html(&rendered).unwrap().contains("Hi"));
+    }
+
+    #[test]
+    fn test_mjml_to_json_rejects_invalid_markup() {
+        assert!(mjml_to_json("<invalid>not mjml</invalid>").is_err());
+    }
+
+    #[test]
+    fn test_mjml_to_json_requires_a_body() {
+        assert!(mjml_to_json("<mjml><mj-head></mj-head></mjml>").is_err());
+    }
+
+    fn strip_ids(value: &serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::Object(map) => serde_json::Value::Object(
+                map.iter()
+                    .filter(|(key, _)| key.as_str() != "id")
+                    .map(|(key, value)| (key.clone(), strip_ids(value)))
+                    .collect(),
+            ),
+            serde_json::Value::Array(items) => {
+                serde_json::Value::Array(items.iter().map(strip_ids).collect())
+            }
+            other => other.clone(),
+        }
     }
 }

--- a/core/src/infrastructure/webhook/repositories/webhook_repository.rs
+++ b/core/src/infrastructure/webhook/repositories/webhook_repository.rs
@@ -188,17 +188,20 @@ impl WebhookRepository for PostgresWebhookRepository {
         name: Option<String>,
         description: Option<String>,
         endpoint: String,
-        headers: HashMap<String, String>,
+        headers: Option<HashMap<String, String>>,
         subscribers: Vec<WebhookTrigger>,
     ) -> Result<Webhook, CoreError> {
-        let headers_json = to_value(headers).unwrap_or_default();
-
         let update_result = WebhookEntity::update_many()
             .set(WebhookActiveModel {
                 name: Set(name),
                 description: Set(description),
                 endpoint: Set(endpoint),
-                headers: Set(headers_json),
+                // `NotSet` leaves the column alone — the caller said nothing
+                // about headers, so the stored ones stay.
+                headers: match headers {
+                    Some(headers) => Set(to_value(headers).unwrap_or_default()),
+                    None => sea_orm::ActiveValue::NotSet,
+                },
                 updated_at: Set(Utc::now().naive_utc()),
                 ..Default::default()
             })
@@ -433,7 +436,7 @@ mod tests {
                 Some("hijacked".to_string()),
                 None,
                 "https://attacker.example/hook".to_string(),
-                HashMap::new(),
+                Some(HashMap::new()),
                 Vec::new(),
             )
             .await;
@@ -494,7 +497,7 @@ mod tests {
                 Some("renamed".to_string()),
                 None,
                 "https://example.com/updated".to_string(),
-                HashMap::new(),
+                Some(HashMap::new()),
                 vec![WebhookTrigger::UserDeleted],
             )
             .await

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -1,5 +1,6 @@
 export namespace Schemas {
   // <Schemas>
+  export type AcsUrl = string;
   export type ActivateThemeResponse = { message: string };
   export type ThemeShadow = "none" | "small" | "large";
   export type ThemeBorders = Partial<{
@@ -89,6 +90,7 @@ export namespace Schemas {
     | { Unauthorized: string }
     | { Forbidden: string }
     | { BadRequest: string }
+    | { Conflict: string }
     | { ServiceUnavailable: string }
     | { OAuthError: { error: string; error_description: string } };
   export type ApiErrorResponse = { code: string; message: string; status: number };
@@ -115,6 +117,7 @@ export namespace Schemas {
   export type ChallengeOtpResponse = Partial<{ required_actions: Array<RequiredAction>; url: string | null }>;
   export type ClientType = "confidential" | "public" | "system";
   export type MaintenanceSessionStrategy = "terminate" | "expire";
+  export type Masked_String = string;
   export type Client = {
     access_token_lifetime?: (number | null) | undefined;
     client_id: string;
@@ -135,10 +138,28 @@ export namespace Schemas {
     redirect_uris?: (Array<RedirectUri> | null) | undefined;
     refresh_token_lifetime?: (number | null) | undefined;
     require_pkce: boolean;
-    secret?: (string | null) | undefined;
+    secret?: (null | Masked_String) | undefined;
     service_account_enabled: boolean;
     temporary_token_lifetime?: (number | null) | undefined;
     updated_at: string;
+  };
+  export type NameIdFormat =
+    | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+    | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+    | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+    | "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+  export type SpEntityId = string;
+  export type ClientSamlConfig = {
+    acs_url: AcsUrl;
+    client_id: string;
+    created_at: string;
+    name_id_format: NameIdFormat;
+    realm_id: RealmId;
+    sign_assertions: boolean;
+    sign_documents: boolean;
+    sp_entity_id: SpEntityId;
+    updated_at: string;
+    want_authn_requests_signed: boolean;
   };
   export type ScopeType = "NONE" | "OPTIONAL" | "DEFAULT";
   export type ClientScope = {
@@ -161,7 +182,7 @@ export namespace Schemas {
   };
   export type ClientScopeMapping = { client_id: string; default_scope_type: ScopeType; scope_id: string };
   export type ClientScopesResponse = { data: Array<ClientScope> };
-  export type ClientSecretResponse = { client_secret?: (string | null) | undefined };
+  export type ClientSecretResponse = Partial<{ client_secret: string | null }>;
   export type ClientsResponse = { data: Array<Client> };
   export type CodeChallengeMethod = "S256" | "PLAIN";
   export type FlowId = string;
@@ -175,7 +196,9 @@ export namespace Schemas {
     | "token_exchange"
     | "idp_redirect"
     | "idp_callback"
-    | "finalize";
+    | "finalize"
+    | "saml_authn_request"
+    | "saml_assertion";
   export type CompassFlowStep = {
     duration_ms?: (number | null) | undefined;
     error_code?: (string | null) | undefined;
@@ -227,7 +250,6 @@ export namespace Schemas {
     public_client?: boolean | undefined;
     service_account_enabled?: boolean | undefined;
   };
-  export type CreatedClientResponse = Client & Partial<{ client_secret: string | null }>;
   export type EmailType = "reset_password" | "magic_link" | "email_verification";
   export type EmailTemplate = {
     created_at: string;
@@ -300,6 +322,7 @@ export namespace Schemas {
     name: string;
     permissions: Array<string>;
     realm_id: RealmId;
+    require_mfa: boolean;
     updated_at: string;
   };
   export type CreateRoleResponse = { data: Role };
@@ -308,6 +331,7 @@ export namespace Schemas {
     name: string;
     permissions: Array<string>;
   };
+  export type CreateSamlAttributeMapperValidator = Partial<{ name: string; name_format: string; source: string }>;
   export type PortalThemePages = Partial<{
     deviceVerified: unknown;
     deviceVerify: unknown;
@@ -338,6 +362,8 @@ export namespace Schemas {
     layout_id?: (string | null) | undefined;
     name: string;
   };
+  export type LoginAlias = "username" | "email";
+  export type LoginAliases = Array<LoginAlias>;
   export type RealmSetting = {
     access_token_lifetime: number;
     compass_enabled: boolean;
@@ -350,6 +376,7 @@ export namespace Schemas {
     id_token_lifetime: number;
     lockout_duration_seconds: number;
     lockout_threshold: number;
+    login_aliases: LoginAliases;
     magic_link_enabled: boolean;
     magic_link_template_id?: (string | null) | undefined;
     magic_link_ttl: number;
@@ -357,7 +384,9 @@ export namespace Schemas {
     realm_id: RealmId;
     refresh_token_lifetime: number;
     remember_me_enabled: boolean;
+    require_mfa: boolean;
     reset_password_template_id?: (string | null) | undefined;
+    seawatch_pii_mode: string;
     temporary_token_lifetime: number;
     updated_at: string;
     user_registration_enabled: boolean;
@@ -396,6 +425,7 @@ export namespace Schemas {
     lastname: string | null;
     username: string;
   }>;
+  export type CreateWebOriginValidator = Partial<{ value: string }>;
   export type WebhookTrigger =
     | "user.created"
     | "user.email_verified"
@@ -417,6 +447,11 @@ export namespace Schemas {
     | "redirect_uri.created"
     | "redirect_uri.updated"
     | "redirect_uri.deleted"
+    | "web_origin.created"
+    | "web_origin.deleted"
+    | "client.saml_config.updated"
+    | "client.saml_attribute_mapper.created"
+    | "client.saml_attribute_mapper.deleted"
     | "role.created"
     | "role.updated"
     | "role.deleted"
@@ -435,7 +470,6 @@ export namespace Schemas {
     created_at: string;
     description?: (string | null) | undefined;
     endpoint: string;
-    headers: Record<string, string>;
     id: string;
     name?: (string | null) | undefined;
     subscribers: Array<WebhookSubscriber>;
@@ -477,6 +511,7 @@ export namespace Schemas {
   export type DeleteClientResponse = { message: string; realm_name: string };
   export type DeleteClientScopeResponse = { message: string };
   export type DeleteEmailTemplateResponse = { message: string };
+  export type DeleteIdentityProviderLinkResponse = { count: number };
   export type DeleteIdentityProviderResponse = { count: number };
   export type DeletePortalLayoutResponse = { message: string };
   export type DeleteProtocolMapperResponse = { message: string };
@@ -488,15 +523,16 @@ export namespace Schemas {
   export type DeleteUserCredentialResponse = { message: string; realm_name: string; user_id: string };
   export type DeleteUserResponse = { count: number };
   export type DeleteWebhookResponse = { message: string; realm_name: string };
-  export type DeviceAuthorizationRequest = Partial<{ client_id: string | null; scope: string | null }>;
+  export type DeviceAuthorizationRequest = Partial<{
+    client_id: string | null;
+    client_secret: string | null;
+    scope: string | null;
+  }>;
+  export type DeviceVerificationPreview = { client_id: string; client_name: string; scopes: Array<string> };
   export type DeviceVerifyAction = "approve" | "deny";
   export type DeviceVerifyRequest = { action: DeviceVerifyAction; user_code: string };
-  export type DeviceVerificationPreview = {
-    client_id: string;
-    client_name: string;
-    scopes: Array<string>;
-  };
   export type DeviceVerifyResponse = { status: string };
+  export type EmailTemplateExportFormat = "json" | "mjml";
   export type EvaluatedMapper = { config: unknown; mapper_type: string; name: string };
   export type EvaluatedRoles = { client_roles: Record<string, Array<string>>; realm_roles: Array<string> };
   export type EvaluatedScope = { default_scope_type: string; name: string; protocol: string };
@@ -510,6 +546,13 @@ export namespace Schemas {
   };
   export type EvaluateScopesValidator = { scope?: (string | null) | undefined; user_id: string };
   export type EventStatus = "success" | "failure";
+  export type ExportEnvelope = {
+    email_type?: (string | null) | undefined;
+    ferriskey: string;
+    name: string;
+    tree: Record<string, unknown>;
+    version: number;
+  };
   export type FlowStats = {
     avg_duration_ms?: (number | null) | undefined;
     failure_count: number;
@@ -568,21 +611,25 @@ export namespace Schemas {
     | "client_created"
     | "client_deleted"
     | "client_secret_rotated"
+    | "client_secret_viewed"
     | "realm_config_changed"
     | "email_not_sent"
     | "email_sent"
     | "client_maintenance_enabled"
     | "client_maintenance_disabled"
     | "session_created"
-    | "session_revoked";
+    | "session_revoked"
+    | "identity_provider_link_removed";
   export type SecurityEventId = string;
   export type SecurityEvent = {
     actor_id?: (string | null) | undefined;
     actor_type?: (null | ActorType) | undefined;
     details?: unknown | undefined;
+    event_hash?: (Array<number> | null) | undefined;
     event_type: SecurityEventType;
     id: SecurityEventId;
     ip_address?: (string | null) | undefined;
+    prev_hash?: (Array<number> | null) | undefined;
     realm_id: RealmId;
     resource?: (string | null) | undefined;
     status: EventStatus;
@@ -634,6 +681,15 @@ export namespace Schemas {
   };
   export type GroupMemberPage = { data: Array<GroupMemberDetail>; limit: number; offset: number; total: number };
   export type GroupNode = Group & { children: Array<GroupNode> };
+  export type IdentityProviderLinkResponse = {
+    created_at: string;
+    id: string;
+    identity_provider_alias: string;
+    identity_provider_id: string;
+    identity_provider_user_id: string;
+    updated_at: string;
+  };
+  export type IdentityProviderLinksResponse = { data: Array<IdentityProviderLinkResponse> };
   export type IdentityProviderPresentation = {
     display_name: string;
     icon: string;
@@ -656,6 +712,23 @@ export namespace Schemas {
     trust_email: boolean;
   };
   export type IdentityProvidersResponse = { data: Array<IdentityProviderResponse> };
+  export type ImportEmailTemplateResponse = { data: EmailTemplate };
+  export type ImportEmailTemplateValidator = {
+    email_type: string;
+    ferriskey?: (string | null) | undefined;
+    mjml?: (string | null) | undefined;
+    name: string;
+    structure?: unknown | undefined;
+    tree?: unknown | undefined;
+    version?: (number | null) | undefined;
+  };
+  export type ImportPortalLayoutResponse = { data: PortalLayout };
+  export type ImportPortalLayoutValidator = {
+    ferriskey?: (string | null) | undefined;
+    name: string;
+    tree: unknown;
+    version?: (number | null) | undefined;
+  };
   export type InitiateDeviceFlowOutput = {
     device_code: string;
     expires_in: number;
@@ -811,20 +884,20 @@ export namespace Schemas {
     require_uppercase: boolean;
   };
   export type RealmLoginSetting = {
-    display_name?: (string | null) | undefined
-    email_verification_enabled: boolean
-    forgot_password_enabled: boolean
-    identity_providers: Array<IdentityProviderPresentation>
-    login_aliases: Array<string>
-    magic_link_enabled: boolean
-    magic_link_ttl: number
-    name: string
-    passkey_enabled: boolean
-    remember_me_enabled: boolean
-    theme: PortalThemeConfig
-    user_registration_enabled: boolean
-  }
-  export type RedirectRegistrationResponse = { url: string }
+    display_name?: (string | null) | undefined;
+    email_verification_enabled: boolean;
+    forgot_password_enabled: boolean;
+    identity_providers: Array<IdentityProviderPresentation>;
+    login_aliases: LoginAliases;
+    magic_link_enabled: boolean;
+    magic_link_ttl: number;
+    name: string;
+    passkey_enabled: boolean;
+    remember_me_enabled: boolean;
+    theme: PortalThemeConfig;
+    user_registration_enabled: boolean;
+  };
+  export type RedirectRegistrationResponse = { url: string };
   export type RedirectUri = {
     client_id: string;
     created_at: string;
@@ -833,13 +906,13 @@ export namespace Schemas {
     updated_at: string;
     value: string;
   };
-  export type RegistrationRequest = Partial<{
+  export type RegistrationRequest = {
     email: string;
-    first_name: string | null;
-    last_name: string | null;
+    first_name?: (string | null) | undefined;
+    last_name?: (string | null) | undefined;
     password: string;
     username: string;
-  }>;
+  };
   export type RegistrationResponse =
     | { data: JwtToken; status: "authenticated" }
     | { data: RedirectRegistrationResponse; status: "redirect" }
@@ -855,8 +928,32 @@ export namespace Schemas {
     token: string;
     token_type_hint: string | null;
   }>;
+  export type SamlAttributeName = string;
+  export type SamlAttributeNameFormat =
+    | "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
+    | "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+    | "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified";
+  export type SamlAttributeSource = string;
+  export type SamlAttributeMapper = {
+    client_id: string;
+    created_at: string;
+    id: string;
+    name: SamlAttributeName;
+    name_format: SamlAttributeNameFormat;
+    source: SamlAttributeSource;
+    updated_at: string;
+  };
+  export type SamlAuthnRequestParams = { RelayState?: (string | null) | undefined; SAMLRequest: string };
   export type SendMagicLinkRequest = { email: string };
   export type SendMagicLinkResponse = { message: string };
+  export type SetClientSamlConfigValidator = Partial<{
+    acs_url: string;
+    name_id_format: string;
+    sign_assertions: boolean;
+    sign_documents: boolean;
+    sp_entity_id: string;
+    want_authn_requests_signed: boolean;
+  }>;
   export type SetDefaultPortalLayoutResponse = { data: PortalLayout };
   export type UserAttribute = {
     created_at: string;
@@ -1009,35 +1106,42 @@ export namespace Schemas {
   export type UpdateRealmResponse = { data: Realm };
   export type UpdateRealmSettingResponse = { data: Realm };
   export type UpdateRealmSettingValidator = Partial<{
-    access_token_lifetime: number | null
-    compass_enabled: boolean | null
-    default_signing_algorithm: string | null
-    email_verification_enabled: boolean | null
-    email_verification_template_id: string | null
-    email_verification_ttl_hours: number | null
-    forgot_password_enabled: boolean | null
-    id_token_lifetime: number | null
-    lockout_duration_seconds: number | null
-    lockout_threshold: number | null
-    login_aliases: Array<string> | null
-    magic_link_enabled: boolean | null
-    magic_link_template_id: string | null
-    magic_link_ttl: number | null
-    passkey_enabled: boolean | null
-    refresh_token_lifetime: number | null
-    remember_me_enabled: boolean | null
-    reset_password_template_id: string | null
-    temporary_token_lifetime: number | null
-    user_registration_enabled: boolean | null
-  }>
-  export type UpdateRealmValidator = { display_name?: (string | null) | undefined; name: string }
-  export type UpdateRedirectUriResponse = { data: RedirectUri }
-  export type UpdateRedirectUriValidator = Partial<{ enabled: boolean }>
-  export type UpdateRolePermissionsResponse = { data: Role }
-  export type UpdateRolePermissionsValidator = { permissions: Array<string> }
-  export type UpdateRoleResponse = { data: Role }
-  export type UpdateRoleValidator = Partial<{ description: string | null; name: string | null }>
-  export type UpdateThemeMetadataResponse = { data: PortalTheme }
+    access_token_lifetime: number | null;
+    compass_enabled: boolean | null;
+    default_signing_algorithm: string | null;
+    email_verification_enabled: boolean | null;
+    email_verification_template_id: string | null;
+    email_verification_ttl_hours: number | null;
+    forgot_password_enabled: boolean | null;
+    id_token_lifetime: number | null;
+    lockout_duration_seconds: number | null;
+    lockout_threshold: number | null;
+    login_aliases: Array<string> | null;
+    magic_link_enabled: boolean | null;
+    magic_link_template_id: string | null;
+    magic_link_ttl: number | null;
+    passkey_enabled: boolean | null;
+    refresh_token_lifetime: number | null;
+    remember_me_enabled: boolean | null;
+    require_mfa: boolean | null;
+    reset_password_template_id: string | null;
+    seawatch_pii_mode: string | null;
+    seawatch_pseudo_key: string | null;
+    temporary_token_lifetime: number | null;
+    user_registration_enabled: boolean | null;
+  }>;
+  export type UpdateRealmValidator = { display_name?: (string | null) | undefined; name: string };
+  export type UpdateRedirectUriResponse = { data: RedirectUri };
+  export type UpdateRedirectUriValidator = Partial<{ enabled: boolean }>;
+  export type UpdateRolePermissionsResponse = { data: Role };
+  export type UpdateRolePermissionsValidator = { permissions: Array<string> };
+  export type UpdateRoleResponse = { data: Role };
+  export type UpdateRoleValidator = Partial<{
+    description: string | null;
+    name: string | null;
+    require_mfa: boolean | null;
+  }>;
+  export type UpdateThemeMetadataResponse = { data: PortalTheme };
   export type UpdateThemeMetadataValidator = {
     config?: PortalThemeConfig | undefined;
     layout_id?: (string | null) | undefined;
@@ -1101,50 +1205,6 @@ export namespace Schemas {
     id: string;
     updated_at: string;
     value: WebOriginValue;
-  };
-  export type CreateWebOriginValidator = Partial<{ value: string }>;
-  export type SamlNameIdFormat =
-    | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-    | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
-    | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
-    | "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
-  export type SamlAttributeNameFormat =
-    | "urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
-    | "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
-    | "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified";
-  export type ClientSamlConfig = {
-    acs_url: string;
-    client_id: string;
-    created_at: string;
-    name_id_format: SamlNameIdFormat;
-    realm_id: RealmId;
-    sign_assertions: boolean;
-    sign_documents: boolean;
-    sp_entity_id: string;
-    updated_at: string;
-    want_authn_requests_signed: boolean;
-  };
-  export type SetClientSamlConfigValidator = {
-    acs_url: string;
-    name_id_format?: string | undefined;
-    sign_assertions?: boolean | undefined;
-    sign_documents?: boolean | undefined;
-    sp_entity_id: string;
-    want_authn_requests_signed?: boolean | undefined;
-  };
-  export type SamlAttributeMapper = {
-    client_id: string;
-    created_at: string;
-    id: string;
-    name: string;
-    name_format: SamlAttributeNameFormat;
-    source: string;
-    updated_at: string;
-  };
-  export type CreateSamlAttributeMapperValidator = {
-    name: string;
-    name_format?: string | undefined;
-    source: string;
   };
 
   // </Schemas>
@@ -1295,6 +1355,8 @@ export namespace Endpoints {
         state: string;
         nonce: string;
         session_id: string;
+        code_challenge: string;
+        code_challenge_method: string;
       }>;
       path: { realm_name: string; alias: string };
     };
@@ -1410,7 +1472,7 @@ export namespace Endpoints {
       body: Schemas.CreateClientValidator;
     };
     responses: {
-      201: Schemas.CreatedClientResponse;
+      201: Schemas.Client;
       400: Schemas.ApiErrorResponse;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
@@ -1522,11 +1584,7 @@ export namespace Endpoints {
     parameters: {
       path: { realm_name: string; client_id: string };
     };
-    responses: {
-      200: Schemas.ClientSecretResponse;
-      403: Schemas.ApiErrorResponse;
-      404: Schemas.ApiErrorResponse;
-    };
+    responses: { 200: Schemas.ClientSecretResponse; 403: unknown; 404: unknown };
   };
   export type put_Assign_default_scope = {
     method: "PUT";
@@ -1737,83 +1795,34 @@ export namespace Endpoints {
       500: Schemas.ApiErrorResponse;
     };
   };
-  export type get_Get_web_origins = {
+  export type get_Get_client_roles = {
     method: "GET";
-    path: "/realms/{realm_name}/clients/{client_id}/web-origins";
+    path: "/realms/{realm_name}/clients/{client_id}/roles";
     requestFormat: "json";
     parameters: {
       path: { realm_name: string; client_id: string };
     };
     responses: {
-      200: Array<Schemas.WebOrigin>;
+      200: Schemas.GetClientRolesResponse;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
       404: Schemas.ApiErrorResponse;
       500: Schemas.ApiErrorResponse;
     };
   };
-  export type post_Create_web_origin = {
+  export type post_Create_client_role = {
     method: "POST";
-    path: "/realms/{realm_name}/clients/{client_id}/web-origins";
+    path: "/realms/{realm_name}/clients/{client_id}/roles";
     requestFormat: "json";
     parameters: {
       path: { realm_name: string; client_id: string };
 
-      body: Schemas.CreateWebOriginValidator;
+      body: Schemas.CreateRoleValidator;
     };
     responses: {
-      201: Schemas.WebOrigin;
-      400: Schemas.ApiErrorResponse;
+      201: Schemas.Role;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
-      500: Schemas.ApiErrorResponse;
-    };
-  };
-  export type delete_Delete_web_origin = {
-    method: "DELETE";
-    path: "/realms/{realm_name}/clients/{client_id}/web-origins/{web_origin_id}";
-    requestFormat: "json";
-    parameters: {
-      path: { realm_name: string; client_id: string; web_origin_id: string };
-    };
-    responses: {
-      200: unknown;
-      401: Schemas.ApiErrorResponse;
-      403: Schemas.ApiErrorResponse;
-      404: Schemas.ApiErrorResponse;
-      500: Schemas.ApiErrorResponse;
-    };
-  };
-  export type get_Get_client_saml_config = {
-    method: "GET";
-    path: "/realms/{realm_name}/clients/{client_id}/saml-config";
-    requestFormat: "json";
-    parameters: {
-      path: { realm_name: string; client_id: string };
-    };
-    responses: {
-      200: Schemas.ClientSamlConfig;
-      401: Schemas.ApiErrorResponse;
-      403: Schemas.ApiErrorResponse;
-      404: Schemas.ApiErrorResponse;
-      500: Schemas.ApiErrorResponse;
-    };
-  };
-  export type put_Set_client_saml_config = {
-    method: "PUT";
-    path: "/realms/{realm_name}/clients/{client_id}/saml-config";
-    requestFormat: "json";
-    parameters: {
-      path: { realm_name: string; client_id: string };
-
-      body: Schemas.SetClientSamlConfigValidator;
-    };
-    responses: {
-      201: Schemas.ClientSamlConfig;
-      400: Schemas.ApiErrorResponse;
-      401: Schemas.ApiErrorResponse;
-      403: Schemas.ApiErrorResponse;
-      404: Schemas.ApiErrorResponse;
       500: Schemas.ApiErrorResponse;
     };
   };
@@ -1865,34 +1874,83 @@ export namespace Endpoints {
       500: Schemas.ApiErrorResponse;
     };
   };
-  export type get_Get_client_roles = {
+  export type get_Get_client_saml_config = {
     method: "GET";
-    path: "/realms/{realm_name}/clients/{client_id}/roles";
+    path: "/realms/{realm_name}/clients/{client_id}/saml-config";
     requestFormat: "json";
     parameters: {
       path: { realm_name: string; client_id: string };
     };
     responses: {
-      200: Schemas.GetClientRolesResponse;
+      200: Schemas.ClientSamlConfig;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
       404: Schemas.ApiErrorResponse;
       500: Schemas.ApiErrorResponse;
     };
   };
-  export type post_Create_client_role = {
-    method: "POST";
-    path: "/realms/{realm_name}/clients/{client_id}/roles";
+  export type put_Set_client_saml_config = {
+    method: "PUT";
+    path: "/realms/{realm_name}/clients/{client_id}/saml-config";
     requestFormat: "json";
     parameters: {
       path: { realm_name: string; client_id: string };
 
-      body: Schemas.CreateRoleValidator;
+      body: Schemas.SetClientSamlConfigValidator;
     };
     responses: {
-      201: Schemas.Role;
+      201: Schemas.ClientSamlConfig;
+      400: Schemas.ApiErrorResponse;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type get_Get_web_origins = {
+    method: "GET";
+    path: "/realms/{realm_name}/clients/{client_id}/web-origins";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+    };
+    responses: {
+      200: Array<Schemas.WebOrigin>;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type post_Create_web_origin = {
+    method: "POST";
+    path: "/realms/{realm_name}/clients/{client_id}/web-origins";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string };
+
+      body: Schemas.CreateWebOriginValidator;
+    };
+    responses: {
+      201: Schemas.WebOrigin;
+      400: Schemas.ApiErrorResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type delete_Delete_web_origin = {
+    method: "DELETE";
+    path: "/realms/{realm_name}/clients/{client_id}/web-origins/{web_origin_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; client_id: string; web_origin_id: string };
+    };
+    responses: {
+      200: unknown;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
       500: Schemas.ApiErrorResponse;
     };
   };
@@ -1981,11 +2039,7 @@ export namespace Endpoints {
       query: { user_code: string };
       path: { realm_name: string };
     };
-    responses: {
-      200: Schemas.DeviceVerificationPreview;
-      401: Schemas.ApiErrorResponse;
-      403: Schemas.ApiErrorResponse;
-    };
+    responses: { 200: Schemas.DeviceVerificationPreview; 401: Schemas.ApiErrorResponse; 403: Schemas.ApiErrorResponse };
   };
   export type post_Device_verify = {
     method: "POST";
@@ -2034,6 +2088,23 @@ export namespace Endpoints {
       500: Schemas.ApiErrorResponse;
     };
   };
+  export type post_Import_template = {
+    method: "POST";
+    path: "/realms/{realm_name}/email-templates/import";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string };
+
+      body: Schemas.ImportEmailTemplateValidator;
+    };
+    responses: {
+      201: Schemas.ImportEmailTemplateResponse;
+      400: Schemas.ApiErrorResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
   export type get_Get_template = {
     method: "GET";
     path: "/realms/{realm_name}/email-templates/{template_id}";
@@ -2076,6 +2147,21 @@ export namespace Endpoints {
     };
     responses: {
       200: Schemas.DeleteEmailTemplateResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type get_Export_template = {
+    method: "GET";
+    path: "/realms/{realm_name}/email-templates/{template_id}/export";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; template_id: string; format: "json" | "mjml" };
+    };
+    responses: {
+      200: Schemas.ExportEnvelope;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
       404: Schemas.ApiErrorResponse;
@@ -2441,7 +2527,13 @@ export namespace Endpoints {
 
       body: Schemas.OtpVerifyRequest;
     };
-    responses: { 200: Schemas.VerifyOtpResponse; 400: Schemas.ApiErrorResponse; 500: Schemas.ApiErrorResponse };
+    responses: {
+      200: Schemas.VerifyOtpResponse;
+      400: Schemas.ApiErrorResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
   };
   export type post_Verify_reset_token = {
     method: "POST";
@@ -2970,6 +3062,24 @@ export namespace Endpoints {
       500: Schemas.ApiErrorResponse;
     };
   };
+  export type post_Import_layout = {
+    method: "POST";
+    path: "/realms/{realm_name}/portal-layouts/import";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string };
+
+      body: Schemas.ImportPortalLayoutValidator;
+    };
+    responses: {
+      201: Schemas.ImportPortalLayoutResponse;
+      400: Schemas.ApiErrorResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      422: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
   export type get_Get_public_default_layout = {
     method: "GET";
     path: "/realms/{realm_name}/portal-layouts/public/default";
@@ -3053,6 +3163,21 @@ export namespace Endpoints {
     };
     responses: {
       200: Schemas.SetDefaultPortalLayoutResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type get_Export_layout = {
+    method: "GET";
+    path: "/realms/{realm_name}/portal-layouts/{layout_id}/export";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; layout_id: string };
+    };
+    responses: {
+      200: Schemas.ExportEnvelope;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
       404: Schemas.ApiErrorResponse;
@@ -3406,6 +3531,46 @@ export namespace Endpoints {
     };
     responses: { 200: Schemas.UserInfoResponse; 401: unknown; 403: unknown; 500: unknown };
   };
+  export type get_Saml_sso_redirect = {
+    method: "GET";
+    path: "/realms/{realm_name}/protocol/saml";
+    requestFormat: "json";
+    parameters: {
+      query: { SAMLRequest: string; RelayState?: string | undefined };
+      path: { realm_name: string };
+    };
+    responses: { 302: unknown; 400: unknown; 500: unknown };
+  };
+  export type post_Saml_sso_post = {
+    method: "POST";
+    path: "/realms/{realm_name}/protocol/saml";
+    requestFormat: "form-url";
+    parameters: {
+      path: { realm_name: string };
+
+      body: Schemas.SamlAuthnRequestParams;
+    };
+    responses: { 302: unknown; 400: unknown; 500: unknown };
+  };
+  export type get_Saml_continue = {
+    method: "GET";
+    path: "/realms/{realm_name}/protocol/saml/continue";
+    requestFormat: "json";
+    parameters: {
+      query: { code: string };
+      path: { realm_name: string };
+    };
+    responses: { 200: unknown; 400: unknown; 500: unknown };
+  };
+  export type get_Saml_descriptor = {
+    method: "GET";
+    path: "/realms/{realm_name}/protocol/saml/descriptor";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string };
+    };
+    responses: { 200: unknown; 404: unknown; 500: unknown };
+  };
   export type get_Get_roles = {
     method: "GET";
     path: "/realms/{realm_name}/roles";
@@ -3726,6 +3891,36 @@ export namespace Endpoints {
       500: Schemas.ApiErrorResponse;
     };
   };
+  export type get_List_identity_provider_links = {
+    method: "GET";
+    path: "/realms/{realm_name}/users/{user_id}/identity-provider-links";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; user_id: string };
+    };
+    responses: {
+      200: Schemas.IdentityProviderLinksResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type delete_Delete_identity_provider_link = {
+    method: "DELETE";
+    path: "/realms/{realm_name}/users/{user_id}/identity-provider-links/{link_id}";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; user_id: string; link_id: string };
+    };
+    responses: {
+      200: Schemas.DeleteIdentityProviderLinkResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
   export type get_List_user_organizations = {
     method: "GET";
     path: "/realms/{realm_name}/users/{user_id}/organizations";
@@ -3970,6 +4165,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/device/preview": Endpoints.get_Device_preview;
     "/realms/{realm_name}/email-templates": Endpoints.get_Fetch_templates;
     "/realms/{realm_name}/email-templates/{template_id}": Endpoints.get_Get_template;
+    "/realms/{realm_name}/email-templates/{template_id}/export": Endpoints.get_Export_template;
     "/realms/{realm_name}/federation/providers": Endpoints.get_List_providers;
     "/realms/{realm_name}/federation/providers/{id}": Endpoints.get_Get_provider;
     "/realms/{realm_name}/identity-providers": Endpoints.get_List_identity_providers;
@@ -3992,6 +4188,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/portal-layouts/public/default": Endpoints.get_Get_public_default_layout;
     "/realms/{realm_name}/portal-layouts/public/{layout_id}": Endpoints.get_Get_public_layout;
     "/realms/{realm_name}/portal-layouts/{layout_id}": Endpoints.get_Get_layout;
+    "/realms/{realm_name}/portal-layouts/{layout_id}/export": Endpoints.get_Export_layout;
     "/realms/{realm_name}/portal/active": Endpoints.get_Get_active_theme;
     "/realms/{realm_name}/portal/page-requirements": Endpoints.get_Get_page_requirements;
     "/realms/{realm_name}/portal/theme": Endpoints.get_Get_theme;
@@ -4002,6 +4199,9 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/protocol/openid-connect/jwks.json": Endpoints.get_Get_jwks_json;
     "/realms/{realm_name}/protocol/openid-connect/logout": Endpoints.get_Logout_get;
     "/realms/{realm_name}/protocol/openid-connect/userinfo": Endpoints.get_Get_userinfo;
+    "/realms/{realm_name}/protocol/saml": Endpoints.get_Saml_sso_redirect;
+    "/realms/{realm_name}/protocol/saml/continue": Endpoints.get_Saml_continue;
+    "/realms/{realm_name}/protocol/saml/descriptor": Endpoints.get_Saml_descriptor;
     "/realms/{realm_name}/roles": Endpoints.get_Get_roles;
     "/realms/{realm_name}/roles/{role_id}": Endpoints.get_Get_role;
     "/realms/{realm_name}/seawatch/v1/security-events": Endpoints.get_Get_security_events;
@@ -4011,6 +4211,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/users/{user_id}": Endpoints.get_Get_user;
     "/realms/{realm_name}/users/{user_id}/attributes": Endpoints.get_Get_user_attributes;
     "/realms/{realm_name}/users/{user_id}/credentials": Endpoints.get_Get_user_credentials;
+    "/realms/{realm_name}/users/{user_id}/identity-provider-links": Endpoints.get_List_identity_provider_links;
     "/realms/{realm_name}/users/{user_id}/organizations": Endpoints.get_List_user_organizations;
     "/realms/{realm_name}/users/{user_id}/permissions": Endpoints.get_Get_user_permissions;
     "/realms/{realm_name}/users/{user_id}/roles": Endpoints.get_Get_user_roles;
@@ -4034,6 +4235,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/clients/{client_id}/web-origins": Endpoints.post_Create_web_origin;
     "/realms/{realm_name}/device/verify": Endpoints.post_Device_verify;
     "/realms/{realm_name}/email-templates": Endpoints.post_Create_template;
+    "/realms/{realm_name}/email-templates/import": Endpoints.post_Import_template;
     "/realms/{realm_name}/federation/providers": Endpoints.post_Create_provider;
     "/realms/{realm_name}/federation/providers/{id}/sync-users": Endpoints.post_Sync_users;
     "/realms/{realm_name}/federation/providers/{id}/test-connection": Endpoints.post_Test_connection;
@@ -4063,6 +4265,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/organizations/{organization_id}/members": Endpoints.post_Add_member;
     "/realms/{realm_name}/organizations/{organization_id}/members/{user_id}/roles": Endpoints.post_Assign_member_role;
     "/realms/{realm_name}/portal-layouts": Endpoints.post_Create_layout;
+    "/realms/{realm_name}/portal-layouts/import": Endpoints.post_Import_layout;
     "/realms/{realm_name}/portal/themes": Endpoints.post_Create_theme;
     "/realms/{realm_name}/portal/themes/{theme_id}/activate": Endpoints.post_Activate_theme;
     "/realms/{realm_name}/protocol/openid-connect/auth/device": Endpoints.post_Device_authorization;
@@ -4071,6 +4274,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/protocol/openid-connect/revoke": Endpoints.post_Revoke_token;
     "/realms/{realm_name}/protocol/openid-connect/token": Endpoints.post_Exchange_token;
     "/realms/{realm_name}/protocol/openid-connect/token/introspect": Endpoints.post_Introspect_token;
+    "/realms/{realm_name}/protocol/saml": Endpoints.post_Saml_sso_post;
     "/realms/{realm_name}/roles": Endpoints.post_Create_realm_role;
     "/realms/{realm_name}/users": Endpoints.post_Create_user;
     "/realms/{realm_name}/users/{user_id}/roles/{role_id}": Endpoints.post_Assign_role;
@@ -4138,6 +4342,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/users/{user_id}": Endpoints.delete_Delete_user;
     "/realms/{realm_name}/users/{user_id}/attributes/{key}": Endpoints.delete_Delete_user_attribute;
     "/realms/{realm_name}/users/{user_id}/credentials/{credential_id}": Endpoints.delete_Delete_user_credential;
+    "/realms/{realm_name}/users/{user_id}/identity-provider-links/{link_id}": Endpoints.delete_Delete_identity_provider_link;
     "/realms/{realm_name}/users/{user_id}/roles/{role_id}": Endpoints.delete_Unassign_role;
     "/realms/{realm_name}/users/{user_id}/sessions/{session_id}": Endpoints.delete_Revoke_user_session;
     "/realms/{realm_name}/webhooks/{webhook_id}": Endpoints.delete_Delete_webhook;

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -550,7 +550,7 @@ export namespace Schemas {
     email_type?: (string | null) | undefined;
     ferriskey: string;
     name: string;
-    tree: Record<string, unknown>;
+    tree: Array<Record<string, unknown>>;
     version: number;
   };
   export type FlowStats = {
@@ -1000,7 +1000,7 @@ export namespace Schemas {
     updated: number;
   };
   export type TestConnectionResponse = { details?: unknown | undefined; message: string; success: boolean };
-  export type ThemeExportLayout = { name: string; tree: Record<string, unknown> };
+  export type ThemeExportLayout = { name: string; tree: Array<Record<string, unknown>> };
   export type ThemeExportEnvelope = {
     config: Record<string, unknown>;
     ferriskey: string;
@@ -1183,7 +1183,7 @@ export namespace Schemas {
   export type UpdateWebhookValidator = Partial<{
     description: string | null;
     endpoint: string;
-    headers: Record<string, string>;
+    headers: Record<string, string> | null;
     name: string | null;
     subscribers: Array<WebhookTrigger>;
   }>;
@@ -2177,7 +2177,8 @@ export namespace Endpoints {
     path: "/realms/{realm_name}/email-templates/{template_id}/export";
     requestFormat: "json";
     parameters: {
-      path: { realm_name: string; template_id: string; format: "json" | "mjml" };
+      query: Partial<{ format: "json" | "mjml" }>;
+      path: { realm_name: string; template_id: string };
     };
     responses: {
       200: Schemas.ExportEnvelope;

--- a/front/src/api/api.client.ts
+++ b/front/src/api/api.client.ts
@@ -714,7 +714,7 @@ export namespace Schemas {
   export type IdentityProvidersResponse = { data: Array<IdentityProviderResponse> };
   export type ImportEmailTemplateResponse = { data: EmailTemplate };
   export type ImportEmailTemplateValidator = {
-    email_type: string;
+    email_type?: (string | null) | undefined;
     ferriskey?: (string | null) | undefined;
     mjml?: (string | null) | undefined;
     name: string;
@@ -726,7 +726,17 @@ export namespace Schemas {
   export type ImportPortalLayoutValidator = {
     ferriskey?: (string | null) | undefined;
     name: string;
-    tree: unknown;
+    tree?: unknown | undefined;
+    version?: (number | null) | undefined;
+  };
+  export type ImportPortalThemeLayoutValidator = { name: string; tree: Record<string, unknown> };
+  export type ImportPortalThemeResponse = { data: PortalTheme };
+  export type ImportPortalThemeValidator = {
+    config?: Record<string, unknown> | undefined;
+    ferriskey?: (string | null) | undefined;
+    layout?: (null | ImportPortalThemeLayoutValidator) | undefined;
+    name: string;
+    pages?: Record<string, unknown> | undefined;
     version?: (number | null) | undefined;
   };
   export type InitiateDeviceFlowOutput = {
@@ -990,6 +1000,15 @@ export namespace Schemas {
     updated: number;
   };
   export type TestConnectionResponse = { details?: unknown | undefined; message: string; success: boolean };
+  export type ThemeExportLayout = { name: string; tree: Record<string, unknown> };
+  export type ThemeExportEnvelope = {
+    config: Record<string, unknown>;
+    ferriskey: string;
+    layout?: (null | ThemeExportLayout) | undefined;
+    name: string;
+    pages: Record<string, unknown>;
+    version: number;
+  };
   export type ToggleMaintenanceResponse = { message: string };
   export type ToggleMaintenanceValidator = {
     enabled: boolean;
@@ -3279,6 +3298,23 @@ export namespace Endpoints {
       500: Schemas.ApiErrorResponse;
     };
   };
+  export type post_Import_theme = {
+    method: "POST";
+    path: "/realms/{realm_name}/portal/themes/import";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string };
+
+      body: Schemas.ImportPortalThemeValidator;
+    };
+    responses: {
+      201: Schemas.ImportPortalThemeResponse;
+      400: Schemas.ApiErrorResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
   export type get_Get_theme_by_id = {
     method: "GET";
     path: "/realms/{realm_name}/portal/themes/{theme_id}";
@@ -3337,6 +3373,21 @@ export namespace Endpoints {
     };
     responses: {
       200: Schemas.ActivateThemeResponse;
+      401: Schemas.ApiErrorResponse;
+      403: Schemas.ApiErrorResponse;
+      404: Schemas.ApiErrorResponse;
+      500: Schemas.ApiErrorResponse;
+    };
+  };
+  export type get_Export_theme = {
+    method: "GET";
+    path: "/realms/{realm_name}/portal/themes/{theme_id}/export";
+    requestFormat: "json";
+    parameters: {
+      path: { realm_name: string; theme_id: string };
+    };
+    responses: {
+      200: Schemas.ThemeExportEnvelope;
       401: Schemas.ApiErrorResponse;
       403: Schemas.ApiErrorResponse;
       404: Schemas.ApiErrorResponse;
@@ -4194,6 +4245,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/portal/theme": Endpoints.get_Get_theme;
     "/realms/{realm_name}/portal/themes": Endpoints.get_List_themes;
     "/realms/{realm_name}/portal/themes/{theme_id}": Endpoints.get_Get_theme_by_id;
+    "/realms/{realm_name}/portal/themes/{theme_id}/export": Endpoints.get_Export_theme;
     "/realms/{realm_name}/protocol/openid-connect/auth": Endpoints.get_Auth_handler;
     "/realms/{realm_name}/protocol/openid-connect/certs": Endpoints.get_Get_certs;
     "/realms/{realm_name}/protocol/openid-connect/jwks.json": Endpoints.get_Get_jwks_json;
@@ -4267,6 +4319,7 @@ export type EndpointByMethod = {
     "/realms/{realm_name}/portal-layouts": Endpoints.post_Create_layout;
     "/realms/{realm_name}/portal-layouts/import": Endpoints.post_Import_layout;
     "/realms/{realm_name}/portal/themes": Endpoints.post_Create_theme;
+    "/realms/{realm_name}/portal/themes/import": Endpoints.post_Import_theme;
     "/realms/{realm_name}/portal/themes/{theme_id}/activate": Endpoints.post_Activate_theme;
     "/realms/{realm_name}/protocol/openid-connect/auth/device": Endpoints.post_Device_authorization;
     "/realms/{realm_name}/protocol/openid-connect/logout": Endpoints.post_Logout_post;

--- a/front/src/api/builder-export.ts
+++ b/front/src/api/builder-export.ts
@@ -58,6 +58,13 @@ export async function downloadPortalLayoutExport(realm: string, layoutId: string
   saveBlob(blob, filename)
 }
 
+export async function downloadPortalThemeExport(realm: string, themeId: string): Promise<void> {
+  const { blob, filename } = await fetchExport(
+    `/realms/${realm}/portal/themes/${themeId}/export`,
+  )
+  saveBlob(blob, filename)
+}
+
 /** Reads a file the user picked and parses it as the JSON export envelope. */
 export async function readExportFile(file: File): Promise<Record<string, unknown>> {
   const text = await file.text()

--- a/front/src/api/builder-export.ts
+++ b/front/src/api/builder-export.ts
@@ -1,0 +1,70 @@
+import { authStore } from '@/store/auth.store.ts'
+
+/**
+ * Downloading an export cannot go through the generated client: it hands back a
+ * parsed body, while a download needs the bytes and the filename the server
+ * chose in `Content-Disposition`. So this issues the request itself, with the
+ * same bearer token the generated fetcher uses.
+ */
+async function fetchExport(path: string): Promise<{ blob: Blob; filename: string }> {
+  const token = authStore.getState().accessToken
+  const response = await fetch(new URL(path, window.apiUrl).toString(), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  })
+
+  if (!response.ok) {
+    throw new Error(`export failed with status ${response.status}`)
+  }
+
+  return {
+    blob: await response.blob(),
+    filename: filenameFromContentDisposition(response.headers.get('Content-Disposition')),
+  }
+}
+
+/** Falls back to a neutral name when the header is missing or unparseable. */
+function filenameFromContentDisposition(header: string | null): string {
+  const match = header?.match(/filename="([^"]+)"/)
+  return match?.[1] ?? 'export.json'
+}
+
+/** Hands the blob to the browser as a save-to-disk, then releases the object URL. */
+function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}
+
+export async function downloadEmailTemplateExport(
+  realm: string,
+  templateId: string,
+  format: 'json' | 'mjml',
+): Promise<void> {
+  const { blob, filename } = await fetchExport(
+    `/realms/${realm}/email-templates/${templateId}/export?format=${format}`,
+  )
+  saveBlob(blob, filename)
+}
+
+export async function downloadPortalLayoutExport(realm: string, layoutId: string): Promise<void> {
+  const { blob, filename } = await fetchExport(
+    `/realms/${realm}/portal-layouts/${layoutId}/export`,
+  )
+  saveBlob(blob, filename)
+}
+
+/** Reads a file the user picked and parses it as the JSON export envelope. */
+export async function readExportFile(file: File): Promise<Record<string, unknown>> {
+  const text = await file.text()
+
+  try {
+    return JSON.parse(text) as Record<string, unknown>
+  } catch {
+    throw new Error('This file is not valid JSON.')
+  }
+}

--- a/front/src/api/email-template.api.ts
+++ b/front/src/api/email-template.api.ts
@@ -58,6 +58,27 @@ export const useUpdateEmailTemplate = () => {
   })
 }
 
+export const useImportEmailTemplate = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/email-templates/import')
+      .mutationOptions,
+    onSuccess: async (_, variables) => {
+      const keys = window.tanstackApi.get('/realms/{realm_name}/email-templates', {
+        path: { realm_name: variables.path.realm_name },
+      }).queryKey
+
+      await queryClient.invalidateQueries({ queryKey: keys })
+      toast.success('Email template imported successfully')
+    },
+    // The server refuses a file that belongs to the other builder or that uses
+    // a format version it cannot read; its message says which, so surface it.
+    onError: (error) => {
+      toast.error('Failed to import', { description: error.message })
+    },
+  })
+}
+
 export const useDeleteEmailTemplate = () => {
   const queryClient = useQueryClient()
   return useMutation({

--- a/front/src/api/portal-layouts.api.ts
+++ b/front/src/api/portal-layouts.api.ts
@@ -125,3 +125,24 @@ export const useSetDefaultPortalLayout = () => {
     },
   })
 }
+
+export const useImportPortalLayout = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/portal-layouts/import')
+      .mutationOptions,
+    onSuccess: async (_, variables) => {
+      const keys = window.tanstackApi.get('/realms/{realm_name}/portal-layouts', {
+        path: { realm_name: variables.path.realm_name },
+      }).queryKey
+
+      await queryClient.invalidateQueries({ queryKey: keys })
+      toast.success('Portal layout imported successfully')
+    },
+    // The server refuses a file that belongs to the other builder or that uses
+    // a format version it cannot read; its message says which, so surface it.
+    onError: (error) => {
+      toast.error('Failed to import', { description: error.message })
+    },
+  })
+}

--- a/front/src/api/portal-theme.api.tsx
+++ b/front/src/api/portal-theme.api.tsx
@@ -89,6 +89,26 @@ export const useUpdatePortalThemeMetadata = () => {
   })
 }
 
+export const useImportPortalTheme = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation('post', '/realms/{realm_name}/portal/themes/import')
+      .mutationOptions,
+    onSuccess: async (_, variables) => {
+      const listKey = window.tanstackApi.get('/realms/{realm_name}/portal/themes', {
+        path: { realm_name: variables.path.realm_name },
+      }).queryKey
+      await queryClient.invalidateQueries({ queryKey: listKey })
+      toast.success('Portal theme imported')
+    },
+    // The server refuses a file that belongs to another builder or that uses a
+    // format version it cannot read; its message says which, so surface it.
+    onError: (error) => {
+      toast.error('Failed to import', { description: error.message })
+    },
+  })
+}
+
 export const useUpdatePortalThemePage = () => {
   const queryClient = useQueryClient()
   return useMutation({

--- a/front/src/lib/builder-portal/default-pages.ts
+++ b/front/src/lib/builder-portal/default-pages.ts
@@ -1,0 +1,52 @@
+import type { BuilderNode } from '@/lib/builder-core'
+import type { Schemas } from '@/api/api.client'
+import { PORTAL_PRESETS } from './presets'
+
+type PageType = Schemas.PortalPageType
+
+/**
+ * The preset(s) a freshly created theme starts each page with.
+ *
+ * A theme created with empty pages cannot be activated: the server refuses
+ * activation until every page carries the blocks its flow needs (an email and
+ * password field on Login, a code field on TOTP, and so on), so an admin had to
+ * compose twelve pages by hand before their theme could go live. Seeding each
+ * page from the matching preset means a new theme is activatable as it stands,
+ * and the admin edits from something rather than from nothing.
+ *
+ * Login takes two presets: the sign-in card carries the credentials form, and
+ * `or-continue-with` appends the identity providers block the page requires.
+ */
+const PAGE_PRESET_IDS: Record<PageType, string[]> = {
+  login: ['sign-in-card', 'or-continue-with'],
+  register: ['register-card'],
+  totp: ['totp-card'],
+  forgot_password: ['forgot-password-card'],
+  reset_password: ['reset-password-card'],
+  magic_link_request: ['magic-link-request-card'],
+  magic_link_verify: ['magic-link-verify-card'],
+  verify_email: ['verify-email-card'],
+  email_verified: ['email-verified-card'],
+  totp_setup: ['totp-setup-card'],
+  device_verify: ['device-verify-card'],
+  device_verified: ['device-verified-card'],
+}
+
+export const DEFAULT_PAGE_TYPES = Object.keys(PAGE_PRESET_IDS) as PageType[]
+
+/**
+ * Builds the starting tree for one page. Presets are factories because every
+ * node needs a fresh id, so this must be called per theme, never cached.
+ */
+export function defaultPageTree(pageType: PageType): BuilderNode[] {
+  return PAGE_PRESET_IDS[pageType].flatMap((presetId) => {
+    const preset = PORTAL_PRESETS.find((candidate) => candidate.id === presetId)
+    // A preset renamed out from under this table would silently produce an
+    // empty page, which is exactly the un-activatable state this exists to
+    // prevent — so say so instead of shipping the hole.
+    if (!preset) {
+      throw new Error(`unknown portal preset "${presetId}" for page "${pageType}"`)
+    }
+    return preset.factory()
+  })
+}

--- a/front/src/lib/builder-portal/index.ts
+++ b/front/src/lib/builder-portal/index.ts
@@ -11,6 +11,7 @@ export {
 export { treeToReactNode } from './renderer'
 export { PortalPreview } from './preview'
 export { PORTAL_PRESETS, type PortalPreset } from './presets'
+export { DEFAULT_PAGE_TYPES, defaultPageTree } from './default-pages'
 export { useIframeFit } from './use-iframe-fit'
 export type {
   PortalNodeType,

--- a/front/src/lib/saml.ts
+++ b/front/src/lib/saml.ts
@@ -6,7 +6,7 @@ export interface SamlOption<TValue extends string> {
   description: string
 }
 
-const NAME_ID_FORMATS: Record<Schemas.SamlNameIdFormat, Omit<SamlOption<string>, 'value'>> = {
+const NAME_ID_FORMATS: Record<Schemas.NameIdFormat, Omit<SamlOption<string>, 'value'>> = {
   'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress': {
     label: 'Email address',
     description: 'The user is identified by their email address. What most applications expect.',
@@ -49,12 +49,12 @@ function toOptions<TValue extends string>(
   return (Object.keys(formats) as TValue[]).map((value) => ({ value, ...formats[value] }))
 }
 
-export const NAME_ID_FORMAT_OPTIONS = toOptions<Schemas.SamlNameIdFormat>(NAME_ID_FORMATS)
+export const NAME_ID_FORMAT_OPTIONS = toOptions<Schemas.NameIdFormat>(NAME_ID_FORMATS)
 
 export const ATTRIBUTE_NAME_FORMAT_OPTIONS =
   toOptions<Schemas.SamlAttributeNameFormat>(ATTRIBUTE_NAME_FORMATS)
 
-export const DEFAULT_NAME_ID_FORMAT: Schemas.SamlNameIdFormat =
+export const DEFAULT_NAME_ID_FORMAT: Schemas.NameIdFormat =
   'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
 
 export const DEFAULT_ATTRIBUTE_NAME_FORMAT: Schemas.SamlAttributeNameFormat =
@@ -98,7 +98,7 @@ export function describeAttributeSource(source: string): string {
 }
 
 export function describeNameIdFormat(format: string): string {
-  return NAME_ID_FORMATS[format as Schemas.SamlNameIdFormat]?.label ?? format
+  return NAME_ID_FORMATS[format as Schemas.NameIdFormat]?.label ?? format
 }
 
 export function describeAttributeNameFormat(format: string): string {

--- a/front/src/pages/email-template/feature/page-email-template-list-feature.tsx
+++ b/front/src/pages/email-template/feature/page-email-template-list-feature.tsx
@@ -1,6 +1,12 @@
 import { useNavigate, useParams } from 'react-router-dom'
 import type { RouterParams } from '@/routes/router'
-import { useGetEmailTemplates, useDeleteEmailTemplate } from '@/api/email-template.api'
+import {
+  useGetEmailTemplates,
+  useDeleteEmailTemplate,
+  useImportEmailTemplate,
+} from '@/api/email-template.api'
+import { downloadEmailTemplateExport, readExportFile } from '@/api/builder-export'
+import { toast } from 'sonner'
 import { EMAIL_TEMPLATE_BUILDER_URL } from '@/routes/sub-router/email-template.router'
 import PageEmailTemplateList from '../ui/page-email-template-list'
 
@@ -11,6 +17,7 @@ export default function PageEmailTemplateListFeature() {
 
   const { data, isLoading } = useGetEmailTemplates({ realm })
   const { mutate: deleteTemplate } = useDeleteEmailTemplate()
+  const { mutate: importTemplate } = useImportEmailTemplate()
 
   const handleEdit = (templateId: string) => {
     navigate(EMAIL_TEMPLATE_BUILDER_URL(realm_name, templateId))
@@ -20,6 +27,28 @@ export default function PageEmailTemplateListFeature() {
     deleteTemplate({
       path: { realm_name: realm, template_id: templateId },
     })
+  }
+
+  const handleExport = (templateId: string, format: 'json' | 'mjml') => {
+    downloadEmailTemplateExport(realm, templateId, format).catch(() =>
+      toast.error('Could not export this template'),
+    )
+  }
+
+  /**
+   * The exported file is sent back as-is: the server reads its envelope, and
+   * refuses a file belonging to the other builder or written in a format it
+   * cannot read.
+   */
+  const handleImport = (file: File) => {
+    readExportFile(file)
+      .then((envelope) => {
+        importTemplate({
+          path: { realm_name: realm },
+          body: envelope as never,
+        })
+      })
+      .catch((error: Error) => toast.error(error.message))
   }
 
   const handleCreate = () => {
@@ -32,6 +61,8 @@ export default function PageEmailTemplateListFeature() {
       isLoading={isLoading}
       onEdit={handleEdit}
       onDelete={handleDelete}
+      onExport={handleExport}
+      onImport={handleImport}
       onCreate={handleCreate}
     />
   )

--- a/front/src/pages/email-template/ui/page-email-template-list.tsx
+++ b/front/src/pages/email-template/ui/page-email-template-list.tsx
@@ -5,12 +5,14 @@ import {
   Link2,
   Mail,
   MailCheck,
+  Download,
   Pencil,
   Plus,
   Search,
   Trash2,
+  Upload,
 } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 
 interface EmailTemplate {
   id: string
@@ -26,6 +28,8 @@ interface Props {
   onEdit: (id: string) => void
   onDelete: (id: string) => void
   onCreate: () => void
+  onExport: (id: string, format: 'json' | 'mjml') => void
+  onImport: (file: File) => void
 }
 
 type EmailType = 'reset_password' | 'magic_link' | 'email_verification'
@@ -85,11 +89,14 @@ export default function PageEmailTemplateList({
   isLoading,
   onEdit,
   onDelete,
+  onExport,
+  onImport,
   onCreate,
 }: Props) {
   const [query, setQuery] = useState('')
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
   const [sort, setSort] = useState<SortKey>('recent')
+  const importInputRef = useRef<HTMLInputElement>(null)
 
   const stats = useMemo(() => {
     const total = templates.length
@@ -138,13 +145,35 @@ export default function PageEmailTemplateList({
             verifications.
           </p>
         </div>
-        <button
-          onClick={onCreate}
-          className='inline-flex items-center gap-2 rounded-md bg-primary px-3.5 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors'
-        >
-          <Plus className='h-4 w-4' />
-          New Template
-        </button>
+        <div className='flex items-center gap-2'>
+          <button
+            onClick={() => importInputRef.current?.click()}
+            className='inline-flex items-center gap-2 rounded-md border border-border px-3.5 py-2 text-sm font-medium hover:bg-muted transition-colors'
+          >
+            <Upload className='h-4 w-4' />
+            Import
+          </button>
+          {/* The picker stays hidden; the button above is the affordance. */}
+          <input
+            ref={importInputRef}
+            type='file'
+            accept='application/json,.json'
+            className='hidden'
+            onChange={(event) => {
+              const file = event.target.files?.[0]
+              if (file) onImport(file)
+              // Reset so picking the same file twice fires onChange again.
+              event.target.value = ''
+            }}
+          />
+          <button
+            onClick={onCreate}
+            className='inline-flex items-center gap-2 rounded-md bg-primary px-3.5 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors'
+          >
+            <Plus className='h-4 w-4' />
+            New Template
+          </button>
+        </div>
       </div>
 
       {/* Stats by type */}
@@ -298,6 +327,20 @@ export default function PageEmailTemplateList({
                       title='Edit'
                     >
                       <Pencil className='h-3.5 w-3.5' />
+                    </button>
+                    <button
+                      onClick={() => onExport(tpl.id, 'json')}
+                      className='p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+                      title='Export as JSON'
+                    >
+                      <Download className='h-3.5 w-3.5' />
+                    </button>
+                    <button
+                      onClick={() => onExport(tpl.id, 'mjml')}
+                      className='px-1.5 py-1 rounded-md text-[10px] font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+                      title='Export as MJML'
+                    >
+                      MJML
                     </button>
                     <button
                       onClick={() => onDelete(tpl.id)}

--- a/front/src/pages/portal-layouts/feature/page-portal-layouts-list-feature.tsx
+++ b/front/src/pages/portal-layouts/feature/page-portal-layouts-list-feature.tsx
@@ -1,6 +1,12 @@
 import { useNavigate, useParams } from 'react-router-dom'
 import type { RouterParams } from '@/routes/router'
-import { useDeletePortalLayout, useGetPortalLayouts } from '@/api/portal-layouts.api'
+import {
+  useDeletePortalLayout,
+  useGetPortalLayouts,
+  useImportPortalLayout,
+} from '@/api/portal-layouts.api'
+import { downloadPortalLayoutExport, readExportFile } from '@/api/builder-export'
+import { toast } from 'sonner'
 import { PORTAL_LAYOUT_BUILDER_URL } from '@/routes/sub-router/portal-layouts.router'
 import PagePortalLayoutsList from '../ui/page-portal-layouts-list'
 
@@ -11,6 +17,7 @@ export default function PagePortalLayoutsListFeature() {
 
   const { data, isLoading } = useGetPortalLayouts({ realm })
   const { mutate: deleteLayout } = useDeletePortalLayout()
+  const { mutate: importLayout } = useImportPortalLayout()
 
   const handleEdit = (layoutId: string) => {
     navigate(PORTAL_LAYOUT_BUILDER_URL(realm_name, layoutId))
@@ -18,6 +25,28 @@ export default function PagePortalLayoutsListFeature() {
 
   const handleDelete = (layoutId: string) => {
     deleteLayout({ path: { realm_name: realm, layout_id: layoutId } })
+  }
+
+  const handleExport = (layoutId: string) => {
+    downloadPortalLayoutExport(realm, layoutId).catch(() =>
+      toast.error('Could not export this layout'),
+    )
+  }
+
+  /**
+   * The exported file is sent back as-is: the server reads its envelope, and
+   * refuses a file belonging to the other builder or written in a format it
+   * cannot read.
+   */
+  const handleImport = (file: File) => {
+    readExportFile(file)
+      .then((envelope) => {
+        importLayout({
+          path: { realm_name: realm },
+          body: envelope as never,
+        })
+      })
+      .catch((error: Error) => toast.error(error.message))
   }
 
   const handleCreate = () => {
@@ -30,6 +59,8 @@ export default function PagePortalLayoutsListFeature() {
       isLoading={isLoading}
       onEdit={handleEdit}
       onDelete={handleDelete}
+      onExport={handleExport}
+      onImport={handleImport}
       onCreate={handleCreate}
     />
   )

--- a/front/src/pages/portal-layouts/ui/page-portal-layouts-list.tsx
+++ b/front/src/pages/portal-layouts/ui/page-portal-layouts-list.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
-import { LayoutTemplate, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Download, LayoutTemplate, Pencil, Plus, Trash2, Upload } from 'lucide-react'
+import { useRef } from 'react'
 import { PortalOverviewHeader } from '@/pages/portal/components/portal-overview-header'
 
 interface PortalLayoutListItem {
@@ -16,6 +17,8 @@ interface Props {
   onEdit: (id: string) => void
   onDelete: (id: string) => void
   onCreate: () => void
+  onExport: (id: string) => void
+  onImport: (file: File) => void
 }
 
 function LayoutAvatar({ name }: { name: string }) {
@@ -37,7 +40,11 @@ export default function PagePortalLayoutsList({
   onEdit,
   onDelete,
   onCreate,
+  onExport,
+  onImport,
 }: Props) {
+  const importInputRef = useRef<HTMLInputElement>(null)
+
   return (
     <div className='flex flex-col gap-6 p-8'>
       <PortalOverviewHeader
@@ -48,6 +55,23 @@ export default function PagePortalLayoutsList({
       <div>
         <div className='flex items-center justify-between mb-3'>
           <h2 className='text-base font-semibold'>Layouts ({layouts.length})</h2>
+          <Button variant='outline' size='sm' onClick={() => importInputRef.current?.click()}>
+            <Upload size={14} />
+            Import
+          </Button>
+          {/* The picker stays hidden; the button above is the affordance. */}
+          <input
+            ref={importInputRef}
+            type='file'
+            accept='application/json,.json'
+            className='hidden'
+            onChange={(event) => {
+              const file = event.target.files?.[0]
+              if (file) onImport(file)
+              // Reset so picking the same file twice fires onChange again.
+              event.target.value = ''
+            }}
+          />
         </div>
 
         <div className='-mx-8 border-t border-b overflow-hidden'>
@@ -104,6 +128,14 @@ export default function PagePortalLayoutsList({
                     onClick={() => onEdit(layout.id)}
                   >
                     <Pencil size={14} />
+                  </Button>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    title='Export'
+                    onClick={() => onExport(layout.id)}
+                  >
+                    <Download size={14} />
                   </Button>
                   <Button
                     variant='ghost'

--- a/front/src/pages/portal/themes/feature/page-themes-list-feature.tsx
+++ b/front/src/pages/portal/themes/feature/page-themes-list-feature.tsx
@@ -5,9 +5,11 @@ import {
   useCreatePortalTheme,
   useDeletePortalTheme,
   useGetActivePortalTheme,
+  useImportPortalTheme,
   useListPortalThemes,
   useUpdatePortalThemePage,
 } from '@/api/portal-theme.api'
+import { downloadPortalThemeExport, readExportFile } from '@/api/builder-export'
 import { DEFAULT_PAGE_TYPES, defaultPageTree } from '@/lib/builder-portal'
 import { toast } from 'sonner'
 import { themeBuilderUrl } from '@/routes/sub-router/portal-theme.router'
@@ -26,6 +28,7 @@ export default function PageThemesListFeature() {
 
   const { mutate: createTheme, isPending: isCreating } = useCreatePortalTheme()
   const { mutateAsync: updatePage } = useUpdatePortalThemePage()
+  const { mutate: importTheme } = useImportPortalTheme()
   const { mutate: deleteTheme } = useDeletePortalTheme()
   const { mutate: activateTheme } = useActivatePortalTheme()
 
@@ -87,6 +90,27 @@ export default function PageThemesListFeature() {
     activateTheme({ path: { realm_name: realm, theme_id: themeId } })
   }
 
+  const handleExport = (themeId: string) => {
+    downloadPortalThemeExport(realm, themeId).catch(() =>
+      toast.error('Could not export this theme'),
+    )
+  }
+
+  /**
+   * The exported file is sent back as-is: it carries the theme's tokens, its
+   * pages and the layout it is framed by, which the server recreates.
+   */
+  const handleImport = (file: File) => {
+    readExportFile(file)
+      .then((envelope) => {
+        importTheme({
+          path: { realm_name: realm },
+          body: envelope as never,
+        })
+      })
+      .catch((error: Error) => toast.error(error.message))
+  }
+
   const handleDelete = (themeId: string) => {
     deleteTheme({ path: { realm_name: realm, theme_id: themeId } })
   }
@@ -101,6 +125,8 @@ export default function PageThemesListFeature() {
       onEdit={handleEdit}
       onActivate={handleActivate}
       onDelete={handleDelete}
+      onExport={handleExport}
+      onImport={handleImport}
     />
   )
 }

--- a/front/src/pages/portal/themes/feature/page-themes-list-feature.tsx
+++ b/front/src/pages/portal/themes/feature/page-themes-list-feature.tsx
@@ -6,7 +6,10 @@ import {
   useDeletePortalTheme,
   useGetActivePortalTheme,
   useListPortalThemes,
+  useUpdatePortalThemePage,
 } from '@/api/portal-theme.api'
+import { DEFAULT_PAGE_TYPES, defaultPageTree } from '@/lib/builder-portal'
+import { toast } from 'sonner'
 import { themeBuilderUrl } from '@/routes/sub-router/portal-theme.router'
 import PageThemesList from '../ui/page-themes-list'
 import { defaultTheme } from '@/pages/portal-theme/lib/theme'
@@ -22,8 +25,41 @@ export default function PageThemesListFeature() {
   const activeThemeId = activeData?.theme_id ?? null
 
   const { mutate: createTheme, isPending: isCreating } = useCreatePortalTheme()
+  const { mutateAsync: updatePage } = useUpdatePortalThemePage()
   const { mutate: deleteTheme } = useDeletePortalTheme()
   const { mutate: activateTheme } = useActivatePortalTheme()
+
+  /**
+   * Fills a new theme's pages with their default composition.
+   *
+   * A theme created with empty pages cannot be activated — the server requires
+   * each flow's blocks to be present — so seeding here is what makes a fresh
+   * theme usable without composing twelve pages by hand first.
+   */
+  const seedDefaultPages = async (themeId: string) => {
+    // Sequential rather than concurrent: should the access token expire
+    // mid-seed, twelve parallel calls would each start their own refresh with
+    // the same refresh token, and reuse detection revokes a rotated family.
+    // One at a time, the first refresh covers the calls that follow. Twelve
+    // small writes cost little enough that the wait is not worth the risk.
+    let failed = 0
+    for (const pageType of DEFAULT_PAGE_TYPES) {
+      try {
+        await updatePage({
+          path: { realm_name: realm, theme_id: themeId, page_type: pageType },
+          body: { tree: defaultPageTree(pageType) },
+        })
+      } catch {
+        failed += 1
+      }
+    }
+
+    if (failed > 0) {
+      toast.warning(
+        `${failed} page${failed > 1 ? 's' : ''} could not be pre-filled — open them before activating this theme.`,
+      )
+    }
+  }
 
   const handleCreate = (name: string) => {
     createTheme(
@@ -32,11 +68,12 @@ export default function PageThemesListFeature() {
         body: { name, config: defaultTheme },
       },
       {
-        onSuccess: (res) => {
+        onSuccess: async (res) => {
           const newId = res?.data?.id
-          if (newId) {
-            navigate(themeBuilderUrl(pathname, realm, newId))
-          }
+          if (!newId) return
+
+          await seedDefaultPages(newId)
+          navigate(themeBuilderUrl(pathname, realm, newId))
         },
       },
     )

--- a/front/src/pages/portal/themes/ui/page-themes-list.tsx
+++ b/front/src/pages/portal/themes/ui/page-themes-list.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Skeleton } from '@/components/ui/skeleton'
-import { CheckCircle2, Palette, Pencil, Plus, Trash2 } from 'lucide-react'
+import { CheckCircle2, Download, Palette, Pencil, Plus, Trash2, Upload } from 'lucide-react'
 import type { Schemas } from '@/api/api.client'
 import { PortalOverviewHeader } from '../../components/portal-overview-header'
 
@@ -22,6 +22,8 @@ interface Props {
   onEdit: (id: string) => void
   onActivate: (id: string) => void
   onDelete: (id: string) => void
+  onExport: (id: string) => void
+  onImport: (file: File) => void
 }
 
 function ThemeAvatar({ name }: { name: string }) {
@@ -55,9 +57,12 @@ export default function PageThemesList({
   onEdit,
   onActivate,
   onDelete,
+  onExport,
+  onImport,
 }: Props) {
   const [createOpen, setCreateOpen] = useState(false)
   const [newName, setNewName] = useState('')
+  const importInputRef = useRef<HTMLInputElement>(null)
 
   const submitCreate = () => {
     if (!newName.trim()) return
@@ -76,6 +81,23 @@ export default function PageThemesList({
       <div>
         <div className='flex items-center justify-between mb-3'>
           <h2 className='text-base font-semibold'>Themes ({themes.length})</h2>
+          <Button variant='outline' size='sm' onClick={() => importInputRef.current?.click()}>
+            <Upload size={14} />
+            Import
+          </Button>
+          {/* The picker stays hidden; the button above is the affordance. */}
+          <input
+            ref={importInputRef}
+            type='file'
+            accept='application/json,.json'
+            className='hidden'
+            onChange={(event) => {
+              const file = event.target.files?.[0]
+              if (file) onImport(file)
+              // Reset so picking the same file twice fires onChange again.
+              event.target.value = ''
+            }}
+          />
         </div>
 
         <div className='-mx-8 border-t border-b overflow-hidden'>
@@ -146,6 +168,14 @@ export default function PageThemesList({
                         onClick={() => onEdit(theme.id)}
                       >
                         <Pencil size={14} />
+                      </Button>
+                      <Button
+                        variant='ghost'
+                        size='icon'
+                        title='Export'
+                        onClick={() => onExport(theme.id)}
+                      >
+                        <Download size={14} />
                       </Button>
                       <Button
                         variant='ghost'

--- a/front/src/pages/realm/feature/page-realm-settings-edit-webhook-feature.tsx
+++ b/front/src/pages/realm/feature/page-realm-settings-edit-webhook-feature.tsx
@@ -32,7 +32,11 @@ export default function PageRealmSettingsEditWebhookFeature() {
         description: webhook.description ?? '',
         endpoint: webhook.endpoint,
         subscribers: initialTriggers,
-        headers: Object.entries(webhook.headers).map(([key, value]) => ({ key, value })),
+        // The API never returns a webhook's headers — they are marked
+        // `skip_serializing` alongside the delivery secret — so there is
+        // nothing to prefill here. Submitting the form sends whatever the user
+        // enters, which replaces the stored headers.
+        headers: [],
       }
     : undefined
 

--- a/front/src/pages/realm/feature/page-realm-settings-edit-webhook-feature.tsx
+++ b/front/src/pages/realm/feature/page-realm-settings-edit-webhook-feature.tsx
@@ -34,8 +34,10 @@ export default function PageRealmSettingsEditWebhookFeature() {
         subscribers: initialTriggers,
         // The API never returns a webhook's headers — they are marked
         // `skip_serializing` alongside the delivery secret — so there is
-        // nothing to prefill here. Submitting the form sends whatever the user
-        // enters, which replaces the stored headers.
+        // nothing to prefill. The submit handler leaves them out of the
+        // payload unless the user actually enters some, and the server keeps
+        // what it has: editing the endpoint must not wipe the headers that
+        // authenticate the deliveries.
         headers: [],
       }
     : undefined
@@ -69,12 +71,16 @@ export default function PageRealmSettingsEditWebhookFeature() {
   const onSubmit = form.handleSubmit((data) => {
     if (!realm_name || !webhook_id) return
 
-    const headers: Record<string, string> = {}
-    if (data.headers) {
-      data.headers.forEach((header) => {
-        headers[header.key] = header.value
-      })
-    }
+    // Only send headers when the user typed some. An empty list means "I did
+    // not touch them", not "delete them" — the form cannot show the stored
+    // ones, so it is in no position to replace them.
+    const entered = (data.headers ?? []).filter((header) => header.key.trim().length > 0)
+    const headers = entered.length
+      ? entered.reduce<Record<string, string>>((acc, header) => {
+          acc[header.key] = header.value
+          return acc
+        }, {})
+      : undefined
 
     updateWebhook({
       body: {
@@ -82,7 +88,7 @@ export default function PageRealmSettingsEditWebhookFeature() {
         endpoint: data.endpoint,
         name: data.name,
         subscribers: data.subscribers as WebhookTrigger[],
-        headers,
+        ...(headers ? { headers } : {}),
       },
       path: {
         realm_name,

--- a/front/src/utils/webhook-utils.ts
+++ b/front/src/utils/webhook-utils.ts
@@ -12,6 +12,11 @@ export const WEBHOOK_CATEGORIES: Record<string, Schemas.WebhookTrigger[]> = {
     'redirect_uri.updated',
     'client.maintenance.enabled',
     'client.maintenance.disabled',
+    'web_origin.created',
+    'web_origin.deleted',
+    'client.saml_config.updated',
+    'client.saml_attribute_mapper.created',
+    'client.saml_attribute_mapper.deleted',
   ],
   Realm: ['realm.created', 'realm.deleted', 'realm.settings.updated', 'realm.updated'],
   Role: ['role.created', 'role.updated'],
@@ -73,6 +78,11 @@ export const WEBHOOK_TRIGGER_LABELS: Record<Schemas.WebhookTrigger, string> = {
   'webhook.updated': 'Webhook Updated',
   'client.maintenance.enabled': 'Client Maintenance Enabled',
   'client.maintenance.disabled': 'Client Maintenance Disabled',
+  'web_origin.created': 'Web Origin Created',
+  'web_origin.deleted': 'Web Origin Deleted',
+  'client.saml_config.updated': 'Client SAML Configuration Updated',
+  'client.saml_attribute_mapper.created': 'Client SAML Attribute Mapper Created',
+  'client.saml_attribute_mapper.deleted': 'Client SAML Attribute Mapper Deleted',
 }
 
 export const WEBHOOK_TRIGGER_DESCRIPTIONS: Record<Schemas.WebhookTrigger, string> = {
@@ -114,6 +124,12 @@ export const WEBHOOK_TRIGGER_DESCRIPTIONS: Record<Schemas.WebhookTrigger, string
   'webhook.updated': 'A webhook has been updated.',
   'client.maintenance.enabled': 'Maintenance mode has been enabled on a client.',
   'client.maintenance.disabled': 'Maintenance mode has been disabled on a client.',
+  'web_origin.created': 'A web origin has been registered on a client.',
+  'web_origin.deleted': 'A web origin has been removed from a client.',
+  'client.saml_config.updated':
+    'The SAML service provider configuration of a client has been updated.',
+  'client.saml_attribute_mapper.created': 'A SAML attribute mapper has been added to a client.',
+  'client.saml_attribute_mapper.deleted': 'A SAML attribute mapper has been removed from a client.',
 }
 
 export type WebhookCategory = {

--- a/libs/ferriskey-api-core/src/api_entities.rs
+++ b/libs/ferriskey-api-core/src/api_entities.rs
@@ -1,4 +1,5 @@
 pub mod api_error;
 pub mod api_response_body;
 pub mod api_success;
+pub mod export;
 pub mod response;

--- a/libs/ferriskey-api-core/src/api_entities/export.rs
+++ b/libs/ferriskey-api-core/src/api_entities/export.rs
@@ -25,7 +25,7 @@ pub struct ExportEnvelope {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email_type: Option<String>,
     /// The builder tree (`BuilderNode[]`).
-    #[schema(value_type = Object)]
+    #[schema(value_type = Vec<Object>)]
     pub tree: serde_json::Value,
 }
 
@@ -122,7 +122,7 @@ pub struct ThemeExportEnvelope {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct ThemeExportLayout {
     pub name: String,
-    #[schema(value_type = Object)]
+    #[schema(value_type = Vec<Object>)]
     pub tree: serde_json::Value,
 }
 
@@ -291,11 +291,17 @@ mod tests {
                 .expect("serialize");
 
         assert_eq!(
-            response.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            response
+                .headers()
+                .get(header::CONTENT_DISPOSITION)
+                .expect("a download must name its file"),
             "attachment; filename=\"reset-password.json\""
         );
         assert_eq!(
-            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .expect("a download must declare its type"),
             "application/json"
         );
     }

--- a/libs/ferriskey-api-core/src/api_entities/export.rs
+++ b/libs/ferriskey-api-core/src/api_entities/export.rs
@@ -1,0 +1,241 @@
+//! Shared pieces of the builder import/export file format.
+//!
+//! Email templates and portal layouts are both stored as builder trees, so both
+//! export the same envelope — kind, format version, name and the tree itself —
+//! and the frontend can tell one file from the other before loading it into a
+//! canvas.
+
+use crate::api_entities::api_error::ApiError;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Bumped when the envelope itself changes shape, never when a builder tree does.
+pub const FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+pub struct ExportEnvelope {
+    /// Which builder the file belongs to: `email-template` or `portal-layout`.
+    pub ferriskey: String,
+    /// Format version, bumped when the envelope itself changes shape.
+    pub version: u32,
+    pub name: String,
+    /// Email templates only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email_type: Option<String>,
+    /// The builder tree (`BuilderNode[]`).
+    #[schema(value_type = Object)]
+    pub tree: serde_json::Value,
+}
+
+impl ExportEnvelope {
+    pub const EMAIL_TEMPLATE: &'static str = "email-template";
+    pub const PORTAL_LAYOUT: &'static str = "portal-layout";
+
+    /// The envelope of an email template. `email_type` is carried so an import
+    /// can restore the template under the type it was exported from.
+    pub fn email_template(name: String, email_type: String, tree: serde_json::Value) -> Self {
+        Self {
+            ferriskey: Self::EMAIL_TEMPLATE.to_string(),
+            version: FORMAT_VERSION,
+            name,
+            email_type: Some(email_type),
+            tree,
+        }
+    }
+
+    /// The envelope of a portal layout, which has no email type.
+    pub fn portal_layout(name: String, tree: serde_json::Value) -> Self {
+        Self {
+            ferriskey: Self::PORTAL_LAYOUT.to_string(),
+            version: FORMAT_VERSION,
+            name,
+            email_type: None,
+            tree,
+        }
+    }
+
+    /// Serialises the envelope into a download: pretty JSON, so a file a human
+    /// opens is readable, under a filename derived from the envelope's name.
+    pub fn into_download(self) -> Result<Response, serde_json::Error> {
+        let filename = format!("{}.json", slugify(&self.name));
+        let body = serde_json::to_vec_pretty(&self)?;
+
+        Ok(download(body, "application/json", &filename))
+    }
+}
+
+/// Turns a template/layout name into a filename stem: lowercase, ASCII
+/// alphanumerics and dashes only, so it is safe in a `Content-Disposition`
+/// header on any platform.
+pub fn slugify(name: &str) -> String {
+    let slug = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+
+    let slug = slug
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+
+    if slug.is_empty() {
+        "export".to_string()
+    } else {
+        slug
+    }
+}
+
+/// Refuses an import whose envelope names another builder or a format from the
+/// future. Both fields are optional: a payload assembled by hand, carrying only
+/// a name and a tree, stays importable — the check only holds an exported file
+/// to what it claims to be.
+pub fn ensure_importable(
+    ferriskey: Option<&str>,
+    version: Option<u32>,
+    expected_kind: &str,
+) -> Result<(), ApiError> {
+    if let Some(kind) = ferriskey
+        && kind != expected_kind
+    {
+        return Err(ApiError::BadRequest(
+            format!("expected a {expected_kind} export, but this file is a {kind} export").into(),
+        ));
+    }
+
+    if let Some(version) = version
+        && version > FORMAT_VERSION
+    {
+        return Err(ApiError::BadRequest(
+            format!(
+                "this file uses export format version {version}, which this server does not \
+                 understand — it reads up to version {FORMAT_VERSION}"
+            )
+            .into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// A response the browser saves to a file rather than renders. `filename` is
+/// used as given, so callers pass a [`slugify`]ed name.
+pub fn download(body: Vec<u8>, content_type: &'static str, filename: &str) -> Response {
+    let mut response = (StatusCode::OK, body).into_response();
+    let headers = response.headers_mut();
+    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    headers.insert(header::CONTENT_DISPOSITION, content_disposition(filename));
+    response
+}
+
+/// `Content-Disposition` for a download. The filename is already slugified, so
+/// it never needs escaping; a header that somehow fails to build falls back to
+/// a plain `attachment`.
+pub fn content_disposition(filename: &str) -> HeaderValue {
+    HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
+        .unwrap_or_else(|_| HeaderValue::from_static("attachment"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_collapses_separators() {
+        assert_eq!(slugify("Reset password"), "reset-password");
+        assert_eq!(slugify("  Welcome — v2 !!"), "welcome-v2");
+        assert_eq!(slugify("Réinitialisation"), "r-initialisation");
+    }
+
+    #[test]
+    fn slugify_falls_back_when_nothing_survives() {
+        assert_eq!(slugify("///"), "export");
+        assert_eq!(slugify(""), "export");
+    }
+
+    #[test]
+    fn envelope_omits_email_type_for_layouts() {
+        let envelope = ExportEnvelope::portal_layout("Default".to_string(), serde_json::json!([]));
+
+        let json = serde_json::to_value(&envelope).expect("serialize");
+        assert_eq!(json["ferriskey"], "portal-layout");
+        assert!(json.get("email_type").is_none());
+    }
+
+    #[test]
+    fn an_email_template_envelope_carries_its_type() {
+        let envelope = ExportEnvelope::email_template(
+            "Reset password".to_string(),
+            "reset_password".to_string(),
+            serde_json::json!([]),
+        );
+
+        let json = serde_json::to_value(&envelope).expect("serialize");
+        assert_eq!(json["ferriskey"], "email-template");
+        assert_eq!(json["email_type"], "reset_password");
+    }
+
+    #[test]
+    fn an_import_refuses_a_file_from_the_other_builder() {
+        let refused = ensure_importable(
+            Some(ExportEnvelope::EMAIL_TEMPLATE),
+            Some(1),
+            ExportEnvelope::PORTAL_LAYOUT,
+        );
+
+        assert!(
+            refused.is_err(),
+            "an email template must not import as a layout"
+        );
+    }
+
+    #[test]
+    fn an_import_refuses_a_format_it_cannot_read() {
+        assert!(
+            ensure_importable(
+                None,
+                Some(FORMAT_VERSION + 1),
+                ExportEnvelope::PORTAL_LAYOUT
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn a_hand_written_payload_carries_no_envelope_and_is_still_accepted() {
+        assert!(ensure_importable(None, None, ExportEnvelope::PORTAL_LAYOUT).is_ok());
+        assert!(
+            ensure_importable(
+                Some(ExportEnvelope::PORTAL_LAYOUT),
+                Some(FORMAT_VERSION),
+                ExportEnvelope::PORTAL_LAYOUT
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn a_download_names_its_file_after_the_envelope() {
+        let response =
+            ExportEnvelope::portal_layout("Reset password".to_string(), serde_json::json!([]))
+                .into_download()
+                .expect("serialize");
+
+        assert_eq!(
+            response.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "attachment; filename=\"reset-password.json\""
+        );
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+    }
+}

--- a/libs/ferriskey-api-core/src/api_entities/export.rs
+++ b/libs/ferriskey-api-core/src/api_entities/export.rs
@@ -94,6 +94,67 @@ pub fn slugify(name: &str) -> String {
     }
 }
 
+/// The envelope of an exported portal theme.
+///
+/// A theme is more than a tree: it carries the token config plus one tree per
+/// page of the authentication flow, and it points at the layout that frames
+/// them. The layout travels *inside* the file rather than as an id — ids are
+/// realm-local, so an id would dangle the moment the file crosses into another
+/// deployment, which is the whole point of exporting one.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+pub struct ThemeExportEnvelope {
+    /// Always `portal-theme`; the kind check reads this.
+    pub ferriskey: String,
+    pub version: u32,
+    pub name: String,
+    /// The theme's design tokens, verbatim.
+    #[schema(value_type = Object)]
+    pub config: serde_json::Value,
+    /// One builder tree per page, keyed by page type.
+    #[schema(value_type = Object)]
+    pub pages: serde_json::Value,
+    /// The layout this theme is framed by, when it has one. Carried by value so
+    /// the import can recreate it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layout: Option<ThemeExportLayout>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+pub struct ThemeExportLayout {
+    pub name: String,
+    #[schema(value_type = Object)]
+    pub tree: serde_json::Value,
+}
+
+impl ThemeExportEnvelope {
+    pub const KIND: &'static str = "portal-theme";
+
+    pub fn new(
+        name: String,
+        config: serde_json::Value,
+        pages: serde_json::Value,
+        layout: Option<ThemeExportLayout>,
+    ) -> Self {
+        Self {
+            ferriskey: Self::KIND.to_string(),
+            version: FORMAT_VERSION,
+            name,
+            config,
+            pages,
+            layout,
+        }
+    }
+
+    /// Same download shape as a builder export: pretty JSON under a filename
+    /// derived from the theme's name.
+    pub fn into_download(self) -> Result<Response, serde_json::Error> {
+        let filename = format!("{}.json", slugify(&self.name));
+        let body = serde_json::to_vec_pretty(&self)?;
+
+        Ok(download(body, "application/json", &filename))
+    }
+}
+
 /// Refuses an import whose envelope names another builder or a format from the
 /// future. Both fields are optional: a payload assembled by hand, carrying only
 /// a name and a tree, stays importable — the check only holds an exported file

--- a/libs/ferriskey-api-core/src/error.rs
+++ b/libs/ferriskey-api-core/src/error.rs
@@ -307,6 +307,7 @@ impl From<CoreError> for ApiError {
             CoreError::PortalLayoutInUse => Self::BadRequest(
                 "Portal layout is referenced by one or more themes and cannot be deleted".into(),
             ),
+            CoreError::PortalLayoutInvalidTree(details) => Self::validation_error(details, "tree"),
             CoreError::PasswordPolicyViolation(details) => {
                 match from_str::<Vec<PasswordPolicyViolation>>(&details) {
                     Ok(violations) => Self::validation_errors(

--- a/libs/ferriskey-api-email-template/Cargo.toml
+++ b/libs/ferriskey-api-email-template/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = { workspace = true }
 utoipa = { workspace = true }
 uuid = { workspace = true }
 validator = { workspace = true }
+
+[dev-dependencies]
+chrono = { workspace = true }

--- a/libs/ferriskey-api-email-template/src/handlers/export_template.rs
+++ b/libs/ferriskey-api-email-template/src/handlers/export_template.rs
@@ -27,6 +27,7 @@ pub enum EmailTemplateExportFormat {
 }
 
 #[derive(Debug, Default, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct ExportTemplateQuery {
     #[serde(default)]
     pub format: EmailTemplateExportFormat,
@@ -45,7 +46,13 @@ pub struct ExportTemplateQuery {
         ExportTemplateQuery,
     ),
     responses(
-        (status = 200, description = "Email template exported successfully", content_type = "application/json", body = ExportEnvelope),
+        // Two shapes behind one status: the envelope, or the MJML markup when
+        // `format=mjml`. Declaring only the JSON one made generated clients
+        // believe an MJML export returns an envelope.
+        (status = 200, description = "Email template exported successfully", content(
+            (ExportEnvelope = "application/json"),
+            (String = "text/plain"),
+        )),
         (status = 404, description = "Email template not found", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),

--- a/libs/ferriskey-api-email-template/src/handlers/export_template.rs
+++ b/libs/ferriskey-api-email-template/src/handlers/export_template.rs
@@ -1,0 +1,137 @@
+use axum::{
+    Extension,
+    extract::{Path, Query, State},
+    response::Response as AxumResponse,
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    email_template::{
+        entities::EmailTemplate,
+        ports::{EmailTemplateService, GetEmailTemplateInput},
+    },
+};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use ferriskey_api_core::api_entities::api_error::{ApiError, ApiErrorResponse};
+use ferriskey_api_core::api_entities::export::{ExportEnvelope, download, slugify};
+use ferriskey_api_core::app_state::AppState;
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum EmailTemplateExportFormat {
+    #[default]
+    Json,
+    Mjml,
+}
+
+#[derive(Debug, Default, Deserialize, IntoParams)]
+pub struct ExportTemplateQuery {
+    #[serde(default)]
+    pub format: EmailTemplateExportFormat,
+}
+
+#[utoipa::path(
+    get,
+    path = "/{template_id}/export",
+    tag = "email-template",
+    summary = "Export email template",
+    description = "Returns the template as a downloadable file: the builder JSON envelope (`format=json`, \
+                   the default) or the rendered MJML markup (`format=mjml`).",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+        ("template_id" = Uuid, Path, description = "Email template ID"),
+        ExportTemplateQuery,
+    ),
+    responses(
+        (status = 200, description = "Email template exported successfully", content_type = "application/json", body = ExportEnvelope),
+        (status = 404, description = "Email template not found", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn export_template(
+    Path((realm_name, template_id)): Path<(String, Uuid)>,
+    Query(query): Query<ExportTemplateQuery>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+) -> Result<AxumResponse, ApiError> {
+    let template = state
+        .service
+        .get_template(
+            identity,
+            GetEmailTemplateInput {
+                realm_name,
+                template_id,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    match query.format {
+        EmailTemplateExportFormat::Json => {
+            template_envelope(&template).into_download().map_err(|e| {
+                ApiError::InternalServerError(format!("failed to serialize template: {e}").into())
+            })
+        }
+        // MJML leaves as the markup itself, not wrapped in an envelope: it is
+        // what a mail designer opens in their own tooling.
+        EmailTemplateExportFormat::Mjml => Ok(download(
+            template.mjml.into_bytes(),
+            "text/plain; charset=utf-8",
+            &format!("{}.mjml", slugify(&template.name)),
+        )),
+    }
+}
+
+/// Builds the export envelope. `structure` is persisted as `{ children: [...] }`,
+/// while the envelope carries the bare `BuilderNode[]` the builder works with.
+fn template_envelope(template: &EmailTemplate) -> ExportEnvelope {
+    let tree = template
+        .structure
+        .get("children")
+        .cloned()
+        .unwrap_or_else(|| template.structure.clone());
+
+    ExportEnvelope::email_template(template.name.clone(), template.email_type.to_string(), tree)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use ferriskey_core::domain::email_template::entities::EmailType;
+
+    fn template(structure: serde_json::Value) -> EmailTemplate {
+        EmailTemplate {
+            id: Uuid::new_v4(),
+            realm_id: Uuid::new_v4(),
+            name: "Reset password".to_string(),
+            email_type: EmailType::ResetPassword,
+            structure,
+            mjml: "<mjml><mj-body></mj-body></mjml>".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn envelope_unwraps_the_persisted_children_field() {
+        let tree = serde_json::json!([{ "type": "mj-section", "children": [] }]);
+        let envelope = template_envelope(&template(serde_json::json!({ "children": tree })));
+
+        assert_eq!(envelope.ferriskey, "email-template");
+        assert_eq!(envelope.email_type.as_deref(), Some("reset_password"));
+        assert_eq!(envelope.tree, tree);
+    }
+
+    #[test]
+    fn envelope_falls_back_to_the_raw_structure() {
+        let structure = serde_json::json!([{ "type": "mj-section" }]);
+        let envelope = template_envelope(&template(structure.clone()));
+
+        assert_eq!(envelope.tree, structure);
+    }
+}

--- a/libs/ferriskey-api-email-template/src/handlers/import_template.rs
+++ b/libs/ferriskey-api-email-template/src/handlers/import_template.rs
@@ -1,0 +1,136 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    email_template::{
+        entities::{EmailTemplate, EmailType},
+        ports::{EmailTemplateService, EmailTemplateSource, ImportEmailTemplateInput},
+    },
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::validators::ImportEmailTemplateValidator;
+use ferriskey_api_core::api_entities::export::{ExportEnvelope, ensure_importable};
+use ferriskey_api_core::api_entities::{
+    api_error::{ApiError, ApiErrorResponse, ValidateJson},
+    response::Response,
+};
+use ferriskey_api_core::app_state::AppState;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq)]
+pub struct ImportEmailTemplateResponse {
+    pub data: EmailTemplate,
+}
+
+#[utoipa::path(
+    post,
+    path = "/import",
+    tag = "email-template",
+    summary = "Import email template",
+    description = "Creates an email template from an exported JSON structure or from raw MJML markup. \
+                   MJML is parsed back into a builder structure so the imported template stays editable; \
+                   anything outside <mj-body> (such as <mj-head>) is not representable in the builder and is dropped.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+    ),
+    request_body = ImportEmailTemplateValidator,
+    responses(
+        (status = 201, description = "Email template imported successfully", body = ImportEmailTemplateResponse),
+        (status = 400, description = "Invalid request data", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn import_template(
+    Path(realm_name): Path<String>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+    ValidateJson(payload): ValidateJson<ImportEmailTemplateValidator>,
+) -> Result<Response<ImportEmailTemplateResponse>, ApiError> {
+    ensure_importable(
+        payload.ferriskey.as_deref(),
+        payload.version,
+        ExportEnvelope::EMAIL_TEMPLATE,
+    )?;
+
+    let email_type = payload
+        .email_type
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| ApiError::BadRequest("email_type is required".into()))?;
+    let email_type = EmailType::try_from(email_type).map_err(ApiError::from)?;
+    let source = template_source(&payload.structure, &payload.tree, &payload.mjml)?;
+
+    let template = state
+        .service
+        .import_template(
+            identity,
+            ImportEmailTemplateInput {
+                realm_name,
+                name: payload.name,
+                email_type,
+                source,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::Created(ImportEmailTemplateResponse {
+        data: template,
+    }))
+}
+
+/// Picks the single body source out of the payload. A bare `tree` array is
+/// wrapped into the `{ children: [...] }` structure the renderer expects.
+fn template_source(
+    structure: &Option<serde_json::Value>,
+    tree: &Option<serde_json::Value>,
+    mjml: &Option<String>,
+) -> Result<EmailTemplateSource, ApiError> {
+    match (structure, tree, mjml) {
+        (Some(structure), None, None) => Ok(EmailTemplateSource::Structure(structure.clone())),
+        (None, Some(tree), None) => Ok(EmailTemplateSource::Structure(
+            serde_json::json!({ "children": tree }),
+        )),
+        (None, None, Some(mjml)) => Ok(EmailTemplateSource::Mjml(mjml.clone())),
+        (None, None, None) => Err(ApiError::BadRequest(
+            "one of 'structure', 'tree' or 'mjml' is required".into(),
+        )),
+        _ => Err(ApiError::BadRequest(
+            "only one of 'structure', 'tree' or 'mjml' may be provided".into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wraps_a_bare_tree_into_a_structure() {
+        let tree = serde_json::json!([{ "type": "mj-section", "children": [] }]);
+
+        let source = template_source(&None, &Some(tree.clone()), &None).expect("valid payload");
+
+        let EmailTemplateSource::Structure(structure) = source else {
+            panic!("expected a structure source");
+        };
+        assert_eq!(structure, serde_json::json!({ "children": tree }));
+    }
+
+    #[test]
+    fn rejects_an_empty_payload() {
+        assert!(template_source(&None, &None, &None).is_err());
+    }
+
+    #[test]
+    fn rejects_more_than_one_source() {
+        let structure = Some(serde_json::json!({ "children": [] }));
+        let mjml = Some("<mjml><mj-body></mj-body></mjml>".to_string());
+
+        assert!(template_source(&structure, &None, &mjml).is_err());
+    }
+}

--- a/libs/ferriskey-api-email-template/src/handlers/mod.rs
+++ b/libs/ferriskey-api-email-template/src/handlers/mod.rs
@@ -1,6 +1,8 @@
 pub mod create_template;
 pub mod delete_template;
+pub mod export_template;
 pub mod fetch_templates;
 pub mod get_template;
 pub mod get_variables;
+pub mod import_template;
 pub mod update_template;

--- a/libs/ferriskey-api-email-template/src/router.rs
+++ b/libs/ferriskey-api-email-template/src/router.rs
@@ -1,10 +1,17 @@
 use super::handlers::create_template::{__path_create_template, create_template};
 use super::handlers::delete_template::{__path_delete_template, delete_template};
+use super::handlers::export_template::{
+    __path_export_template, EmailTemplateExportFormat, export_template,
+};
 use super::handlers::fetch_templates::{__path_fetch_templates, fetch_templates};
 use super::handlers::get_template::{__path_get_template, get_template};
 use super::handlers::get_variables::{__path_get_variables, get_variables};
+use super::handlers::import_template::{__path_import_template, import_template};
 use super::handlers::update_template::{__path_update_template, update_template};
-use axum::{Router, middleware, routing::get};
+use axum::{
+    Router, middleware,
+    routing::{get, post},
+};
 use ferriskey_api_core::app_state::AppState;
 use ferriskey_api_core::auth::auth;
 use utoipa::OpenApi;
@@ -16,7 +23,14 @@ use utoipa::OpenApi;
     create_template,
     update_template,
     delete_template,
-))]
+    import_template,
+    export_template,
+),
+// `EmailTemplateExportFormat` is only reached through the `ExportTemplateQuery`
+// query-params struct (`IntoParams`), which utoipa does not walk for component
+// schemas — so the generated `$ref` would dangle and break OpenAPI clients.
+// Register it explicitly here.
+components(schemas(EmailTemplateExportFormat)))]
 pub struct EmailTemplateApiDoc;
 
 #[derive(OpenApi)]
@@ -34,12 +48,26 @@ pub fn email_template_routes(state: AppState) -> Router<AppState> {
         )
         .route(
             &format!(
+                "{}/realms/{{realm_name}}/email-templates/import",
+                state.args.server.root_path
+            ),
+            post(import_template),
+        )
+        .route(
+            &format!(
                 "{}/realms/{{realm_name}}/email-templates/{{template_id}}",
                 state.args.server.root_path
             ),
             get(get_template)
                 .put(update_template)
                 .delete(delete_template),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/email-templates/{{template_id}}/export",
+                state.args.server.root_path
+            ),
+            get(export_template),
         )
         .layer(middleware::from_fn_with_state(state.clone(), auth));
 

--- a/libs/ferriskey-api-email-template/src/validators.rs
+++ b/libs/ferriskey-api-email-template/src/validators.rs
@@ -20,3 +20,38 @@ pub struct UpdateEmailTemplateValidator {
 
     pub structure: serde_json::Value,
 }
+
+/// Import payload. Exactly one of `structure`, `tree` or `mjml` carries the
+/// template body: `structure` is the persisted `{ children: [...] }` wrapper,
+/// `tree` the bare `BuilderNode[]` array exported by the builder, and `mjml`
+/// raw markup that is parsed back into a builder structure.
+#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+pub struct ImportEmailTemplateValidator {
+    /// Which builder the file came from, when it came from an export. Checked
+    /// so a portal layout cannot be imported as an email template.
+    #[serde(default)]
+    pub ferriskey: Option<String>,
+
+    /// Export format version, when the payload came from an export.
+    #[serde(default)]
+    pub version: Option<u32>,
+
+    #[validate(length(min = 1, message = "name is required"))]
+    pub name: String,
+
+    /// Optional at deserialisation so a file from the other builder is answered
+    /// by the envelope check — which says what the file actually is — rather
+    /// than by a "missing field email_type" the person importing cannot act on.
+    /// The handler still requires it.
+    #[serde(default)]
+    pub email_type: Option<String>,
+
+    #[serde(default)]
+    pub structure: Option<serde_json::Value>,
+
+    #[serde(default)]
+    pub tree: Option<serde_json::Value>,
+
+    #[serde(default)]
+    pub mjml: Option<String>,
+}

--- a/libs/ferriskey-api-portal-layouts/src/handlers/export_layout.rs
+++ b/libs/ferriskey-api-portal-layouts/src/handlers/export_layout.rs
@@ -1,0 +1,56 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+    response::Response as AxumResponse,
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::ports::{GetLayoutInput, PortalLayoutsService},
+};
+use uuid::Uuid;
+
+use ferriskey_api_core::api_entities::api_error::{ApiError, ApiErrorResponse};
+use ferriskey_api_core::api_entities::export::ExportEnvelope;
+use ferriskey_api_core::app_state::AppState;
+
+#[utoipa::path(
+    get,
+    path = "/{layout_id}/export",
+    tag = "portal-layouts",
+    summary = "Export a portal layout",
+    description = "Returns the layout as a downloadable JSON envelope.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+        ("layout_id" = Uuid, Path, description = "Portal layout ID"),
+    ),
+    responses(
+        (status = 200, description = "Layout exported successfully", content_type = "application/json", body = ExportEnvelope),
+        (status = 404, description = "Layout not found", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn export_layout(
+    Path((realm_name, layout_id)): Path<(String, Uuid)>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+) -> Result<AxumResponse, ApiError> {
+    let layout = state
+        .service
+        .get_layout(
+            identity,
+            GetLayoutInput {
+                realm_name,
+                layout_id,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    ExportEnvelope::portal_layout(layout.name, layout.tree)
+        .into_download()
+        .map_err(|e| {
+            ApiError::InternalServerError(format!("failed to serialize layout: {e}").into())
+        })
+}

--- a/libs/ferriskey-api-portal-layouts/src/handlers/import_layout.rs
+++ b/libs/ferriskey-api-portal-layouts/src/handlers/import_layout.rs
@@ -57,6 +57,10 @@ pub async fn import_layout(
         ExportEnvelope::PORTAL_LAYOUT,
     )?;
 
+    let tree = payload
+        .tree
+        .ok_or_else(|| ApiError::BadRequest("tree is required".into()))?;
+
     let layout = state
         .service
         .import_layout(
@@ -64,7 +68,7 @@ pub async fn import_layout(
             ImportLayoutInput {
                 realm_name,
                 name: payload.name,
-                tree: payload.tree,
+                tree,
             },
         )
         .await

--- a/libs/ferriskey-api-portal-layouts/src/handlers/import_layout.rs
+++ b/libs/ferriskey-api-portal-layouts/src/handlers/import_layout.rs
@@ -1,0 +1,76 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::{
+        entities::PortalLayout,
+        ports::{ImportLayoutInput, PortalLayoutsService},
+    },
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::validators::ImportPortalLayoutValidator;
+use ferriskey_api_core::api_entities::export::{ExportEnvelope, ensure_importable};
+use ferriskey_api_core::api_entities::{
+    api_error::{ApiError, ApiErrorResponse, ValidateJson},
+    response::Response,
+};
+use ferriskey_api_core::app_state::AppState;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ImportPortalLayoutResponse {
+    pub data: PortalLayout,
+}
+
+#[utoipa::path(
+    post,
+    path = "/import",
+    tag = "portal-layouts",
+    summary = "Import a portal layout",
+    description = "Creates a portal layout from an exported layout tree. The tree is validated before \
+                   it is stored, unlike the plain create endpoint which is fed by the builder itself.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+    ),
+    request_body = ImportPortalLayoutValidator,
+    responses(
+        (status = 201, description = "Layout imported successfully", body = ImportPortalLayoutResponse),
+        (status = 400, description = "Invalid request data", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 422, description = "Invalid layout tree", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn import_layout(
+    Path(realm_name): Path<String>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+    ValidateJson(payload): ValidateJson<ImportPortalLayoutValidator>,
+) -> Result<Response<ImportPortalLayoutResponse>, ApiError> {
+    ensure_importable(
+        payload.ferriskey.as_deref(),
+        payload.version,
+        ExportEnvelope::PORTAL_LAYOUT,
+    )?;
+
+    let layout = state
+        .service
+        .import_layout(
+            identity,
+            ImportLayoutInput {
+                realm_name,
+                name: payload.name,
+                tree: payload.tree,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::Created(ImportPortalLayoutResponse {
+        data: layout,
+    }))
+}

--- a/libs/ferriskey-api-portal-layouts/src/handlers/mod.rs
+++ b/libs/ferriskey-api-portal-layouts/src/handlers/mod.rs
@@ -1,8 +1,10 @@
 pub mod create_layout;
 pub mod delete_layout;
+pub mod export_layout;
 pub mod get_layout;
 pub mod get_public_default_layout;
 pub mod get_public_layout;
+pub mod import_layout;
 pub mod list_layouts;
 pub mod set_default_layout;
 pub mod update_layout;

--- a/libs/ferriskey-api-portal-layouts/src/router.rs
+++ b/libs/ferriskey-api-portal-layouts/src/router.rs
@@ -1,14 +1,19 @@
 use super::handlers::create_layout::{__path_create_layout, create_layout};
 use super::handlers::delete_layout::{__path_delete_layout, delete_layout};
+use super::handlers::export_layout::{__path_export_layout, export_layout};
 use super::handlers::get_layout::{__path_get_layout, get_layout};
 use super::handlers::get_public_default_layout::{
     __path_get_public_default_layout, get_public_default_layout,
 };
 use super::handlers::get_public_layout::{__path_get_public_layout, get_public_layout};
+use super::handlers::import_layout::{__path_import_layout, import_layout};
 use super::handlers::list_layouts::{__path_list_layouts, list_layouts};
 use super::handlers::set_default_layout::{__path_set_default_layout, set_default_layout};
 use super::handlers::update_layout::{__path_update_layout, update_layout};
-use axum::{Router, middleware, routing::get};
+use axum::{
+    Router, middleware,
+    routing::{get, post},
+};
 use ferriskey_api_core::{app_state::AppState, auth::auth};
 use utoipa::OpenApi;
 
@@ -20,6 +25,8 @@ use utoipa::OpenApi;
     update_layout,
     delete_layout,
     set_default_layout,
+    import_layout,
+    export_layout,
 ))]
 pub struct PortalLayoutsApiDoc;
 
@@ -38,10 +45,24 @@ pub fn portal_layouts_routes(state: AppState) -> Router<AppState> {
         )
         .route(
             &format!(
+                "{}/realms/{{realm_name}}/portal-layouts/import",
+                state.args.server.root_path
+            ),
+            post(import_layout),
+        )
+        .route(
+            &format!(
                 "{}/realms/{{realm_name}}/portal-layouts/{{layout_id}}",
                 state.args.server.root_path
             ),
             get(get_layout).put(update_layout).delete(delete_layout),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/portal-layouts/{{layout_id}}/export",
+                state.args.server.root_path
+            ),
+            get(export_layout),
         )
         .route(
             &format!(

--- a/libs/ferriskey-api-portal-layouts/src/validators.rs
+++ b/libs/ferriskey-api-portal-layouts/src/validators.rs
@@ -32,7 +32,12 @@ pub struct ImportPortalLayoutValidator {
     ))]
     pub name: String,
 
-    pub tree: serde_json::Value,
+    /// Optional at deserialisation so a file from another builder is answered
+    /// by the envelope check — which says what the file actually is — rather
+    /// than by a "missing field tree" the person importing cannot act on. The
+    /// handler still requires it.
+    #[serde(default)]
+    pub tree: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]

--- a/libs/ferriskey-api-portal-layouts/src/validators.rs
+++ b/libs/ferriskey-api-portal-layouts/src/validators.rs
@@ -15,6 +15,27 @@ pub struct CreatePortalLayoutValidator {
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+pub struct ImportPortalLayoutValidator {
+    /// Which builder the file came from, when it came from an export. Checked
+    /// so an email template cannot be imported as a layout.
+    #[serde(default)]
+    pub ferriskey: Option<String>,
+
+    /// Export format version, when the payload came from an export.
+    #[serde(default)]
+    pub version: Option<u32>,
+
+    #[validate(length(
+        min = 1,
+        max = 255,
+        message = "name must be between 1 and 255 characters"
+    ))]
+    pub name: String,
+
+    pub tree: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct UpdatePortalLayoutValidator {
     #[validate(length(
         min = 1,

--- a/libs/ferriskey-api-portal-theme/src/handlers/export_theme.rs
+++ b/libs/ferriskey-api-portal-theme/src/handlers/export_theme.rs
@@ -3,6 +3,7 @@ use axum::{
     extract::{Path, State},
     response::Response as AxumResponse,
 };
+use ferriskey_core::domain::common::entities::app_errors::CoreError;
 use ferriskey_core::domain::{
     authentication::value_objects::Identity,
     portal_layouts::ports::{GetLayoutInput, PortalLayoutsService},
@@ -72,9 +73,11 @@ pub async fn export_theme(
 
     // A layout the theme names but that no longer exists is not worth failing
     // an export over: the theme's own tokens and pages are what the file is
-    // for, and the import falls back to the realm's default layout.
+    // for, and the import falls back to the realm's default layout. Only a
+    // missing record is forgiven though — swallowing every error here would
+    // turn a permission denial into a file that silently lost its layout.
     let layout = match theme.layout_id {
-        Some(layout_id) => state
+        Some(layout_id) => match state
             .service
             .get_layout(
                 identity,
@@ -84,11 +87,14 @@ pub async fn export_theme(
                 },
             )
             .await
-            .ok()
-            .map(|layout| ThemeExportLayout {
+        {
+            Ok(layout) => Some(ThemeExportLayout {
                 name: layout.name,
                 tree: layout.tree,
             }),
+            Err(CoreError::NotFound) => None,
+            Err(e) => return Err(ApiError::from(e)),
+        },
         None => None,
     };
 

--- a/libs/ferriskey-api-portal-theme/src/handlers/export_theme.rs
+++ b/libs/ferriskey-api-portal-theme/src/handlers/export_theme.rs
@@ -1,0 +1,105 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+    response::Response as AxumResponse,
+};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_layouts::ports::{GetLayoutInput, PortalLayoutsService},
+    portal_theme::{
+        entities::{PortalPageType, PortalThemePages},
+        ports::{GetThemeByIdInput, PortalThemeService},
+    },
+};
+use uuid::Uuid;
+
+use ferriskey_api_core::api_entities::api_error::{ApiError, ApiErrorResponse};
+use ferriskey_api_core::api_entities::export::{ThemeExportEnvelope, ThemeExportLayout};
+use ferriskey_api_core::app_state::AppState;
+
+/// Keys the pages by their canonical page-type name.
+///
+/// `PortalThemePages` serialises its fields in camelCase, while a page type is
+/// `snake_case` on the wire — importing what the struct produces would fail on
+/// the very file this endpoint just wrote. Building the map from the page types
+/// themselves keeps the file format tied to the names the import understands,
+/// whatever the struct does internally.
+fn export_pages(pages: &PortalThemePages) -> serde_json::Value {
+    let entries = PortalPageType::ALL.iter().filter_map(|page_type| {
+        let key = serde_json::to_value(page_type).ok()?;
+        Some((key.as_str()?.to_string(), pages.get(*page_type).clone()))
+    });
+
+    serde_json::Value::Object(entries.collect())
+}
+
+#[utoipa::path(
+    get,
+    path = "/portal/themes/{theme_id}/export",
+    tag = "portal-theme",
+    summary = "Export a portal theme",
+    description = "Returns the theme as a downloadable JSON envelope: its design tokens, every page tree, \
+                   and the layout it is framed by, carried by value so the file can be imported into \
+                   another realm or deployment.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+        ("theme_id" = Uuid, Path, description = "Portal theme ID"),
+    ),
+    responses(
+        (status = 200, description = "Theme exported successfully", content_type = "application/json", body = ThemeExportEnvelope),
+        (status = 404, description = "Theme not found", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn export_theme(
+    Path((realm_name, theme_id)): Path<(String, Uuid)>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+) -> Result<AxumResponse, ApiError> {
+    let theme = state
+        .service
+        .get_theme_by_id(
+            identity.clone(),
+            GetThemeByIdInput {
+                realm_name: realm_name.clone(),
+                theme_id,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    // A layout the theme names but that no longer exists is not worth failing
+    // an export over: the theme's own tokens and pages are what the file is
+    // for, and the import falls back to the realm's default layout.
+    let layout = match theme.layout_id {
+        Some(layout_id) => state
+            .service
+            .get_layout(
+                identity,
+                GetLayoutInput {
+                    realm_name,
+                    layout_id,
+                },
+            )
+            .await
+            .ok()
+            .map(|layout| ThemeExportLayout {
+                name: layout.name,
+                tree: layout.tree,
+            }),
+        None => None,
+    };
+
+    let config = serde_json::to_value(&theme.config).map_err(|e| {
+        ApiError::InternalServerError(format!("failed to serialize theme: {e}").into())
+    })?;
+    let pages = export_pages(&theme.pages);
+
+    ThemeExportEnvelope::new(theme.name, config, pages, layout)
+        .into_download()
+        .map_err(|e| {
+            ApiError::InternalServerError(format!("failed to serialize theme: {e}").into())
+        })
+}

--- a/libs/ferriskey-api-portal-theme/src/handlers/import_theme.rs
+++ b/libs/ferriskey-api-portal-theme/src/handlers/import_theme.rs
@@ -2,10 +2,12 @@ use axum::{
     Extension,
     extract::{Path, State},
 };
-use ferriskey_core::application::portal_theme::{ImportPortalThemeInput, ImportPortalThemeLayout};
 use ferriskey_core::domain::{
     authentication::value_objects::Identity,
-    portal_theme::entities::{PortalPageType, PortalTheme, PortalThemeConfig},
+    portal_theme::{
+        entities::{PortalPageType, PortalTheme, PortalThemeConfig},
+        ports::{ImportPortalThemeInput, ImportPortalThemeLayout},
+    },
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/libs/ferriskey-api-portal-theme/src/handlers/import_theme.rs
+++ b/libs/ferriskey-api-portal-theme/src/handlers/import_theme.rs
@@ -1,0 +1,142 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+};
+use ferriskey_core::application::portal_theme::{ImportPortalThemeInput, ImportPortalThemeLayout};
+use ferriskey_core::domain::{
+    authentication::value_objects::Identity,
+    portal_theme::entities::{PortalPageType, PortalTheme},
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::validators::ImportPortalThemeValidator;
+use ferriskey_api_core::api_entities::{
+    api_error::{ApiError, ApiErrorResponse, ValidateJson},
+    export::{ThemeExportEnvelope, ensure_importable},
+    response::Response,
+};
+use ferriskey_api_core::app_state::AppState;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ImportPortalThemeResponse {
+    pub data: PortalTheme,
+}
+
+/// Reads the page trees out of the file.
+///
+/// Pages are optional and named by page type: a file that carries only some of
+/// them imports the ones it has, and the theme is simply not activatable until
+/// the rest are filled in — which is the same state a hand-built theme is in.
+/// An unknown page name is refused rather than dropped, since silently losing a
+/// page is how an import looks successful and renders wrong.
+fn theme_pages(
+    pages: serde_json::Value,
+) -> Result<Vec<(PortalPageType, serde_json::Value)>, ApiError> {
+    let serde_json::Value::Object(pages) = pages else {
+        return Err(ApiError::BadRequest("'pages' must be an object".into()));
+    };
+
+    pages
+        .into_iter()
+        .map(|(name, tree)| {
+            let page_type = serde_json::from_value::<PortalPageType>(serde_json::Value::String(
+                name.clone(),
+            ))
+            .map_err(|_| ApiError::BadRequest(format!("unknown page type '{name}'").into()))?;
+
+            Ok((page_type, tree))
+        })
+        .collect()
+}
+
+#[utoipa::path(
+    post,
+    path = "/portal/themes/import",
+    tag = "portal-theme",
+    summary = "Import a portal theme",
+    description = "Creates a portal theme from an exported JSON envelope: its design tokens, its page \
+                   trees, and the layout carried inside the file, which is recreated and bound to the \
+                   new theme.",
+    params(
+        ("realm_name" = String, Path, description = "Name of the realm"),
+    ),
+    request_body = ImportPortalThemeValidator,
+    responses(
+        (status = 201, description = "Theme imported successfully", body = ImportPortalThemeResponse),
+        (status = 400, description = "Invalid request data", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    ),
+)]
+pub async fn import_theme(
+    Path(realm_name): Path<String>,
+    State(state): State<AppState>,
+    Extension(identity): Extension<Identity>,
+    ValidateJson(payload): ValidateJson<ImportPortalThemeValidator>,
+) -> Result<Response<ImportPortalThemeResponse>, ApiError> {
+    ensure_importable(
+        payload.ferriskey.as_deref(),
+        payload.version,
+        ThemeExportEnvelope::KIND,
+    )?;
+
+    let config = serde_json::from_value(payload.config)
+        .map_err(|e| ApiError::BadRequest(format!("invalid theme config: {e}").into()))?;
+
+    let theme = state
+        .service
+        .import_portal_theme(
+            identity,
+            ImportPortalThemeInput {
+                realm_name,
+                name: payload.name,
+                config,
+                pages: theme_pages(payload.pages)?,
+                layout: payload.layout.map(|layout| ImportPortalThemeLayout {
+                    name: layout.name,
+                    tree: layout.tree,
+                }),
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Response::Created(ImportPortalThemeResponse { data: theme }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_names_are_read_as_page_types() {
+        let pages = serde_json::json!({ "login": [], "device_verify": [] });
+
+        let parsed = theme_pages(pages).expect("both names are valid page types");
+
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.iter().any(|(pt, _)| *pt == PortalPageType::Login));
+        assert!(
+            parsed
+                .iter()
+                .any(|(pt, _)| *pt == PortalPageType::DeviceVerify)
+        );
+    }
+
+    #[test]
+    fn an_unknown_page_name_is_refused_rather_than_dropped() {
+        let pages = serde_json::json!({ "login": [], "checkout": [] });
+
+        assert!(
+            theme_pages(pages).is_err(),
+            "a page the server cannot place must fail the import"
+        );
+    }
+
+    #[test]
+    fn pages_must_be_an_object() {
+        assert!(theme_pages(serde_json::json!([])).is_err());
+    }
+}

--- a/libs/ferriskey-api-portal-theme/src/handlers/import_theme.rs
+++ b/libs/ferriskey-api-portal-theme/src/handlers/import_theme.rs
@@ -5,7 +5,7 @@ use axum::{
 use ferriskey_core::application::portal_theme::{ImportPortalThemeInput, ImportPortalThemeLayout};
 use ferriskey_core::domain::{
     authentication::value_objects::Identity,
-    portal_theme::entities::{PortalPageType, PortalTheme},
+    portal_theme::entities::{PortalPageType, PortalTheme, PortalThemeConfig},
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -82,8 +82,15 @@ pub async fn import_theme(
         ThemeExportEnvelope::KIND,
     )?;
 
-    let config = serde_json::from_value(payload.config)
-        .map_err(|e| ApiError::BadRequest(format!("invalid theme config: {e}").into()))?;
+    // `config` is optional in the file: `serde(default)` on a `Value` yields
+    // `Null`, which the config struct refuses, so an envelope written without
+    // one would be rejected instead of falling back to the defaults.
+    let config = if payload.config.is_null() {
+        PortalThemeConfig::default()
+    } else {
+        serde_json::from_value(payload.config)
+            .map_err(|e| ApiError::BadRequest(format!("invalid theme config: {e}").into()))?
+    };
 
     let theme = state
         .service

--- a/libs/ferriskey-api-portal-theme/src/handlers/mod.rs
+++ b/libs/ferriskey-api-portal-theme/src/handlers/mod.rs
@@ -1,10 +1,12 @@
 pub mod activate_theme;
 pub mod create_theme;
 pub mod delete_theme;
+pub mod export_theme;
 pub mod get_active_theme;
 pub mod get_page_requirements;
 pub mod get_theme;
 pub mod get_theme_by_id;
+pub mod import_theme;
 pub mod list_themes;
 pub mod update_theme;
 pub mod update_theme_metadata;

--- a/libs/ferriskey-api-portal-theme/src/router.rs
+++ b/libs/ferriskey-api-portal-theme/src/router.rs
@@ -1,10 +1,12 @@
 use super::handlers::activate_theme::{__path_activate_theme, activate_theme};
 use super::handlers::create_theme::{__path_create_theme, create_theme};
 use super::handlers::delete_theme::{__path_delete_theme, delete_theme};
+use super::handlers::export_theme::{__path_export_theme, export_theme};
 use super::handlers::get_active_theme::{__path_get_active_theme, get_active_theme};
 use super::handlers::get_page_requirements::{__path_get_page_requirements, get_page_requirements};
 use super::handlers::get_theme::{__path_get_theme, get_theme};
 use super::handlers::get_theme_by_id::{__path_get_theme_by_id, get_theme_by_id};
+use super::handlers::import_theme::{__path_import_theme, import_theme};
 use super::handlers::list_themes::{__path_list_themes, list_themes};
 use super::handlers::update_theme::{__path_update_theme, update_theme};
 use super::handlers::update_theme_metadata::{__path_update_theme_metadata, update_theme_metadata};
@@ -28,6 +30,8 @@ use utoipa::OpenApi;
     update_theme_page,
     activate_theme,
     get_page_requirements,
+    import_theme,
+    export_theme,
 ))]
 pub struct PortalThemeApiDoc;
 
@@ -61,6 +65,20 @@ pub fn portal_theme_routes(state: AppState) -> Router<AppState> {
             get(get_theme_by_id)
                 .put(update_theme_metadata)
                 .delete(delete_theme),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/portal/themes/import",
+                state.args.server.root_path
+            ),
+            post(import_theme),
+        )
+        .route(
+            &format!(
+                "{}/realms/{{realm_name}}/portal/themes/{{theme_id}}/export",
+                state.args.server.root_path
+            ),
+            get(export_theme),
         )
         .route(
             &format!(

--- a/libs/ferriskey-api-portal-theme/src/validators.rs
+++ b/libs/ferriskey-api-portal-theme/src/validators.rs
@@ -46,6 +46,7 @@ pub struct ImportPortalThemeValidator {
 
     /// The layout carried inside the file, recreated on import.
     #[serde(default)]
+    #[validate(nested)]
     pub layout: Option<ImportPortalThemeLayoutValidator>,
 }
 

--- a/libs/ferriskey-api-portal-theme/src/validators.rs
+++ b/libs/ferriskey-api-portal-theme/src/validators.rs
@@ -19,6 +19,44 @@ pub struct CreateThemeValidator {
     pub config: PortalThemeConfig,
 }
 
+/// Import payload — an exported theme envelope, sent back verbatim.
+#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+pub struct ImportPortalThemeValidator {
+    /// Which builder the file came from, when it came from an export. Checked
+    /// so a layout or an email template cannot be imported as a theme.
+    #[serde(default)]
+    pub ferriskey: Option<String>,
+
+    /// Export format version, when the payload came from an export.
+    #[serde(default)]
+    pub version: Option<u32>,
+
+    #[validate(length(min = 1, max = 255))]
+    pub name: String,
+
+    /// The theme's design tokens. Missing keys fall back to their defaults.
+    #[serde(default)]
+    #[schema(value_type = Object)]
+    pub config: serde_json::Value,
+
+    /// One builder tree per page, keyed by page type.
+    #[serde(default)]
+    #[schema(value_type = Object)]
+    pub pages: serde_json::Value,
+
+    /// The layout carried inside the file, recreated on import.
+    #[serde(default)]
+    pub layout: Option<ImportPortalThemeLayoutValidator>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+pub struct ImportPortalThemeLayoutValidator {
+    #[validate(length(min = 1, max = 255))]
+    pub name: String,
+    #[schema(value_type = Object)]
+    pub tree: serde_json::Value,
+}
+
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct UpdateThemeMetadataValidator {
     #[validate(length(min = 1, max = 255))]

--- a/libs/ferriskey-api-webhook/src/validators.rs
+++ b/libs/ferriskey-api-webhook/src/validators.rs
@@ -37,8 +37,11 @@ pub struct UpdateWebhookValidator {
     #[serde(default)]
     pub endpoint: String,
 
+    /// Omitted keeps the stored headers: the API never returns them, so a
+    /// client editing another field has no way to send them back and would
+    /// otherwise wipe them.
     #[serde(default)]
-    pub headers: HashMap<String, String>,
+    pub headers: Option<HashMap<String, String>>,
 
     #[serde(default)]
     pub subscribers: Vec<WebhookTrigger>,

--- a/libs/ferriskey-domain/src/common/app_errors.rs
+++ b/libs/ferriskey-domain/src/common/app_errors.rs
@@ -350,6 +350,9 @@ pub enum CoreError {
     #[error("Portal layout is referenced by one or more themes and cannot be deleted")]
     PortalLayoutInUse,
 
+    #[error("Invalid portal layout tree: {0}")]
+    PortalLayoutInvalidTree(String),
+
     #[error("Password policy violated: {0}")]
     PasswordPolicyViolation(String),
 }

--- a/libs/ferriskey-mail/src/email_template/ports.rs
+++ b/libs/ferriskey-mail/src/email_template/ports.rs
@@ -43,6 +43,12 @@ pub trait EmailTemplateService: Send + Sync {
         identity: Identity,
         input: RenderEmailTemplateInput,
     ) -> impl Future<Output = Result<String, CoreError>> + Send;
+
+    fn import_template(
+        &self,
+        identity: Identity,
+        input: ImportEmailTemplateInput,
+    ) -> impl Future<Output = Result<EmailTemplate, CoreError>> + Send;
 }
 
 #[cfg_attr(any(test, feature = "mock"), mockall::automock)]
@@ -92,6 +98,11 @@ pub trait TemplateRenderer: Send + Sync {
 
     /// Converts the intermediate representation into final HTML.
     fn render_to_html(&self, intermediate: &str) -> Result<String, CoreError>;
+
+    /// Converts an intermediate representation back into a builder structure (JSON).
+    /// The inverse of [`TemplateRenderer::render_to_intermediate`], used to import
+    /// externally authored markup into the builder.
+    fn parse_intermediate(&self, intermediate: &str) -> Result<serde_json::Value, CoreError>;
 }
 
 pub trait EmailTemplatePolicy: Send + Sync {
@@ -139,4 +150,18 @@ pub struct DeleteEmailTemplateInput {
 pub struct RenderEmailTemplateInput {
     pub realm_name: String,
     pub template_id: Uuid,
+}
+
+/// Where an imported template comes from: either the builder's own JSON tree,
+/// or raw MJML markup that has to be parsed back into one.
+pub enum EmailTemplateSource {
+    Structure(serde_json::Value),
+    Mjml(String),
+}
+
+pub struct ImportEmailTemplateInput {
+    pub realm_name: String,
+    pub name: String,
+    pub email_type: EmailType,
+    pub source: EmailTemplateSource,
 }

--- a/libs/ferriskey-mail/src/email_template/services.rs
+++ b/libs/ferriskey-mail/src/email_template/services.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use crate::email_template::entities::EmailTemplate;
 use crate::email_template::ports::{
     CreateEmailTemplateInput, DeleteEmailTemplateInput, EmailTemplatePolicy,
-    EmailTemplateRepository, EmailTemplateService, GetEmailTemplateInput, GetEmailTemplatesInput,
-    RenderEmailTemplateInput, TemplateRenderer, UpdateEmailTemplateInput,
+    EmailTemplateRepository, EmailTemplateService, EmailTemplateSource, GetEmailTemplateInput,
+    GetEmailTemplatesInput, ImportEmailTemplateInput, RenderEmailTemplateInput, TemplateRenderer,
+    UpdateEmailTemplateInput,
 };
 use ferriskey_domain::auth::Identity;
 use ferriskey_domain::client::ports::ClientRepository;
@@ -234,6 +235,47 @@ where
 
         self.template_renderer.render_to_html(&template.mjml)
     }
+
+    async fn import_template(
+        &self,
+        identity: Identity,
+        input: ImportEmailTemplateInput,
+    ) -> Result<EmailTemplate, CoreError> {
+        let realm = self
+            .realm_repository
+            .get_by_name(&input.realm_name)
+            .await?
+            .ok_or(CoreError::InvalidRealm)?;
+
+        ensure_policy(
+            self.policy
+                .can_manage_email_template(&identity, &realm)
+                .await,
+            "insufficient permissions",
+        )?;
+
+        // MJML imports are parsed back into a builder structure so the imported
+        // template stays editable in the builder, like any other template.
+        let structure = match input.source {
+            EmailTemplateSource::Structure(structure) => structure,
+            EmailTemplateSource::Mjml(mjml) => self.template_renderer.parse_intermediate(&mjml)?,
+        };
+
+        let mjml = self.template_renderer.render_to_intermediate(&structure)?;
+
+        // Validate that the MJML can be converted to HTML
+        self.template_renderer.render_to_html(&mjml)?;
+
+        self.email_template_repository
+            .create(
+                realm.id.into(),
+                input.name,
+                input.email_type.to_string(),
+                structure,
+                mjml,
+            )
+            .await
+    }
 }
 
 #[cfg(test)]
@@ -264,6 +306,12 @@ mod tests {
 
         fn render_to_html(&self, _intermediate: &str) -> Result<String, CoreError> {
             Ok("<html><body>Test</body></html>".to_string())
+        }
+
+        fn parse_intermediate(&self, _intermediate: &str) -> Result<serde_json::Value, CoreError> {
+            Ok(
+                json!({"children": [{"type": "mj-section", "props": {}, "styles": {}, "children": []}]}),
+            )
         }
     }
 

--- a/libs/ferriskey-mail/src/email_verification/services.rs
+++ b/libs/ferriskey-mail/src/email_verification/services.rs
@@ -456,6 +456,10 @@ mod tests {
         fn render_to_html(&self, _intermediate: &str) -> Result<String, CoreError> {
             Ok("<html><body>Test</body></html>".to_string())
         }
+
+        fn parse_intermediate(&self, _intermediate: &str) -> Result<serde_json::Value, CoreError> {
+            Ok(serde_json::json!({"children": []}))
+        }
     }
 
     fn test_realm() -> Realm {

--- a/libs/ferriskey-portal-layouts/src/entities.rs
+++ b/libs/ferriskey-portal-layouts/src/entities.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use ferriskey_domain::common::app_errors::CoreError;
 use ferriskey_domain::realm::RealmId;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -14,6 +15,55 @@ pub struct PortalLayout {
     pub is_default: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// Checks that a layout tree is a well-formed builder tree before it is stored.
+///
+/// The builder itself only ever produces valid trees, so this exists for
+/// externally supplied ones (imports): a malformed tree would otherwise be
+/// accepted here and only blow up in the portal renderer.
+pub fn validate_tree(tree: &serde_json::Value) -> Result<(), CoreError> {
+    let nodes = tree.as_array().ok_or_else(|| {
+        CoreError::PortalLayoutInvalidTree("tree must be an array of nodes".to_string())
+    })?;
+
+    for (index, node) in nodes.iter().enumerate() {
+        validate_node(node, &format!("tree[{index}]"))?;
+    }
+
+    Ok(())
+}
+
+fn validate_node(node: &serde_json::Value, path: &str) -> Result<(), CoreError> {
+    let node = node
+        .as_object()
+        .ok_or_else(|| CoreError::PortalLayoutInvalidTree(format!("{path} must be an object")))?;
+
+    let node_type = node.get("type").and_then(|value| value.as_str());
+    if node_type.is_none_or(str::is_empty) {
+        return Err(CoreError::PortalLayoutInvalidTree(format!(
+            "{path} is missing a non-empty 'type'"
+        )));
+    }
+
+    // `children` is required, not merely well-typed when present: the builder
+    // walks a tree assuming every node has one (`node.children.length`), so a
+    // node without it is accepted here and then crashes the editor the first
+    // time someone opens the imported layout.
+    match node.get("children") {
+        None => Err(CoreError::PortalLayoutInvalidTree(format!(
+            "{path} is missing 'children'; a node with no child still needs an empty array"
+        ))),
+        Some(serde_json::Value::Array(children)) => {
+            for (index, child) in children.iter().enumerate() {
+                validate_node(child, &format!("{path}.children[{index}]"))?;
+            }
+            Ok(())
+        }
+        Some(_) => Err(CoreError::PortalLayoutInvalidTree(format!(
+            "{path}.children must be an array"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -68,5 +118,48 @@ mod tests {
         };
         let json = serde_json::to_value(&layout).expect("to_value");
         assert!(json.get("tree").unwrap().is_array());
+    }
+
+    #[test]
+    fn validate_tree_accepts_a_nested_builder_tree() {
+        assert!(validate_tree(&sample_tree()).is_ok());
+        assert!(validate_tree(&serde_json::json!([])).is_ok());
+    }
+
+    #[test]
+    fn validate_tree_rejects_non_array_roots() {
+        let result = validate_tree(&serde_json::json!({ "children": [] }));
+        assert!(matches!(result, Err(CoreError::PortalLayoutInvalidTree(_))));
+    }
+
+    #[test]
+    fn validate_tree_rejects_a_node_without_children() {
+        let tree = serde_json::json!([
+            { "type": "container", "children": [{ "type": "text", "props": {} }] }
+        ]);
+
+        let error = validate_tree(&tree).expect_err("a node without children must be refused");
+        assert!(
+            format!("{error:?}").contains("children"),
+            "the message should name the missing field: {error:?}"
+        );
+    }
+
+    #[test]
+    fn validate_tree_rejects_nodes_without_a_type() {
+        let result = validate_tree(&serde_json::json!([{ "id": "a", "children": [] }]));
+        assert!(matches!(result, Err(CoreError::PortalLayoutInvalidTree(_))));
+    }
+
+    #[test]
+    fn validate_tree_reports_the_path_of_a_bad_descendant() {
+        let tree = serde_json::json!([
+            { "type": "container", "children": [{ "type": "row", "children": "nope" }] }
+        ]);
+
+        let Err(CoreError::PortalLayoutInvalidTree(message)) = validate_tree(&tree) else {
+            panic!("expected an invalid tree error");
+        };
+        assert_eq!(message, "tree[0].children[0].children must be an array");
     }
 }

--- a/libs/ferriskey-portal-layouts/src/ports.rs
+++ b/libs/ferriskey-portal-layouts/src/ports.rs
@@ -53,6 +53,12 @@ pub trait PortalLayoutsService: Send + Sync {
         &self,
         input: GetLayoutInput,
     ) -> impl Future<Output = Result<Option<PortalLayout>, CoreError>> + Send;
+
+    fn import_layout(
+        &self,
+        identity: Identity,
+        input: ImportLayoutInput,
+    ) -> impl Future<Output = Result<PortalLayout, CoreError>> + Send;
 }
 
 #[cfg_attr(any(test, feature = "mock"), mockall::automock)]
@@ -134,6 +140,12 @@ pub struct CreateLayoutInput {
 pub struct UpdateLayoutInput {
     pub realm_name: String,
     pub layout_id: Uuid,
+    pub name: String,
+    pub tree: serde_json::Value,
+}
+
+pub struct ImportLayoutInput {
+    pub realm_name: String,
     pub name: String,
     pub tree: serde_json::Value,
 }

--- a/libs/ferriskey-portal-layouts/src/services.rs
+++ b/libs/ferriskey-portal-layouts/src/services.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use crate::entities::PortalLayout;
+use crate::entities::{PortalLayout, validate_tree};
 use crate::ports::{
-    CreateLayoutInput, GetLayoutInput, ListLayoutsInput, PortalLayoutsPolicy,
+    CreateLayoutInput, GetLayoutInput, ImportLayoutInput, ListLayoutsInput, PortalLayoutsPolicy,
     PortalLayoutsRepository, PortalLayoutsService, UpdateLayoutInput,
 };
 use ferriskey_domain::auth::Identity;
@@ -229,6 +229,26 @@ where
         self.layouts_repository
             .get_by_id(realm.id.into(), input.layout_id)
             .await
+    }
+
+    async fn import_layout(
+        &self,
+        identity: Identity,
+        input: ImportLayoutInput,
+    ) -> Result<PortalLayout, CoreError> {
+        // Unlike `create_layout`, the tree here comes from a file rather than
+        // from the builder, so it is validated before it reaches the database.
+        validate_tree(&input.tree)?;
+
+        self.create_layout(
+            identity,
+            CreateLayoutInput {
+                realm_name: input.realm_name,
+                name: input.name,
+                tree: input.tree,
+            },
+        )
+        .await
     }
 }
 

--- a/libs/ferriskey-portal-theme/src/ports.rs
+++ b/libs/ferriskey-portal-theme/src/ports.rs
@@ -198,3 +198,17 @@ pub struct UpdateThemePageInput {
     pub page_type: PortalPageType,
     pub tree: serde_json::Value,
 }
+
+pub struct ImportPortalThemeLayout {
+    pub name: String,
+    pub tree: serde_json::Value,
+}
+
+pub struct ImportPortalThemeInput {
+    pub realm_name: String,
+    pub name: String,
+    pub config: PortalThemeConfig,
+    /// Every page the file carries, in the order it should be written.
+    pub pages: Vec<(PortalPageType, serde_json::Value)>,
+    pub layout: Option<ImportPortalThemeLayout>,
+}

--- a/libs/ferriskey-webhook/src/ports.rs
+++ b/libs/ferriskey-webhook/src/ports.rs
@@ -78,6 +78,9 @@ pub trait WebhookRepository: Send + Sync {
         subscribers: Vec<WebhookTrigger>,
     ) -> impl Future<Output = Result<Webhook, CoreError>> + Send;
 
+    /// `headers` is optional: `None` leaves the stored headers untouched, so a
+    /// caller editing an unrelated field cannot silently drop them. The API
+    /// never returns them, which means a client has no way to send them back.
     #[allow(clippy::too_many_arguments)]
     fn update_webhook(
         &self,
@@ -86,7 +89,7 @@ pub trait WebhookRepository: Send + Sync {
         name: Option<String>,
         description: Option<String>,
         endpoint: String,
-        headers: HashMap<String, String>,
+        headers: Option<HashMap<String, String>>,
         subscribers: Vec<WebhookTrigger>,
     ) -> impl Future<Output = Result<Webhook, CoreError>> + Send;
 
@@ -158,7 +161,8 @@ pub struct UpdateWebhookInput {
     pub name: Option<String>,
     pub description: Option<String>,
     pub endpoint: String,
-    pub headers: HashMap<String, String>,
+    /// Omitted means "keep what is stored"; `Some` replaces the whole set.
+    pub headers: Option<HashMap<String, String>>,
     pub subscribers: Vec<WebhookTrigger>,
 }
 

--- a/libs/ferriskey-webhook/src/services.rs
+++ b/libs/ferriskey-webhook/src/services.rs
@@ -211,7 +211,9 @@ where
             .ok_or(CoreError::WebhookNotFound)?;
 
         let endpoint = validate_endpoint(&input.endpoint)?;
-        reject_reserved_headers(&input.headers)?;
+        if let Some(headers) = input.headers.as_ref() {
+            reject_reserved_headers(headers)?;
+        }
 
         let webhook = self
             .webhook_repository
@@ -370,7 +372,7 @@ mod tests {
             name: Some("renamed".to_string()),
             description: None,
             endpoint: "https://93.184.216.34/hook".to_string(),
-            headers: HashMap::new(),
+            headers: Some(HashMap::new()),
             subscribers: Vec::new(),
         }
     }


### PR DESCRIPTION
This pull request introduces import and export support for email templates, portal layouts, and portal themes, including backend logic, frontend APIs, and utility functions for downloading and uploading these resources. It adds the ability to parse and convert MJML email templates to and from a builder-friendly JSON structure, and ensures robust handling of file downloads with correct filenames. The changes also provide user feedback on import operations and improve CORS header exposure for downloads.

**Import/Export Functionality**

* Added backend service methods to import email templates, portal layouts, and portal themes, including new input types and logic to handle associated resources (e.g., layouts within themes) (`core/src/application/email_template/mod.rs`, `core/src/application/portal_layouts/mod.rs`, `core/src/application/portal_theme/mod.rs`). [[1]](diffhunk://#diff-e485de6d1ec41bd0c57bf88dcc393cb7ff54ac84aa3a1cf53d4ad25549699a3fR77-R86) [[2]](diffhunk://#diff-f4fda28f2f470d77b29b05ea40cb8d73e27803cb430485dd58e9fd8fa6024035R92-R101) [[3]](diffhunk://#diff-3ea921d6d22855890be6bbfcd62cc1a625b46e39d40e6cfdc6f62c9ae7d73172R116-R198)
* Implemented frontend React Query hooks for importing email templates, portal layouts, and portal themes, with success/error toasts and cache invalidation (`front/src/api/email-template.api.ts`, `front/src/api/portal-layouts.api.ts`, `front/src/api/portal-theme.api.tsx`). [[1]](diffhunk://#diff-7bbf0dd51fc05544dc88f14245850a3df966a51e543216ef3680b81242571977R61-R81) [[2]](diffhunk://#diff-e8417fbe47aefb9d093b6f6b460d92c0099750194bad69de2c2e81dfa939246fR128-R148) [[3]](diffhunk://#diff-8e2d820eca04f05da11feae4c8b44647a1e65eb09fac507f44031bed81652616R92-R111)

**MJML Email Template Parsing and Conversion**

* Added a method to parse MJML markup into a builder JSON structure, including robust error handling, and provided tests for round-tripping and edge cases (`core/src/infrastructure/email_template/renderer/mjml_renderer.rs`). [[1]](diffhunk://#diff-44f2f4667cce213b48a15b913fb2ab908dbdbdf0750a88be2aa22eb855db78b0R30-R175) [[2]](diffhunk://#diff-44f2f4667cce213b48a15b913fb2ab908dbdbdf0750a88be2aa22eb855db78b0R464-R535)
* Updated test mocks to support the new `parse_intermediate` method (`core/src/domain/trident/services.rs`).

**Frontend Download Utilities**

* Added a utility module to handle downloading exports, extracting filenames from the `Content-Disposition` header, and reading user-uploaded files as JSON (`front/src/api/builder-export.ts`).

**CORS and Header Exposure**

* Updated the backend server to expose the `Content-Disposition` header for cross-origin downloads, ensuring the frontend can access the correct filename for downloaded exports (`api/src/application/http/server/http_server.rs`). [[1]](diffhunk://#diff-3f7e1ac039637b684578ba0876f2a120aef9e59d418c1881ebc2042c758b8cf4L29-R31) [[2]](diffhunk://#diff-3f7e1ac039637b684578ba0876f2a120aef9e59d418c1881ebc2042c758b8cf4R114-R117)

These changes collectively provide a robust and user-friendly import/export experience for templates, layouts, and themes, with strong backend validation and improved interoperability between the frontend and backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import and export email templates as JSON or MJML.
  * Import and export portal layouts and themes, including page content, design settings, and optional layouts.
  * Newly created portal themes now include default page compositions.
  * Added webhook events for web-origin and SAML configuration changes.

* **Bug Fixes**
  * Downloads now retain the server-provided filename instead of using a generic name.
  * Webhook headers are no longer incorrectly prefilled when editing, and omitted headers preserve existing values.
  * Invalid import files and portal layout structures now show clearer validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->