### PR TITLE
feat(front): let a portal button override the theme's colours

### DIFF
--- a/front/src/lib/builder-portal/config-panels/button-color-section.tsx
+++ b/front/src/lib/builder-portal/config-panels/button-color-section.tsx
@@ -1,0 +1,41 @@
+import type { BuilderNode } from '../../builder-core'
+import { ColorField } from './shared-fields'
+import { ConfigSection } from './config-section'
+
+/**
+ * Colour overrides shared by the button blocks.
+ *
+ * Each field is optional: left empty, the button keeps the colour its variant
+ * takes from the theme, so branding stays centralised by default and only the
+ * buttons an author deliberately singles out break away from it.
+ */
+export function ButtonColorSection({
+  node,
+  updateProp,
+}: {
+  node: BuilderNode
+  updateProp: (key: string, value: string) => void
+}) {
+  return (
+    <ConfigSection title='Colors' defaultOpen={false}>
+      <div className='px-3 pb-1 text-[11px] text-muted-foreground'>
+        Leave empty to follow the theme.
+      </div>
+      <ColorField
+        label='Background'
+        value={node.props.backgroundColor as string}
+        onChange={(v) => updateProp('backgroundColor', v)}
+      />
+      <ColorField
+        label='Label'
+        value={node.props.color as string}
+        onChange={(v) => updateProp('color', v)}
+      />
+      <ColorField
+        label='Border'
+        value={node.props.borderColor as string}
+        onChange={(v) => updateProp('borderColor', v)}
+      />
+    </ConfigSection>
+  )
+}

--- a/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
+++ b/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { findNodePath, useBuilderContext, type BuilderNode } from '../../builder-core'
 import { ConfigSection } from './config-section'
+import { ButtonColorSection } from './button-color-section'
 import { DimensionInput } from './dimension-input'
 import { LinkedSidesInput } from './linked-sides-input'
 import { ColorField, SelectField, TextField } from './shared-fields'
@@ -709,6 +710,7 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
               allowEmpty={false}
             />
           </ConfigSection>
+          <ButtonColorSection node={node} updateProp={updateProp} />
         </div>
       )
 
@@ -755,6 +757,7 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
               allowEmpty={false}
             />
           </ConfigSection>
+          <ButtonColorSection node={node} updateProp={updateProp} />
         </div>
       )
 
@@ -805,6 +808,7 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
               allowEmpty={false}
             />
           </ConfigSection>
+          <ButtonColorSection node={node} updateProp={updateProp} />
         </div>
       )
 

--- a/front/src/lib/builder-portal/renderer.tsx
+++ b/front/src/lib/builder-portal/renderer.tsx
@@ -1521,6 +1521,15 @@ export function buttonStyle(node: BuilderNode): CSSProperties {
   const justifyContent =
     align === 'left' ? 'flex-start' : align === 'right' ? 'flex-end' : 'center'
 
+  // Per-node colour overrides. Empty means "follow the theme", so each one
+  // falls back to the token the variant would have used — a button saved
+  // before these props existed renders exactly as it did. `||` and not `??`:
+  // clearing the field in the config panel stores an empty string, which must
+  // read as "unset" and not reach the stylesheet.
+  const backgroundOverride = (node.props.backgroundColor as string) || ''
+  const labelOverride = (node.props.color as string) || ''
+  const borderOverride = (node.props.borderColor as string) || ''
+
   const base: CSSProperties = {
     display: 'inline-flex',
     alignItems: 'center',
@@ -1539,25 +1548,30 @@ export function buttonStyle(node: BuilderNode): CSSProperties {
   if (variant === 'secondary') {
     return {
       ...base,
-      backgroundColor: 'var(--fk-color-secondary-button, #ffffff)',
-      color: 'var(--fk-color-secondary-button-label, #111827)',
-      borderColor: 'var(--fk-color-body-text, #d1d5db)',
+      backgroundColor: backgroundOverride || 'var(--fk-color-secondary-button, #ffffff)',
+      color: labelOverride || 'var(--fk-color-secondary-button-label, #111827)',
+      borderColor: borderOverride || 'var(--fk-color-body-text, #d1d5db)',
     }
   }
 
   if (variant === 'outline') {
     return {
       ...base,
-      backgroundColor: 'transparent',
-      color: 'var(--fk-color-primary-button, #635dff)',
-      borderColor: 'var(--fk-color-primary-button, #635dff)',
+      // Stays transparent unless the author asks otherwise — an outline button
+      // that painted a token background would stop being an outline button.
+      backgroundColor: backgroundOverride || 'transparent',
+      color: labelOverride || 'var(--fk-color-primary-button, #635dff)',
+      borderColor: borderOverride || 'var(--fk-color-primary-button, #635dff)',
     }
   }
 
   return {
     ...base,
-    backgroundColor: 'var(--fk-color-primary-button, #635dff)',
-    color: 'var(--fk-color-primary-button-label, #ffffff)',
+    backgroundColor: backgroundOverride || 'var(--fk-color-primary-button, #635dff)',
+    color: labelOverride || 'var(--fk-color-primary-button-label, #ffffff)',
+    // `base` already draws a transparent border, so this only matters when the
+    // author sets one.
+    borderColor: borderOverride || undefined,
   }
 }
 


### PR DESCRIPTION
A button's colours came entirely from the theme, so an author who wanted a single destructive or secondary action to stand out had no way to say it, short of changing the palette for every button in the realm.

Buttons, submit buttons and the device approve / deny pair gain an optional Colors section: background, label, border. Left empty — which is how every stored button starts — each falls back to the exact token its variant used before, so nothing already saved changes appearance.

Checked on a themed portal: an untouched submit button still computes to the theme's amber, a button given an override renders it without affecting its neighbours, and clearing the field returns it to the theme.

Two details worth flagging for review:

- The fallbacks use `||` rather than `??`. Clearing a colour field stores an empty string, which has to read as "unset" and not reach the stylesheet.
- Nothing is added to `defaultProps`. There is no merge between defaults and stored props at render time, so a default would only reach buttons created after the deploy and would pin their colour against the theme.

The outline variant keeps a transparent background unless asked otherwise. Magic-link and passkey buttons are untouched: their panel points at Theme → Buttons, which stays their single source of colour.

Not addressed here: `styleForNodeWithProps` only routes `button` and `submit_button` through `buttonStyle`, so per-breakpoint overrides on the device buttons still produce no CSS. That is pre-existing, and it is the one change in this area that could alter a stored layout — it deserves its own change after a look at what is actually in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional button color customization for background, label, and border colors.
  * Available for standard, submit, approve, and deny buttons.
  * Empty color fields preserve the existing theme colors.
  * Color changes are reflected immediately in the rendered button styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->