### PR TITLE
feat(front): paint the portal page and let a layout center its content

### DIFF
--- a/front/src/lib/builder-core/components/canvas.tsx
+++ b/front/src/lib/builder-core/components/canvas.tsx
@@ -253,9 +253,15 @@ interface CanvasProps {
    * runtime — and let the layout's centering apply.
    */
   fillHeight?: boolean
+  /**
+   * Padding around the drop zone. Editor chrome, not part of the page — a
+   * layout that fills the viewport height would overflow by exactly this much
+   * and show a scrollbar the real page never has.
+   */
+  padded?: boolean
 }
 
-export function Canvas({ maxWidth = 600, fillHeight = true }: CanvasProps) {
+export function Canvas({ maxWidth = 600, fillHeight = true, padded = true }: CanvasProps) {
   const { tree, selectNode } = useBuilderContext()
 
   const { setNodeRef, isOver } = useDroppable({
@@ -293,7 +299,7 @@ export function Canvas({ maxWidth = 600, fillHeight = true }: CanvasProps) {
 
   return (
     <div
-      className='flex min-h-full flex-1 items-start justify-center p-6'
+      className={`flex min-h-full flex-1 items-start justify-center ${padded ? 'p-6' : ''}`}
       onClick={() => selectNode(null)}
     >
       {emptyState}

--- a/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
+++ b/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
@@ -1113,8 +1113,45 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
         <div className='flex flex-col'>
           {identity}
           <div className='px-3 py-2 text-xs text-muted-foreground'>
-            The page content slot is replaced at runtime by the page using this layout. No configuration needed.
+            The page using this layout is rendered here. It fills the viewport and
+            centres its content by default — clear a field to let the slot hug the
+            page instead.
           </div>
+          <ConfigSection title='Size'>
+            <DimensionInput
+              label='Min height'
+              value={node.props.minHeight as string}
+              onChange={(v) => updateProp('minHeight', v)}
+            />
+            <DimensionInput
+              label='Min width'
+              value={node.props.minWidth as string}
+              onChange={(v) => updateProp('minWidth', v)}
+            />
+          </ConfigSection>
+          <ConfigSection title='Alignment' defaultOpen={false}>
+            <SelectField
+              label='Vertical'
+              value={node.props.justifyContent as string}
+              options={[
+                { label: 'Top', value: 'flex-start' },
+                { label: 'Center', value: 'center' },
+                { label: 'Bottom', value: 'flex-end' },
+              ]}
+              onChange={(v) => updateProp('justifyContent', v)}
+            />
+            <SelectField
+              label='Horizontal'
+              value={node.props.alignItems as string}
+              options={[
+                { label: 'Left', value: 'flex-start' },
+                { label: 'Center', value: 'center' },
+                { label: 'Right', value: 'flex-end' },
+                { label: 'Stretch', value: 'stretch' },
+              ]}
+              onChange={(v) => updateProp('alignItems', v)}
+            />
+          </ConfigSection>
         </div>
       )
 

--- a/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
+++ b/front/src/lib/builder-portal/config-panels/config-panel-renderer.tsx
@@ -118,6 +118,17 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
           {identity}
           <ConfigSection title='Layout'>
             <SelectField
+              label='Display'
+              value={(node.props.display as string) || 'flex'}
+              options={[
+                { label: 'Flex', value: 'flex' },
+                { label: 'Block', value: 'block' },
+                { label: 'Grid', value: 'grid' },
+              ]}
+              onChange={(v) => updateProp('display', v)}
+              allowEmpty={false}
+            />
+            <SelectField
               label='Direction'
               value={node.props.direction as string}
               options={[
@@ -137,6 +148,28 @@ function renderPortalConfigPanelInner(node: BuilderNode, onUpdate: OnUpdate): Re
                 { label: 'Stretch', value: 'stretch' },
               ]}
               onChange={(v) => updateProp('align', v)}
+              allowEmpty={false}
+            />
+            <SelectField
+              label='Justify (main axis)'
+              value={node.props.justifyContent as string}
+              options={[
+                { label: 'Start', value: 'flex-start' },
+                { label: 'Center', value: 'center' },
+                { label: 'End', value: 'flex-end' },
+                { label: 'Space between', value: 'space-between' },
+                { label: 'Space around', value: 'space-around' },
+              ]}
+              onChange={(v) => updateProp('justifyContent', v)}
+            />
+            <SelectField
+              label='Fill page height'
+              value={node.props.flexGrow as string}
+              options={[
+                { label: 'No', value: '' },
+                { label: 'Yes', value: '1' },
+              ]}
+              onChange={(v) => updateProp('flexGrow', v)}
               allowEmpty={false}
             />
             <DimensionInput label='Gap' value={node.props.gap as string} onChange={(v) => updateProp('gap', v)} />

--- a/front/src/lib/builder-portal/renderer.tsx
+++ b/front/src/lib/builder-portal/renderer.tsx
@@ -1097,9 +1097,17 @@ export function cardFooterStyle(node: BuilderNode): CSSProperties {
 export function containerStyle(node: BuilderNode): CSSProperties {
   const order = (node.props.order as string) || ''
   return {
-    display: 'flex',
+    // `display` was hardcoded to flex. It stays the default, so a stored
+    // container is unaffected, but a layout can now ask for block or grid.
+    display: ((node.props.display as string) || 'flex') as CSSProperties['display'],
     flexDirection: ((node.props.direction as string) || 'column') as 'row' | 'column',
     alignItems: (node.props.align as string) || 'stretch',
+    // Main-axis placement, and whether the container takes the height left
+    // over by its siblings — together, that is what lets a layout centre its
+    // content on the page. Both stay `undefined` when unset, so the emitted
+    // style is byte-for-byte what it was for every container already saved.
+    justifyContent: (node.props.justifyContent as string) || undefined,
+    flexGrow: (node.props.flexGrow as string) ? Number(node.props.flexGrow) : undefined,
     gap: (node.props.gap as string) || '12px',
     padding: (node.props.padding as string) || '16px',
     backgroundColor: (node.props.backgroundColor as string) || undefined,

--- a/front/src/lib/builder-portal/renderer.tsx
+++ b/front/src/lib/builder-portal/renderer.tsx
@@ -594,19 +594,11 @@ function renderNode(node: BuilderNode, options: RenderOptions): ReactNode {
       )
 
     case 'page-content':
-      // The slot must always span the full content area its layout exposes,
-      // regardless of how the surrounding container is aligned. Without an
-      // explicit `width: 100%`, a parent like `Container { align: center }`
-      // (very common: an admin who wants their card centred) collapses the
-      // slot to the page tree's intrinsic width — so even a `width: 100%`
-      // div inside the page would only stretch to whatever its siblings
-      // happen to be, not to the layout's actual horizontal real estate.
-      // `align-self: stretch` covers the flex-child case in one go.
       return (
         <div
           key={node.id}
           data-portal-page-content
-          style={{ width: '100%', alignSelf: 'stretch' }}
+          style={pageContentStyle(node)}
         >
           {options.pageContent ?? null}
         </div>
@@ -1091,6 +1083,33 @@ export function cardFooterStyle(node: BuilderNode): CSSProperties {
     justifyContent: (node.props.justifyContent as string) || 'flex-end',
     alignItems: (node.props.alignItems as string) || 'center',
     gap: (node.props.gap as string) || '8px',
+  }
+}
+
+/**
+ * The slot the page is rendered into.
+ *
+ * It spans the full content area its layout exposes whatever the surrounding
+ * container does: without an explicit `width: 100%`, a parent like
+ * `Container { align: center }` — very common, an admin centring their card —
+ * collapses the slot to the page's intrinsic width. `align-self: stretch`
+ * covers the flex-child case in one go.
+ *
+ * It also fills the viewport by default, so a page lands on a surface it can
+ * centre things in rather than one that hugs its content. Both minimums are
+ * plain props, so an author who wants the slot to hug its content again just
+ * clears them.
+ */
+export function pageContentStyle(node: BuilderNode): CSSProperties {
+  return {
+    width: '100%',
+    alignSelf: 'stretch',
+    minHeight: (node.props.minHeight as string) || '100vh',
+    minWidth: (node.props.minWidth as string) || '100vw',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: (node.props.justifyContent as string) || 'center',
+    alignItems: (node.props.alignItems as string) || 'center',
   }
 }
 

--- a/front/src/lib/builder-portal/renderer.tsx
+++ b/front/src/lib/builder-portal/renderer.tsx
@@ -1139,7 +1139,18 @@ export function pageContentStyle(node: BuilderNode): CSSProperties {
 function fillStyle(node: BuilderNode, options: RenderOptions): CSSProperties {
   if (!options.fillPath?.has(node.id)) return {}
   if (node.props.flexGrow !== undefined && node.props.flexGrow !== '') return {}
-  return { flexGrow: 1, minHeight: 0 }
+
+  // Growing is only half the job: a `div` defaults to `display: block`, whose
+  // children are not flex items, so the slot inside would stay content-height
+  // no matter how tall its ancestor grew. Give an ancestor that never chose a
+  // display one that passes the height down; an explicit choice is left alone.
+  const display = (node.props.display as string) || ''
+  const layout: CSSProperties =
+    display === '' && node.type !== 'container'
+      ? { display: 'flex', flexDirection: 'column' }
+      : {}
+
+  return { ...layout, flexGrow: 1, minHeight: 0 }
 }
 
 /**

--- a/front/src/lib/builder-portal/renderer.tsx
+++ b/front/src/lib/builder-portal/renderer.tsx
@@ -63,10 +63,16 @@ type RenderOptions = {
    * `cursor: wait` and dim the button.
    */
   isSubmitting?: boolean
+  /**
+   * Blocks on the path to the page slot, stretched so the slot has room to
+   * take. Computed by `treeToReactNode`; callers never pass it.
+   */
+  fillPath?: Set<string>
 }
 
 export function treeToReactNode(tree: BuilderNode[], options: RenderOptions = {}): ReactNode {
-  return tree.map((node) => renderNode(node, options))
+  const fillPath = options.fillPath ?? pathToPageContent(tree)
+  return tree.map((node) => renderNode(node, { ...options, fillPath }))
 }
 
 /**
@@ -87,7 +93,11 @@ function renderNode(node: BuilderNode, options: RenderOptions): ReactNode {
   switch (node.type) {
     case 'container':
       return (
-        <div key={node.id} {...idAttr} style={containerStyle(node)}>
+        <div
+          key={node.id}
+          {...idAttr}
+          style={{ ...containerStyle(node), ...fillStyle(node, options) }}
+        >
           {node.children.length > 0
             ? node.children.map((c) => renderNode(c, options))
             : null}
@@ -102,7 +112,11 @@ function renderNode(node: BuilderNode, options: RenderOptions): ReactNode {
     case 'grid':
     case 'div':
       return (
-        <div key={node.id} {...idAttr} style={divStyle(node)}>
+        <div
+          key={node.id}
+          {...idAttr}
+          style={{ ...divStyle(node), ...fillStyle(node, options) }}
+        >
           {node.children.length > 0
             ? node.children.map((c) => renderNode(c, options))
             : null}
@@ -1104,13 +1118,52 @@ export function pageContentStyle(node: BuilderNode): CSSProperties {
   return {
     width: '100%',
     alignSelf: 'stretch',
-    minHeight: (node.props.minHeight as string) || '100vh',
-    minWidth: (node.props.minWidth as string) || '100vw',
+    // `flex: 1` and not `min-height: 100vh`: the slot has siblings — a header,
+    // a footer — and an absolute height would stack on top of theirs and push
+    // the page into a scrollbar. Taking the leftover room fills the viewport
+    // exactly, whatever surrounds it.
+    flex: '1 1 auto',
+    minHeight: (node.props.minHeight as string) || 0,
+    minWidth: (node.props.minWidth as string) || undefined,
     display: 'flex',
     flexDirection: 'column',
     justifyContent: (node.props.justifyContent as string) || 'center',
     alignItems: (node.props.alignItems as string) || 'center',
   }
+}
+
+/**
+ * Stretches a block that sits between the root and the page slot, unless its
+ * author already said how it should behave.
+ */
+function fillStyle(node: BuilderNode, options: RenderOptions): CSSProperties {
+  if (!options.fillPath?.has(node.id)) return {}
+  if (node.props.flexGrow !== undefined && node.props.flexGrow !== '') return {}
+  return { flexGrow: 1, minHeight: 0 }
+}
+
+/**
+ * Ids of the blocks between the tree's root and the page slot.
+ *
+ * "Leftover room" only exists if every ancestor of the slot claims it too —
+ * a flex child that doesn't grow hands its children nothing to share. Rather
+ * than asking an author to tick "fill" on each level, the renderer walks the
+ * path once and stretches it.
+ */
+function pathToPageContent(tree: BuilderNode[]): Set<string> {
+  const path = new Set<string>()
+
+  const walk = (nodes: BuilderNode[], ancestors: string[]): boolean =>
+    nodes.some((node) => {
+      if (node.type === 'page-content') {
+        ancestors.forEach((id) => path.add(id))
+        return true
+      }
+      return walk(node.children, [...ancestors, node.id])
+    })
+
+  walk(tree, [])
+  return path
 }
 
 export function containerStyle(node: BuilderNode): CSSProperties {

--- a/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
+++ b/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
@@ -10,6 +10,7 @@ import {
   cardHeaderStyle,
   cardStyle,
   containerStyle,
+  pageContentStyle,
   divStyle,
   forgotPasswordLinkStyle,
   headingStyle,
@@ -692,24 +693,16 @@ function EditableRegisterLink({
   )
 }
 
-function PageContentSlot({ isSelected }: { node: BuilderNode; isSelected: boolean }) {
+function PageContentSlot({ node, isSelected }: { node: BuilderNode; isSelected: boolean }) {
   return (
     <div
       style={{
         ...chromeStyle(isSelected),
-        // Mirror the runtime stretch behaviour (`<div data-portal-page-content>`
-        // is rendered with `width: 100%` + `align-self: stretch`), otherwise
-        // the layout builder paints a content-width placeholder while the
-        // live portal renders full-width — and the admin can't tell the two
-        // apart until they ship.
-        width: '100%',
-        alignSelf: 'stretch',
+        // The placeholder is drawn with the slot's own runtime style, so the
+        // builder shows the surface the page will actually get instead of a
+        // content-sized box the admin only discovers is wrong once shipped.
+        ...pageContentStyle(node),
         boxSizing: 'border-box',
-        minHeight: 120,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
         gap: 8,
         padding: 24,
         borderRadius: 4,

--- a/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
+++ b/front/src/lib/builder-portal/visual-blocks/visual-block-registry.tsx
@@ -10,7 +10,6 @@ import {
   cardHeaderStyle,
   cardStyle,
   containerStyle,
-  pageContentStyle,
   divStyle,
   forgotPasswordLinkStyle,
   headingStyle,
@@ -693,16 +692,27 @@ function EditableRegisterLink({
   )
 }
 
-function PageContentSlot({ node, isSelected }: { node: BuilderNode; isSelected: boolean }) {
+function PageContentSlot({ isSelected }: { node: BuilderNode; isSelected: boolean }) {
   return (
     <div
       style={{
         ...chromeStyle(isSelected),
-        // The placeholder is drawn with the slot's own runtime style, so the
-        // builder shows the surface the page will actually get instead of a
-        // content-sized box the admin only discovers is wrong once shipped.
-        ...pageContentStyle(node),
+        // Mirror the runtime stretch behaviour (`<div data-portal-page-content>`
+        // is rendered with `width: 100%` + `align-self: stretch`), otherwise
+        // the layout builder paints a content-width placeholder while the
+        // live portal renders full-width — and the admin can't tell the two
+        // apart until they ship. The runtime slot also grows into whatever
+        // room is left; here a fixed minimum keeps the drop zone reachable
+        // in an otherwise empty layout.
+        width: '100%',
+        alignSelf: 'stretch',
+        flex: '1 1 auto',
         boxSizing: 'border-box',
+        minHeight: 120,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
         gap: 8,
         padding: 24,
         borderRadius: 4,

--- a/front/src/pages/authentication/components/portal-layout-wrapper.tsx
+++ b/front/src/pages/authentication/components/portal-layout-wrapper.tsx
@@ -342,6 +342,28 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
     <style dangerouslySetInnerHTML={{ __html: buttonInteractionCss }} />
   )
 
+  /**
+   * The page the portal is drawn on.
+   *
+   * The theme has always exposed a page background, but only the loading state
+   * ever painted it — every finished screen rendered on whatever the browser
+   * happened to show, which is why a layout shorter than the viewport left a
+   * bare strip below itself. Giving the root the theme's colour and the full
+   * viewport height makes that setting mean something, and gives a layout a
+   * page to fill.
+   *
+   * `flex column` is what lets a layout opt into filling the leftover height
+   * (see the container's `flexGrow`); with a single child it changes nothing
+   * for layouts that don't ask.
+   */
+  const pageSurface: CSSProperties = {
+    ...cssVars,
+    minHeight: '100vh',
+    background: 'var(--fk-color-page-bg)',
+    display: 'flex',
+    flexDirection: 'column',
+  }
+
   // The layout is only renderable when it has a `page-content` slot.
   // Without one, applying it would hide the page entirely.
   const layoutIsValid = layoutTree.length > 0 && layoutHasPageContent(layoutTree)
@@ -370,7 +392,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
         <style dangerouslySetInnerHTML={{ __html: verifiedStyleCss }} />
       ) : null
       return (
-        <div style={cssVars} onClick={handlePortalActionClick}>
+        <div style={pageSurface} onClick={handlePortalActionClick}>
           {verifiedStyle}
           {buttonInteractionStyle}
           {layoutIsValid
@@ -384,7 +406,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
       )
     }
     return (
-      <div style={cssVars}>
+      <div style={pageSurface}>
         <DeviceVerifyShell>
           <DeviceVerifyResult
             status={deviceResult}
@@ -397,7 +419,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
 
   if (!pageIsValid || (layoutTree.length > 0 && !layoutIsValid)) {
     return (
-      <div style={cssVars}>
+      <div style={pageSurface}>
         {responsiveStyle}
         {buttonInteractionStyle}
         {children}
@@ -413,7 +435,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
 
   if (!layoutIsValid) {
     return (
-      <div style={cssVars} onClick={handlePortalActionClick}>
+      <div style={pageSurface} onClick={handlePortalActionClick}>
         {responsiveStyle}
         {buttonInteractionStyle}
         {pageContent}
@@ -422,7 +444,7 @@ export function PortalLayoutWrapper({ children, pageType }: Props) {
   }
 
   return (
-    <div style={cssVars} onClick={handlePortalActionClick}>
+    <div style={pageSurface} onClick={handlePortalActionClick}>
       {responsiveStyle}
       {buttonInteractionStyle}
       {treeToReactNode(layoutTree, { runtime: true, pageContent, identityProviders, totpSetup, deviceConsent, formError, isSubmitting })}

--- a/front/src/pages/portal-layouts/ui/page-portal-layout-builder.tsx
+++ b/front/src/pages/portal-layouts/ui/page-portal-layout-builder.tsx
@@ -196,7 +196,7 @@ export default function PagePortalLayoutBuilder({
                       iframeRectRef.current = rect
                     }}
                   >
-                    <Canvas maxWidth={viewportWidth} />
+                    <Canvas maxWidth={viewportWidth} padded={false} />
                   </CanvasFrame>
                 </div>
               </div>


### PR DESCRIPTION
Two commits: the first gives the portal a page to fill, the second gives a layout the means to lay itself out on it.

**The theme paints the page.** The theme has always exposed a page background and nothing ever painted it — only the loading state used the token, so a layout shorter than the viewport left a strip of unstyled page below it. The root now carries the theme's colour and a full viewport height, the same treatment the loading state already applied. All five returns share one style object so the background does not flicker between screens.

**The root block can lay out its content.** A container could only be a flex column that hugged its content: no main-axis placement, no way to use the height the page now offers. It gains `display`, `justifyContent` and `flexGrow` (offered as "Fill page height"), all optional. Unset, they resolve to `undefined`, so a container already in the database renders exactly as before — verified on a themed portal, where the card keeps its own height while the root centres it, no scrollbar.

`Canvas` also gains `padded`, used only by the layout builder: its `p-6` is editor chrome, and a root filling the viewport would have overflowed by exactly that much.

⚠️ This changes how existing portals look, deliberately: a realm that never touched the setting moves from the browser's white to the theme default, which is black (`theme.ts:34`). Worth checking what `pageBackground` holds across realms first, and deciding whether that default should be a neutral.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added layout controls for display mode, alignment, and full-height behavior.
  - Added page content sizing and alignment options, including minimum width and height.
  - Page content now supports flexible sizing and centered positioning by default.

- **Improvements**
  - Layouts fill available viewport height more reliably.
  - Portal backgrounds extend consistently across the full screen.
  - Builder canvas previews can use the full device width without extra padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->