### PR TITLE
fix: tell the user what is wrong with their password, where they typed it

### DIFF
--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -2,6 +2,7 @@ import { toast } from 'sonner'
 import { type Fetcher } from '@/api/api.client.ts'
 import { authRefreshController } from '@/hooks/auth-refresh-controller.ts'
 import { authStore } from '@/store/auth.store.ts'
+import { errorMessageFromBody } from '@/lib/api-error.ts'
 
 export interface BaseQuery {
   realm?: string
@@ -167,7 +168,7 @@ export const fetcher: Fetcher['fetch'] = async (input) => {
     }
 
     const error: Error & { status?: number; data?: Record<string, unknown> } = new Error(
-      (errorBody?.message as string) ?? `HTTP ${response.status}: ${response.statusText}`,
+      errorMessageFromBody(errorBody) ?? `HTTP ${response.status}: ${response.statusText}`,
     )
     error.status = response.status
     error.data = errorBody

--- a/front/src/lib/api-error.ts
+++ b/front/src/lib/api-error.ts
@@ -1,13 +1,65 @@
-interface FieldValidationError {
+/**
+ * One entry of a 422 body (`ValidationErrorResponse` on the API side):
+ * `{ errors: [{ field, message }] }`. `field` names the request field the
+ * message belongs to, which is what lets a form show it under the right
+ * input instead of in a toast.
+ */
+export interface FieldValidationError {
   field: string
   message: string
 }
 
-export function apiErrorMessage(error: unknown, fallback: string): string {
-  const data = (error as { data?: { errors?: FieldValidationError[] } } | null)?.data
-  const fieldErrors = data?.errors
+/** The error our `fetcher` throws on a non-2xx response. */
+export interface ApiRequestError extends Error {
+  status?: number
+  data?: Record<string, unknown>
+}
 
-  if (Array.isArray(fieldErrors) && fieldErrors.length > 0) {
+/** Read the `errors` array out of a parsed error body, ignoring malformed entries. */
+export function validationErrorsFromBody(body: unknown): FieldValidationError[] {
+  const errors = (body as { errors?: unknown } | null | undefined)?.errors
+  if (!Array.isArray(errors)) return []
+  return errors.filter(
+    (entry): entry is FieldValidationError =>
+      typeof entry === 'object' &&
+      entry !== null &&
+      typeof (entry as FieldValidationError).field === 'string' &&
+      typeof (entry as FieldValidationError).message === 'string'
+  )
+}
+
+/**
+ * Pull the per-field validation errors out of a thrown request error, so a
+ * form can attach each message to the input that caused it.
+ */
+export function validationErrorsFrom(error: unknown): FieldValidationError[] {
+  return validationErrorsFromBody((error as ApiRequestError | null | undefined)?.data)
+}
+
+/**
+ * Turn a parsed error body into a sentence worth showing. The API speaks
+ * three dialects — `{ message }`, RFC 6749's `{ error_description }`, and a
+ * 422's `{ errors: [...] }` — and the fetcher used to read only the first,
+ * so a rejected password surfaced as "HTTP 422: Unprocessable Entity"
+ * (issue #1302).
+ */
+export function errorMessageFromBody(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined
+  const { message, error_description: errorDescription } = body as Record<string, unknown>
+
+  if (typeof message === 'string' && message.length > 0) return message
+  if (typeof errorDescription === 'string' && errorDescription.length > 0) {
+    return errorDescription
+  }
+
+  const messages = validationErrorsFromBody(body).map((error) => error.message)
+  return messages.length > 0 ? messages.join(' — ') : undefined
+}
+
+export function apiErrorMessage(error: unknown, fallback: string): string {
+  const fieldErrors = validationErrorsFrom(error)
+
+  if (fieldErrors.length > 0) {
     return fieldErrors.map((fieldError) => fieldError.message).join(' — ')
   }
 

--- a/front/src/lib/api-error.ts
+++ b/front/src/lib/api-error.ts
@@ -1,21 +1,13 @@
-/**
- * One entry of a 422 body (`ValidationErrorResponse` on the API side):
- * `{ errors: [{ field, message }] }`. `field` names the request field the
- * message belongs to, which is what lets a form show it under the right
- * input instead of in a toast.
- */
 export interface FieldValidationError {
   field: string
   message: string
 }
 
-/** The error our `fetcher` throws on a non-2xx response. */
 export interface ApiRequestError extends Error {
   status?: number
   data?: Record<string, unknown>
 }
 
-/** Read the `errors` array out of a parsed error body, ignoring malformed entries. */
 export function validationErrorsFromBody(body: unknown): FieldValidationError[] {
   const errors = (body as { errors?: unknown } | null | undefined)?.errors
   if (!Array.isArray(errors)) return []
@@ -28,21 +20,10 @@ export function validationErrorsFromBody(body: unknown): FieldValidationError[] 
   )
 }
 
-/**
- * Pull the per-field validation errors out of a thrown request error, so a
- * form can attach each message to the input that caused it.
- */
 export function validationErrorsFrom(error: unknown): FieldValidationError[] {
   return validationErrorsFromBody((error as ApiRequestError | null | undefined)?.data)
 }
 
-/**
- * Turn a parsed error body into a sentence worth showing. The API speaks
- * three dialects — `{ message }`, RFC 6749's `{ error_description }`, and a
- * 422's `{ errors: [...] }` — and the fetcher used to read only the first,
- * so a rejected password surfaced as "HTTP 422: Unprocessable Entity"
- * (issue #1302).
- */
 export function errorMessageFromBody(body: unknown): string | undefined {
   if (!body || typeof body !== 'object') return undefined
   const { message, error_description: errorDescription } = body as Record<string, unknown>

--- a/front/src/lib/password-policy.ts
+++ b/front/src/lib/password-policy.ts
@@ -1,14 +1,6 @@
 import { z } from 'zod'
 import { DEFAULT_PASSWORD_POLICY, type PublicPasswordPolicy } from '@/api/password-policy.api'
 
-/**
- * One rule of the realm's password policy, in the two shapes the UI needs:
- * a short `label` for the live checklist shown under the input, and a full
- * `message` for the validation error shown when the form is submitted.
- *
- * Both the zod schema and the checklist are derived from this same list, so
- * they can never disagree about what the realm actually requires.
- */
 export interface PasswordRequirement {
   id: string
   label: string
@@ -16,12 +8,6 @@ export interface PasswordRequirement {
   isMet: (password: string) => boolean
 }
 
-/**
- * The rules we can check in the browser. Entropy, common-password and breach
- * checks are deliberately absent: they need the backend's estimator and word
- * lists, so they are enforced server-side and surface as API errors on the
- * field.
- */
 export function passwordPolicyRequirements(
   policy?: PublicPasswordPolicy
 ): PasswordRequirement[] {
@@ -72,17 +58,9 @@ export function passwordPolicyRequirements(
   return requirements
 }
 
-/**
- * Build the zod field for a new password from the realm's policy. Every
- * unmet requirement is reported, not just the first, so a user who is two
- * rules away learns both at once.
- */
 export function buildPasswordField(policy?: PublicPasswordPolicy) {
   const requirements = passwordPolicyRequirements(policy)
 
-  // The upper bound is not a policy rule — it is a guard against a
-  // megabyte-sized string reaching the hasher — so it stays out of the
-  // requirement list the checklist renders.
   return z
     .string()
     .max(100, { message: 'Password must be at most 100 characters long' })

--- a/front/src/lib/password-policy.ts
+++ b/front/src/lib/password-policy.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod'
+import { DEFAULT_PASSWORD_POLICY, type PublicPasswordPolicy } from '@/api/password-policy.api'
+
+/**
+ * One rule of the realm's password policy, in the two shapes the UI needs:
+ * a short `label` for the live checklist shown under the input, and a full
+ * `message` for the validation error shown when the form is submitted.
+ *
+ * Both the zod schema and the checklist are derived from this same list, so
+ * they can never disagree about what the realm actually requires.
+ */
+export interface PasswordRequirement {
+  id: string
+  label: string
+  message: string
+  isMet: (password: string) => boolean
+}
+
+/**
+ * The rules we can check in the browser. Entropy, common-password and breach
+ * checks are deliberately absent: they need the backend's estimator and word
+ * lists, so they are enforced server-side and surface as API errors on the
+ * field.
+ */
+export function passwordPolicyRequirements(
+  policy?: PublicPasswordPolicy
+): PasswordRequirement[] {
+  const minLength = policy?.min_length ?? DEFAULT_PASSWORD_POLICY.min_length
+
+  const requirements: PasswordRequirement[] = [
+    {
+      id: 'length',
+      label: `At least ${minLength} characters`,
+      message: `Password must be at least ${minLength} characters long`,
+      isMet: (password) => password.length >= minLength,
+    },
+  ]
+
+  if (policy?.require_uppercase) {
+    requirements.push({
+      id: 'uppercase',
+      label: 'One uppercase letter',
+      message: 'Password must contain at least one uppercase letter',
+      isMet: (password) => /[A-Z]/.test(password),
+    })
+  }
+  if (policy?.require_lowercase) {
+    requirements.push({
+      id: 'lowercase',
+      label: 'One lowercase letter',
+      message: 'Password must contain at least one lowercase letter',
+      isMet: (password) => /[a-z]/.test(password),
+    })
+  }
+  if (policy?.require_number) {
+    requirements.push({
+      id: 'number',
+      label: 'One number',
+      message: 'Password must contain at least one number',
+      isMet: (password) => /[0-9]/.test(password),
+    })
+  }
+  if (policy?.require_special) {
+    requirements.push({
+      id: 'special',
+      label: 'One special character',
+      message: 'Password must contain at least one special character',
+      isMet: (password) => /[^A-Za-z0-9]/.test(password),
+    })
+  }
+
+  return requirements
+}
+
+/**
+ * Build the zod field for a new password from the realm's policy. Every
+ * unmet requirement is reported, not just the first, so a user who is two
+ * rules away learns both at once.
+ */
+export function buildPasswordField(policy?: PublicPasswordPolicy) {
+  const requirements = passwordPolicyRequirements(policy)
+
+  // The upper bound is not a policy rule — it is a guard against a
+  // megabyte-sized string reaching the hasher — so it stays out of the
+  // requirement list the checklist renders.
+  return z
+    .string()
+    .max(100, { message: 'Password must be at most 100 characters long' })
+    .superRefine((password, ctx) => {
+      for (const requirement of requirements) {
+        if (requirement.isMet(password)) continue
+        ctx.addIssue({ code: 'custom', message: requirement.message })
+      }
+    })
+}

--- a/front/src/pages/authentication/feature/execution/update-password-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/update-password-feature.tsx
@@ -17,12 +17,6 @@ import { usePublicPasswordPolicy } from '@/api/password-policy.api'
 import { passwordPolicyRequirements } from '@/lib/password-policy'
 import { validationErrorsFrom } from '@/lib/api-error'
 
-/**
- * The API reports policy violations against the request field it validated
- * (`password`, or `value` on the update-password payload). Both mean the new
- * password input on this form; anything else has no matching input and falls
- * back to a toast.
- */
 const FIELD_BY_API_FIELD: Record<string, keyof UpdatePasswordSchema> = {
   password: 'password',
   value: 'password',
@@ -58,10 +52,6 @@ export default function UpdatePasswordFeature() {
         },
       },
       {
-        // A rejected password comes back as a 422 listing one message per
-        // broken rule. Attach each one to its input so the user sees what to
-        // fix where they typed it — a toast alone left the form looking
-        // untouched, which read as "nothing happened" (issue #1302).
         onError: (error) => {
           const fieldErrors = validationErrorsFrom(error)
           const unattached: string[] = []

--- a/front/src/pages/authentication/feature/execution/update-password-feature.tsx
+++ b/front/src/pages/authentication/feature/execution/update-password-feature.tsx
@@ -4,13 +4,29 @@ import UpdatePassword from '@/pages/authentication/ui/execution/update-password.
 import { useUpdatePassword } from '@/api/trident.api'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { updatePasswordSchema, UpdatePasswordSchema } from '../../schemas/update-password.schema'
+import {
+  buildUpdatePasswordSchema,
+  UpdatePasswordSchema,
+} from '../../schemas/update-password.schema'
 import { Form } from '@/components/ui/form'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
 import { useAuthenticateMutation } from '@/api/auth.api'
 import { AuthenticationStatus } from '@/api/api.interface'
+import { usePublicPasswordPolicy } from '@/api/password-policy.api'
+import { passwordPolicyRequirements } from '@/lib/password-policy'
+import { validationErrorsFrom } from '@/lib/api-error'
 
+/**
+ * The API reports policy violations against the request field it validated
+ * (`password`, or `value` on the update-password payload). Both mean the new
+ * password input on this form; anything else has no matching input and falls
+ * back to a toast.
+ */
+const FIELD_BY_API_FIELD: Record<string, keyof UpdatePasswordSchema> = {
+  password: 'password',
+  value: 'password',
+}
 
 export default function UpdatePasswordFeature() {
   const { realm_name } = useParams<RouterParams>()
@@ -18,8 +34,15 @@ export default function UpdatePasswordFeature() {
   const { mutate: authenticate, data: authenticateResponse } = useAuthenticateMutation()
   const navigate = useNavigate()
 
+  const { data: passwordPolicy } = usePublicPasswordPolicy(realm_name)
+  const schema = useMemo(() => buildUpdatePasswordSchema(passwordPolicy), [passwordPolicy])
+  const requirements = useMemo(
+    () => passwordPolicyRequirements(passwordPolicy),
+    [passwordPolicy]
+  )
+
   const form = useForm<UpdatePasswordSchema>({
-    resolver: zodResolver(updatePasswordSchema),
+    resolver: zodResolver(schema),
     defaultValues: {
       password: '',
       confirmPassword: ''
@@ -35,8 +58,28 @@ export default function UpdatePasswordFeature() {
         },
       },
       {
+        // A rejected password comes back as a 422 listing one message per
+        // broken rule. Attach each one to its input so the user sees what to
+        // fix where they typed it — a toast alone left the form looking
+        // untouched, which read as "nothing happened" (issue #1302).
         onError: (error) => {
-          toast.error(error.message || 'Failed to update your password')
+          const fieldErrors = validationErrorsFrom(error)
+          const unattached: string[] = []
+
+          for (const fieldError of fieldErrors) {
+            const field = FIELD_BY_API_FIELD[fieldError.field]
+            if (field) {
+              form.setError(field, { type: 'server', message: fieldError.message })
+            } else {
+              unattached.push(fieldError.message)
+            }
+          }
+
+          if (fieldErrors.length === 0 || unattached.length > 0) {
+            toast.error(
+              unattached.join(' — ') || error.message || 'Failed to update your password'
+            )
+          }
         },
       }
     )
@@ -74,7 +117,7 @@ export default function UpdatePasswordFeature() {
 
   return (
     <Form {...form}>
-      <UpdatePassword handleClick={handleClick} />
+      <UpdatePassword handleClick={handleClick} requirements={requirements} />
     </Form>
   )
 }

--- a/front/src/pages/authentication/schemas/update-password.schema.ts
+++ b/front/src/pages/authentication/schemas/update-password.schema.ts
@@ -1,13 +1,26 @@
 import { z } from 'zod'
+import type { PublicPasswordPolicy } from '@/api/password-policy.api'
+import { buildPasswordField } from '@/lib/password-policy'
 
-export const updatePasswordSchema = z
-  .object({
-    password: z.string().min(1).max(100),
-    confirmPassword: z.string().min(1).max(100),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: 'Password must match',
-    path: ['confirmPassword'],
-  })
+/**
+ * The forced-rotation form (a user landing here has a temporary password).
+ * Rules come from the realm's public password policy so the screen refuses
+ * what the backend would refuse, instead of letting the user discover it
+ * one round-trip later.
+ */
+export function buildUpdatePasswordSchema(policy?: PublicPasswordPolicy) {
+  return z
+    .object({
+      password: buildPasswordField(policy),
+      confirmPassword: z.string().min(1, { message: 'Confirm your new password' }),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: 'Password must match',
+      path: ['confirmPassword'],
+    })
+}
+
+// Default schema (no policy) — kept so the inferred type stays stable across the app.
+export const updatePasswordSchema = buildUpdatePasswordSchema()
 
 export type UpdatePasswordSchema = z.infer<typeof updatePasswordSchema>

--- a/front/src/pages/authentication/schemas/update-password.schema.ts
+++ b/front/src/pages/authentication/schemas/update-password.schema.ts
@@ -2,12 +2,6 @@ import { z } from 'zod'
 import type { PublicPasswordPolicy } from '@/api/password-policy.api'
 import { buildPasswordField } from '@/lib/password-policy'
 
-/**
- * The forced-rotation form (a user landing here has a temporary password).
- * Rules come from the realm's public password policy so the screen refuses
- * what the backend would refuse, instead of letting the user discover it
- * one round-trip later.
- */
 export function buildUpdatePasswordSchema(policy?: PublicPasswordPolicy) {
   return z
     .object({
@@ -20,7 +14,6 @@ export function buildUpdatePasswordSchema(policy?: PublicPasswordPolicy) {
     })
 }
 
-// Default schema (no policy) — kept so the inferred type stays stable across the app.
 export const updatePasswordSchema = buildUpdatePasswordSchema()
 
 export type UpdatePasswordSchema = z.infer<typeof updatePasswordSchema>

--- a/front/src/pages/authentication/ui/execution/update-password.tsx
+++ b/front/src/pages/authentication/ui/execution/update-password.tsx
@@ -3,16 +3,24 @@ import { InputText } from '@/components/ui/input-text.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { FormField } from '@/components/ui/form'
 import { useFormContext } from 'react-hook-form'
+import { Check, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { PasswordRequirement } from '@/lib/password-policy'
 import { UpdatePasswordSchema } from '../../schemas/update-password.schema'
 import '../page-login.css'
 
 export interface UpdatePasswordProps {
   handleClick: () => void
+  /** The realm's password rules, checked live against what the user types. */
+  requirements: PasswordRequirement[]
 }
 
-export default function UpdatePassword({ handleClick }: UpdatePasswordProps) {
+export default function UpdatePassword({ handleClick, requirements }: UpdatePasswordProps) {
   const form = useFormContext<UpdatePasswordSchema>()
   const isPending = form.formState.isSubmitting
+  // Watched rather than read from `getValues`, so the checklist re-renders on
+  // every keystroke instead of only on submit.
+  const password = form.watch('password') ?? ''
 
   return (
     <div className='login-shell relative flex min-h-svh items-center justify-center px-6 py-10'>
@@ -58,6 +66,33 @@ export default function UpdatePassword({ handleClick }: UpdatePasswordProps) {
                             />
                           )}
                         />
+                        {requirements.length > 0 && (
+                          <ul className='flex flex-col gap-1.5' aria-label='Password requirements'>
+                            {requirements.map((requirement) => {
+                              const isMet = requirement.isMet(password)
+
+                              return (
+                                <li
+                                  key={requirement.id}
+                                  className={cn(
+                                    'flex items-center gap-2 text-xs transition-colors',
+                                    isMet ? 'text-emerald-600' : 'text-muted-foreground'
+                                  )}
+                                >
+                                  {isMet ? (
+                                    <Check className='h-3.5 w-3.5 shrink-0' aria-hidden />
+                                  ) : (
+                                    <X className='h-3.5 w-3.5 shrink-0' aria-hidden />
+                                  )}
+                                  <span>{requirement.label}</span>
+                                  <span className='sr-only'>
+                                    {isMet ? '(met)' : '(not met yet)'}
+                                  </span>
+                                </li>
+                              )
+                            })}
+                          </ul>
+                        )}
                       </div>
                       <div className='grid gap-3'>
                         <FormField

--- a/front/src/pages/authentication/ui/execution/update-password.tsx
+++ b/front/src/pages/authentication/ui/execution/update-password.tsx
@@ -11,15 +11,12 @@ import '../page-login.css'
 
 export interface UpdatePasswordProps {
   handleClick: () => void
-  /** The realm's password rules, checked live against what the user types. */
   requirements: PasswordRequirement[]
 }
 
 export default function UpdatePassword({ handleClick, requirements }: UpdatePasswordProps) {
   const form = useFormContext<UpdatePasswordSchema>()
   const isPending = form.formState.isSubmitting
-  // Watched rather than read from `getValues`, so the checklist re-renders on
-  // every keystroke instead of only on submit.
   const password = form.watch('password') ?? ''
 
   return (

--- a/front/src/pages/user/schemas/index.ts
+++ b/front/src/pages/user/schemas/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import type { PublicPasswordPolicy } from '@/api/password-policy.api'
+import { buildPasswordField } from '@/lib/password-policy'
 
 /**
  * Build the reset-password validation schema from the realm's actual password policy
@@ -8,36 +9,9 @@ import type { PublicPasswordPolicy } from '@/api/password-policy.api'
  * (they need the entropy estimator / common-password list) and surface as API errors.
  */
 export function buildSetCredentialPasswordSchema(policy?: PublicPasswordPolicy) {
-  const minLength = policy?.min_length ?? 8
-
-  let password = z.string().min(minLength, {
-    message: `Password must be at least ${minLength} characters long`,
-  })
-
-  if (policy?.require_uppercase) {
-    password = password.regex(/[A-Z]/, {
-      message: 'Password must contain at least one uppercase letter',
-    })
-  }
-  if (policy?.require_lowercase) {
-    password = password.regex(/[a-z]/, {
-      message: 'Password must contain at least one lowercase letter',
-    })
-  }
-  if (policy?.require_number) {
-    password = password.regex(/[0-9]/, {
-      message: 'Password must contain at least one number',
-    })
-  }
-  if (policy?.require_special) {
-    password = password.regex(/[^A-Za-z0-9]/, {
-      message: 'Password must contain at least one special character',
-    })
-  }
-
   return z
     .object({
-      password,
+      password: buildPasswordField(policy),
       confirmPassword: z.string(),
       temporary: z.boolean(),
     })

--- a/libs/ferriskey-password-policy/src/error.rs
+++ b/libs/ferriskey-password-policy/src/error.rs
@@ -52,14 +52,15 @@ impl Display for PasswordPolicyError {
             PasswordPolicyError::MissingSpecialCharacter => {
                 write!(f, "Password must contain at least one special character")
             }
-            PasswordPolicyError::InsufficientEntropy {
-                min_bits,
-                actual_bits,
-            } => {
+            // Deliberately jargon-free: this string is rendered as-is on the
+            // login and update-password screens. The bit counts stay on the
+            // variant for logs and tests, but telling an end user their
+            // password has "47.6 bits of entropy" tells them nothing about
+            // what to type instead — see issue #1302.
+            PasswordPolicyError::InsufficientEntropy { .. } => {
                 write!(
                     f,
-                    "Password entropy is too low: {:.1} bits (minimum {:.1} bits required)",
-                    actual_bits, min_bits
+                    "Password is not strong enough. Make it longer, or mix uppercase and lowercase letters, numbers and symbols"
                 )
             }
             PasswordPolicyError::CommonPassword => {
@@ -92,5 +93,51 @@ impl From<&PasswordPolicyError> for PasswordPolicyViolation {
             code: e.code().to_string(),
             message: e.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PasswordPolicyError;
+
+    /// Policy messages are rendered verbatim to end users on the login /
+    /// update-password screens. "Entropy" and "bits" are cryptographic
+    /// vocabulary that means nothing to them, and the numbers are an
+    /// implementation detail of our estimator — see issue #1302.
+    #[test]
+    fn insufficient_entropy_message_avoids_cryptographic_jargon() {
+        let message = PasswordPolicyError::InsufficientEntropy {
+            min_bits: 80.0,
+            actual_bits: 47.6,
+        }
+        .to_string();
+
+        let lowered = message.to_lowercase();
+        assert!(
+            !lowered.contains("entropy"),
+            "message leaks the word entropy: {message}"
+        );
+        assert!(
+            !lowered.contains("bits"),
+            "message leaks a bit count: {message}"
+        );
+        assert!(
+            lowered.contains("strong"),
+            "message should tell the user what is wrong: {message}"
+        );
+    }
+
+    /// The `code` is the machine-readable half of the contract: clients may
+    /// branch on it, so rewording the human message must not move it.
+    #[test]
+    fn insufficient_entropy_code_is_stable() {
+        assert_eq!(
+            PasswordPolicyError::InsufficientEntropy {
+                min_bits: 80.0,
+                actual_bits: 47.6,
+            }
+            .code(),
+            "insufficient_entropy"
+        );
     }
 }

--- a/libs/ferriskey-password-policy/src/error.rs
+++ b/libs/ferriskey-password-policy/src/error.rs
@@ -52,11 +52,6 @@ impl Display for PasswordPolicyError {
             PasswordPolicyError::MissingSpecialCharacter => {
                 write!(f, "Password must contain at least one special character")
             }
-            // Deliberately jargon-free: this string is rendered as-is on the
-            // login and update-password screens. The bit counts stay on the
-            // variant for logs and tests, but telling an end user their
-            // password has "47.6 bits of entropy" tells them nothing about
-            // what to type instead — see issue #1302.
             PasswordPolicyError::InsufficientEntropy { .. } => {
                 write!(
                     f,
@@ -100,10 +95,6 @@ impl From<&PasswordPolicyError> for PasswordPolicyViolation {
 mod tests {
     use super::PasswordPolicyError;
 
-    /// Policy messages are rendered verbatim to end users on the login /
-    /// update-password screens. "Entropy" and "bits" are cryptographic
-    /// vocabulary that means nothing to them, and the numbers are an
-    /// implementation detail of our estimator — see issue #1302.
     #[test]
     fn insufficient_entropy_message_avoids_cryptographic_jargon() {
         let message = PasswordPolicyError::InsufficientEntropy {
@@ -127,8 +118,6 @@ mod tests {
         );
     }
 
-    /// The `code` is the machine-readable half of the contract: clients may
-    /// branch on it, so rewording the human message must not move it.
     #[test]
     fn insufficient_entropy_code_is_stable() {
         assert_eq!(


### PR DESCRIPTION
Closes #1302

## What was happening

Setting a weak password on the forced-rotation screen produced nothing. The request left, the API answered `422`, and the form came back looking untouched. The reporter read that as "the button does nothing".

Two separate defects stacked up:

1. **The message never left the response body.** `fetcher` built its `Error` from `body.message` alone. A `422` answers with `{ errors: [{ field, message }] }`, so the fallback fired and the caller received `"HTTP 422: Unprocessable Entity"` — a string naming the status and hiding the reason. OAuth's `{ error_description }` was dropped the same way.
2. **Even with a message, it had nowhere to go.** `UpdatePasswordFeature` only toasted. Nothing marked the field, so the form gave no sign it had rejected anything.

And the message itself, once recovered, was `Password entropy is too low: 47.6 bits (minimum 80.0 bits required)` — vocabulary from our estimator, describing how we measured the password rather than what to type instead.

## What changed

- **`libs/ferriskey-password-policy`** — `InsufficientEntropy` now renders as *"Password is not strong enough. Make it longer, or mix uppercase and lowercase letters, numbers and symbols"*. The `insufficient_entropy` code is untouched, and tests pin both halves: the message stays jargon-free, the code stays stable.
- **`front/src/lib/api-error.ts`** — one reader for the three dialects the API speaks (`message`, `error_description`, `errors[]`). It already held `apiErrorMessage`, which was unpacking the same `422` shape for SAML toasts; `validationErrorsFrom` now exposes the per-field entries.
- **`front/src/lib/password-policy.ts`** (new) — the realm's rules expressed once, each carrying a short label for a checklist and a full sentence for a validation error. The zod field is generated from that same list, so the two cannot drift. `pages/user/schemas` was rebuilt on it rather than restating the rules.
- **`UpdatePassword`** — API validation errors are attached to the input that caused them, and the realm's rules are listed under the field from the start, ticking green as the user types.

## Notes for the reviewer

- **Why the checklist and not a strength meter.** A meter would need `min_entropy_bits` in `/password-policy/public` plus a copy of the estimator in the browser, and the two implementations would disagree the first time either moved. The checklist shows only rules the browser can evaluate exactly. Entropy, common-password and breach checks stay server-side and surface on the field.
- **Every unmet rule is reported, not just the first** — a user two rules away learns both at once instead of one per submit.
- **`.max(100)` was preserved** when the schema moved to the shared builder; it is a guard against an oversized string reaching the hasher, not a policy rule, so it is deliberately absent from the checklist.
- **Not verified in a browser.** `cargo test -p ferriskey-password-policy` (28 passing), `tsc -b` and `pnpm run lint` are green, and `pnpm run build` succeeds — but the rendered checklist and the inline error have not been seen running. Worth a manual pass: set a temporary password, sign in, type a weak one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password update forms now reflect the realm’s configured password requirements.
  * Added a live checklist showing which password requirements are met while typing.
  * Password validation is shared across password creation and update flows.

* **Bug Fixes**
  * Server-side validation errors now appear on relevant password fields.
  * Improved handling of API error messages, including validation and authentication responses.

* **Improvements**
  * Updated insufficient-entropy messages with clearer, non-technical wording.
  * Added clearer confirmation guidance when entering a new password.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->