### PR TITLE
fix(front): give the theme editor's block library room to breathe

### DIFF
--- a/front/src/pages/portal-layouts/components/sidebar-tabs.tsx
+++ b/front/src/pages/portal-layouts/components/sidebar-tabs.tsx
@@ -56,14 +56,17 @@ function TabButton({
     <button
       type='button'
       onClick={onClick}
-      className={`flex flex-1 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs transition-colors ${
+      // `min-w-0` + `truncate` let a label give ground when the rail is narrow,
+      // instead of the row overflowing into the container's hidden horizontal
+      // scroll — where the third tab simply disappeared.
+      className={`flex min-w-0 flex-1 items-center justify-center gap-1 rounded px-1.5 py-1 text-xs transition-colors ${
         active
           ? 'bg-background text-foreground shadow-sm'
           : 'text-muted-foreground hover:text-foreground'
-      } whitespace-nowrap`}
+      }`}
     >
-      {icon}
-      {label}
+      <span className='shrink-0'>{icon}</span>
+      <span className='truncate'>{label}</span>
     </button>
   )
 }

--- a/front/src/pages/portal/themes/components/page-tree-editor.tsx
+++ b/front/src/pages/portal/themes/components/page-tree-editor.tsx
@@ -177,14 +177,17 @@ export default function PageTreeEditor({
               whole rail lived inside one ScrollArea and a long components
               list silently pushed the nav off-screen — making it impossible
               to navigate back to the Theme tab without page-scrolling. */}
-          <aside className='grid min-h-0 min-w-0 grid-rows-2 overflow-hidden border-r border-border'>
+          {/* Not `grid-rows-2`: equal halves gave the library the same height as
+              the page nav, which is short and already scrollable, leaving the
+              block list squeezed into a few visible rows. */}
+          <aside className='grid min-h-0 min-w-0 grid-rows-[minmax(0,2fr)_minmax(0,3fr)] overflow-hidden border-r border-border'>
             <div className='min-h-0 min-w-0 overflow-hidden border-b border-border'>
               <ScrollArea className='h-full w-full'>{leftRailNav}</ScrollArea>
             </div>
             {/* The library pins its own tabs row and scrolls only the panel
                 body (both axes), so a deep/wide tree scrolls within the rail
                 without dragging the tabs. `min-w-0` keeps the scroll inside
-                the 220px column rather than pushing the canvas. */}
+                the rail column rather than pushing the canvas. */}
             <div className='flex min-h-0 min-w-0 flex-col overflow-hidden'>
               <PageComponentLibrary requiredTypes={requirements} pageType={pageType} />
             </div>
@@ -291,7 +294,12 @@ function EditorGrid({ children }: { children: ReactNode }) {
     <div
       className='grid h-full w-full min-w-0 overflow-hidden'
       style={{
-        gridTemplateColumns: selected ? '220px 1fr 320px' : '220px 1fr',
+        // The rail holds the page nav *and* the component library, whose three
+        // tabs (Components / Presets / Tree) did not fit in 220px — they
+        // overflowed into a hidden horizontal scroll. The canvas is `1fr` and
+        // only scales itself down to fit (see `useIframeFit`), so the widening
+        // costs a slightly smaller preview and nothing else.
+        gridTemplateColumns: selected ? '264px 1fr 320px' : '264px 1fr',
       }}
     >
       {children}


### PR DESCRIPTION
In the theme editor, the Components / Presets / Tree tabs sat in a 220px rail that was also cut into two equal halves, so the block library got the same height as the page nav — which is short and already scrollable — and the three tab labels had to fight for a row barely wide enough to hold them. The row's overflow was hidden (`overflow-x-auto scrollbar-none`), so a label that did not fit simply vanished instead of announcing itself.

The rail widens to 264px and splits 2fr / 3fr in favour of the library: 253px + 380px instead of 316px each, five blocks visible without scrolling. The canvas is `1fr` and only scales itself to fit (`useIframeFit` clamps at 1), so the extra width comes out of the preview's scale and breaks no layout.

The tab buttons gain `min-w-0` and truncate their label, so a narrow rail compresses them rather than pushing one out of sight. `SidebarTabs` is shared with the layout builder, which gets the same resilience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar tab behavior so long labels truncate cleanly instead of overflowing or hiding other tabs.
  * Expanded the editor’s left navigation rail to ensure all component library tabs remain visible.

* **Style**
  * Adjusted sidebar spacing, padding, and vertical layout proportions for a more usable editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->