### PR TITLE
fix(seawatch): stop lying about the audit log's guarantees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,10 +1833,12 @@ name = "ferriskey-api-seawatch"
 version = "0.7.0"
 dependencies = [
  "axum",
+ "chrono",
  "ferriskey-api-core",
  "ferriskey-core",
  "serde",
  "utoipa",
+ "uuid",
 ]
 
 [[package]]

--- a/api/tests/seawatch_test.rs
+++ b/api/tests/seawatch_test.rs
@@ -1,0 +1,316 @@
+/// Integration tests for the SeaWatch audit log (#1270).
+///
+/// These pin two things that were previously broken:
+/// - every stored event is actually linked into the tamper-evident hash chain
+///   (`event_hash`/`prev_hash` are populated, not left NULL)
+/// - `GET .../seawatch/v1/security-events` actually applies the query filter
+///   it's given instead of always returning the unfiltered first page
+///
+/// Require a running PostgreSQL instance. Marked `#[ignore]` so they don't
+/// block regular `cargo test` runs. Run them explicitly with:
+///
+///   cargo test -p ferriskey-api --test seawatch_test -- --ignored
+///
+/// Environment variables (defaults shown):
+///   DATABASE_HOST     = localhost
+///   DATABASE_PORT     = 5432
+///   DATABASE_NAME     = ferriskey
+///   DATABASE_USER     = ferriskey
+///   DATABASE_PASSWORD = ferriskey
+#[cfg(test)]
+mod tests {
+    use std::{env, sync::Arc};
+
+    use axum::Router;
+    use axum::http::HeaderValue;
+    use axum_test::TestServer;
+    use ferriskey_api::{
+        application::http::server::{app_state::AppState, http_server::router},
+        args::Args,
+    };
+    use ferriskey_core::{
+        application::create_service,
+        domain::common::{
+            DatabaseConfig, FerriskeyConfig, entities::StartupConfig, ports::CoreService,
+        },
+    };
+    use serde_json::Value;
+    use sqlx::Executor;
+    use uuid::Uuid;
+
+    fn env_or(key: &str, default: &str) -> String {
+        env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+
+    fn env_u16_or(key: &str, default: u16) -> u16 {
+        env::var(key)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
+    }
+
+    struct SharedContext {
+        app: std::sync::Mutex<Router>,
+        realm_name: String,
+        #[allow(dead_code)]
+        pool: sqlx::PgPool,
+    }
+
+    static RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    static CTX: std::sync::OnceLock<SharedContext> = std::sync::OnceLock::new();
+
+    fn rt() -> &'static tokio::runtime::Runtime {
+        RUNTIME.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build shared runtime")
+        })
+    }
+
+    fn ctx() -> &'static SharedContext {
+        CTX.get_or_init(|| rt().block_on(async { setup().await }))
+    }
+
+    async fn setup() -> SharedContext {
+        let db_host = env_or("DATABASE_HOST", "localhost");
+        let db_port = env_u16_or("DATABASE_PORT", 5432);
+        let db_name = env_or("DATABASE_NAME", "ferriskey");
+        let db_user = env_or("DATABASE_USER", "ferriskey");
+        let db_password = env_or("DATABASE_PASSWORD", "ferriskey");
+
+        let schema = format!("test_seawatch_{}", Uuid::new_v4().simple());
+        let admin_url = format!(
+            "postgres://{}:{}@{}:{}/{}",
+            db_user, db_password, db_host, db_port, db_name
+        );
+
+        let admin_pool = sqlx::PgPool::connect(&admin_url)
+            .await
+            .expect("connect admin pool");
+        admin_pool
+            .execute(format!("CREATE SCHEMA IF NOT EXISTS \"{}\"", schema).as_str())
+            .await
+            .expect("create schema");
+
+        let schema_url = format!(
+            "postgres://{}:{}@{}:{}/{}?options=-c search_path={}",
+            db_user,
+            db_password,
+            db_host,
+            db_port,
+            db_name,
+            urlencoding::encode(&schema)
+        );
+        let pool = sqlx::PgPool::connect(&schema_url)
+            .await
+            .expect("connect schema pool");
+        sqlx::migrate!("../core/migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+
+        let svc = create_service(FerriskeyConfig {
+            webapp_url: "http://localhost:5555".to_string(),
+            database: DatabaseConfig {
+                host: db_host,
+                port: db_port,
+                username: db_user,
+                password: db_password,
+                name: db_name,
+                schema: schema.clone(),
+            },
+        })
+        .await
+        .expect("create service");
+
+        let realm_name = format!("test-realm-{}", Uuid::new_v4().simple());
+        svc.initialize_application(StartupConfig {
+            webapp_url: "http://localhost:5555".to_string(),
+            master_realm_name: realm_name.clone(),
+            admin_username: "admin".to_string(),
+            admin_email: "admin@ferriskey.test".to_string(),
+            admin_password: "admin_pass_1234!".to_string(),
+            default_client_id: "ferriskey-admin".to_string(),
+        })
+        .await
+        .expect("initialize application");
+
+        let args = Arc::new(Args::default());
+        let state = AppState::new(args, svc);
+        let app = router(state).expect("build router");
+
+        SharedContext {
+            app: std::sync::Mutex::new(app),
+            realm_name,
+            pool,
+        }
+    }
+
+    fn server() -> TestServer {
+        let app = ctx().app.lock().expect("lock app mutex").clone();
+        TestServer::new(app).expect("build test server")
+    }
+
+    fn auth_header(token: &str) -> HeaderValue {
+        format!("Bearer {}", token)
+            .parse()
+            .expect("valid header value")
+    }
+
+    async fn login(server: &TestServer, realm_name: &str) -> String {
+        let token_resp = server
+            .post(&format!(
+                "/realms/{}/protocol/openid-connect/token",
+                realm_name
+            ))
+            .form(&[
+                ("grant_type", "password"),
+                ("client_id", "admin-cli"),
+                ("username", "admin"),
+                ("password", "admin_pass_1234!"),
+                ("scope", "openid profile"),
+            ])
+            .await;
+
+        assert_eq!(
+            token_resp.status_code(),
+            200,
+            "password grant failed: {}",
+            token_resp.text()
+        );
+
+        let body: Value = token_resp.json();
+        body["access_token"]
+            .as_str()
+            .expect("access_token")
+            .to_string()
+    }
+
+    async fn create_user(srv: &TestServer, realm: &str, token: &str, username: &str) {
+        let resp = srv
+            .post(&format!("/realms/{}/users", realm))
+            .add_header("Authorization", auth_header(token))
+            .json(&serde_json::json!({
+                "username": username,
+                "firstname": "Test",
+                "lastname": "User",
+                "email": format!("{username}@ferriskey.test"),
+                "email_verified": true,
+            }))
+            .await;
+
+        assert_eq!(
+            resp.status_code(),
+            200,
+            "user creation failed: {}",
+            resp.text()
+        );
+    }
+
+    async fn security_events(srv: &TestServer, realm: &str, token: &str, query: &str) -> Value {
+        let path = if query.is_empty() {
+            format!("/realms/{}/seawatch/v1/security-events", realm)
+        } else {
+            format!("/realms/{}/seawatch/v1/security-events?{}", realm, query)
+        };
+        let resp = srv
+            .get(&path)
+            .add_header("Authorization", auth_header(token))
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            200,
+            "fetching security events failed: {}",
+            resp.text()
+        );
+        resp.json()
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test seawatch_test -- --ignored"]
+    fn every_stored_event_is_linked_into_the_hash_chain() {
+        let srv = server();
+        let realm = ctx().realm_name.clone();
+        rt().block_on(async {
+            let token = login(&srv, &realm).await;
+
+            let body = security_events(&srv, &realm, &token, "").await;
+            let events = body["data"].as_array().expect("events array");
+
+            let session_created = events
+                .iter()
+                .find(|e| e["event_type"] == "session_created")
+                .expect("a session_created event was recorded for the login above");
+
+            assert!(
+                !session_created["event_hash"].is_null(),
+                "session_created event has no event_hash — the chain was not built: {session_created}"
+            );
+            assert!(
+                !session_created["prev_hash"].is_null(),
+                "session_created event has no prev_hash — the chain was not built: {session_created}"
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test seawatch_test -- --ignored"]
+    fn event_types_filter_is_actually_applied() {
+        let srv = server();
+        let realm = ctx().realm_name.clone();
+        rt().block_on(async {
+            let token = login(&srv, &realm).await;
+            create_user(&srv, &realm, &token, &format!("filtertest-{}", Uuid::new_v4().simple())).await;
+
+            // Unfiltered: both event types the two actions above produced should be present.
+            let all = security_events(&srv, &realm, &token, "").await;
+            let all_events = all["data"].as_array().expect("events array");
+            assert!(
+                all_events.iter().any(|e| e["event_type"] == "session_created"),
+                "expected a session_created event in the unfiltered page: {all_events:?}"
+            );
+            assert!(
+                all_events.iter().any(|e| e["event_type"] == "user_created"),
+                "expected a user_created event in the unfiltered page: {all_events:?}"
+            );
+
+            // Filtered to user_created only: session_created must not leak through.
+            let filtered = security_events(&srv, &realm, &token, "event_types=user_created").await;
+            let filtered_events = filtered["data"].as_array().expect("events array");
+            assert!(
+                !filtered_events.is_empty(),
+                "expected at least one user_created event: {filtered_events:?}"
+            );
+            assert!(
+                filtered_events.iter().all(|e| e["event_type"] == "user_created"),
+                "the event_types filter was not applied — a non-user_created event leaked through: {filtered_events:?}"
+            );
+        });
+    }
+
+    #[test]
+    #[ignore = "requires PostgreSQL — run with: cargo test -p ferriskey-api --test seawatch_test -- --ignored"]
+    fn limit_is_actually_applied() {
+        let srv = server();
+        let realm = ctx().realm_name.clone();
+        rt().block_on(async {
+            let token = login(&srv, &realm).await;
+            create_user(
+                &srv,
+                &realm,
+                &token,
+                &format!("limittest-{}", Uuid::new_v4().simple()),
+            )
+            .await;
+
+            let limited = security_events(&srv, &realm, &token, "limit=1").await;
+            let events = limited["data"].as_array().expect("events array");
+            assert_eq!(
+                events.len(),
+                1,
+                "limit=1 should return exactly one event: {events:?}"
+            );
+        });
+    }
+}

--- a/core/src/infrastructure/seawatch/mapper.rs
+++ b/core/src/infrastructure/seawatch/mapper.rs
@@ -21,7 +21,14 @@ impl From<security_events::Model> for SecurityEvent {
             _ => None,
         });
 
-        let event_type = parse_event_type(model.event_type.as_str());
+        let event_type = SecurityEventType::parse(model.event_type.as_str());
+        if event_type == SecurityEventType::Unknown {
+            tracing::warn!(
+                security_event_id = %model.id,
+                raw_event_type = model.event_type.as_str(),
+                "security event has an unrecognised event_type; reading it back as Unknown instead of guessing"
+            );
+        }
 
         let status = match model.status.as_str() {
             "success" => EventStatus::Success,
@@ -47,41 +54,6 @@ impl From<security_events::Model> for SecurityEvent {
             event_hash: decode_hash(model.event_hash),
             prev_hash: decode_hash(model.prev_hash),
         }
-    }
-}
-
-/// Inverse of `SecurityEventType`'s `Display`, which is what the write path
-/// persists. Every variant must round-trip through here — see the tests below.
-///
-/// Unknown values fall back to `LoginSuccess` so that a row written by a newer
-/// version does not break reads on an older one.
-fn parse_event_type(raw: &str) -> SecurityEventType {
-    match raw {
-        "login_success" => SecurityEventType::LoginSuccess,
-        "login_failure" => SecurityEventType::LoginFailure,
-        "password_reset" => SecurityEventType::PasswordReset,
-        "password_reset_requested" => SecurityEventType::PasswordResetRequested,
-        "password_reset_completed" => SecurityEventType::PasswordResetCompleted,
-        "user_created" => SecurityEventType::UserCreated,
-        "user_email_verified" => SecurityEventType::UserEmailVerified,
-        "user_deleted" => SecurityEventType::UserDeleted,
-        "role_assigned" => SecurityEventType::RoleAssigned,
-        "role_unassigned" => SecurityEventType::RoleUnassigned,
-        "role_created" => SecurityEventType::RoleCreated,
-        "role_removed" => SecurityEventType::RoleRemoved,
-        "client_created" => SecurityEventType::ClientCreated,
-        "client_deleted" => SecurityEventType::ClientDeleted,
-        "client_secret_rotated" => SecurityEventType::ClientSecretRotated,
-        "client_secret_viewed" => SecurityEventType::ClientSecretViewed,
-        "realm_config_changed" => SecurityEventType::RealmConfigChanged,
-        "email_not_sent" => SecurityEventType::EmailNotSent,
-        "email_sent" => SecurityEventType::EmailSent,
-        "client_maintenance_enabled" => SecurityEventType::ClientMaintenanceEnabled,
-        "client_maintenance_disabled" => SecurityEventType::ClientMaintenanceDisabled,
-        "session_created" => SecurityEventType::SessionCreated,
-        "session_revoked" => SecurityEventType::SessionRevoked,
-        "identity_provider_link_removed" => SecurityEventType::IdentityProviderLinkRemoved,
-        _ => SecurityEventType::LoginSuccess,
     }
 }
 
@@ -141,18 +113,19 @@ mod tests {
         SecurityEventType::SessionCreated,
         SecurityEventType::SessionRevoked,
         SecurityEventType::IdentityProviderLinkRemoved,
+        SecurityEventType::Unknown,
     ];
 
     /// The write path persists `event_type` via `Display` and the read path
-    /// parses it back with `parse_event_type`. If the two ever drift, events
-    /// silently decode as `LoginSuccess` instead of failing loudly — so pin the
-    /// round-trip for every variant.
+    /// parses it back with `SecurityEventType::parse`. If the two ever drift,
+    /// a real variant would silently decode as `Unknown` instead of failing
+    /// loudly — so pin the round-trip for every variant.
     #[test]
     fn event_type_round_trips_through_its_persisted_form() {
         for expected in ALL_EVENT_TYPES {
             let persisted = expected.to_string();
             assert_eq!(
-                parse_event_type(&persisted),
+                SecurityEventType::parse(&persisted),
                 *expected,
                 "`{persisted}` did not parse back to the variant that produced it"
             );
@@ -160,10 +133,10 @@ mod tests {
     }
 
     #[test]
-    fn unknown_event_type_falls_back_instead_of_panicking() {
+    fn unknown_event_type_falls_back_to_unknown_instead_of_lying_about_success() {
         assert_eq!(
-            parse_event_type("some_event_from_a_newer_version"),
-            SecurityEventType::LoginSuccess
+            SecurityEventType::parse("some_event_from_a_newer_version"),
+            SecurityEventType::Unknown
         );
     }
 
@@ -196,7 +169,8 @@ mod tests {
                 | SecurityEventType::ClientMaintenanceDisabled
                 | SecurityEventType::SessionCreated
                 | SecurityEventType::SessionRevoked
-                | SecurityEventType::IdentityProviderLinkRemoved => true,
+                | SecurityEventType::IdentityProviderLinkRemoved
+                | SecurityEventType::Unknown => true,
             };
 
             assert!(listed && ALL_EVENT_TYPES.contains(event_type));

--- a/core/src/infrastructure/seawatch/repositories/security_event_postgres_repository.rs
+++ b/core/src/infrastructure/seawatch/repositories/security_event_postgres_repository.rs
@@ -48,46 +48,25 @@ impl PostgresSecurityEventRepository {
 }
 
 impl SecurityEventRepository for PostgresSecurityEventRepository {
-    async fn store_event(&self, event: SecurityEvent) -> Result<(), CoreError> {
+    /// Opens a transaction, fetches the current chain head (latest event for
+    /// the realm ordered by `created_at DESC`) under an exclusive lock,
+    /// computes `event_hash = SHA-256(preimage || prev_hash)`, and inserts in
+    /// the same transaction to keep the chain linear even under concurrent
+    /// writes from multiple API workers (Postgres serialises the writes
+    /// within the txn).
+    async fn store_event(&self, mut event: SecurityEvent) -> Result<(), CoreError> {
         let realm_id: Uuid = event.realm_id.into();
         let pii_cfg = self.load_pii_config(realm_id).await;
-        let event = apply_to_event(event, &pii_cfg);
+        event = apply_to_event(event, &pii_cfg);
 
-        let active_model: security_events::ActiveModel = event.into();
-
-        security_events::Entity::insert(active_model)
-            .exec(&self.db)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to store security event: {}", e);
-                CoreError::InternalServerError
-            })?;
-
-        Ok(())
-    }
-
-    /// Atomically compute and persist the chained event.
-    ///
-    /// The implementation opens a transaction, fetches the current chain head
-    /// (latest event for the realm ordered by `created_at DESC`), computes
-    /// `event_hash = SHA-256(preimage || prev_hash)`, and inserts in the same
-    /// transaction to keep the chain linear even under concurrent writes from
-    /// multiple API workers (Postgres serialises the writes within the txn).
-    async fn store_event_chained(
-        &self,
-        mut event: SecurityEvent,
-    ) -> Result<SecurityEvent, CoreError> {
-        let db = &self.db;
-        let realm_uuid: Uuid = event.realm_id.into();
-
-        let txn = db.begin().await.map_err(|e| {
+        let txn = self.db.begin().await.map_err(|e| {
             tracing::error!("Failed to begin transaction for chained event: {}", e);
             CoreError::InternalServerError
         })?;
 
         // Lock the latest row for this realm so concurrent inserts are serialised.
         let head = security_events::Entity::find()
-            .filter(security_events::Column::RealmId.eq(realm_uuid))
+            .filter(security_events::Column::RealmId.eq(realm_id))
             .order_by_desc(security_events::Column::CreatedAt)
             .lock_exclusive()
             .one(&txn)
@@ -108,7 +87,7 @@ impl SecurityEventRepository for PostgresSecurityEventRepository {
         event.prev_hash = Some(prev_hash);
         event.event_hash = Some(hash);
 
-        let active_model: security_events::ActiveModel = event.clone().into();
+        let active_model: security_events::ActiveModel = event.into();
         security_events::Entity::insert(active_model)
             .exec(&txn)
             .await
@@ -122,7 +101,7 @@ impl SecurityEventRepository for PostgresSecurityEventRepository {
             CoreError::InternalServerError
         })?;
 
-        Ok(event)
+        Ok(())
     }
 
     async fn get_events(

--- a/libs/ferriskey-api-seawatch/Cargo.toml
+++ b/libs/ferriskey-api-seawatch/Cargo.toml
@@ -8,5 +8,7 @@ edition.workspace = true
 ferriskey-api-core = { path = "../ferriskey-api-core" }
 ferriskey-core = { path = "../../core" }
 axum = "0.8.8"
+chrono = { workspace = true }
 serde = "1.0.228"
 utoipa = { version = "5.4.0", features = ["chrono", "uuid"] }
+uuid = { workspace = true }

--- a/libs/ferriskey-api-seawatch/src/handlers/get_security_events.rs
+++ b/libs/ferriskey-api-seawatch/src/handlers/get_security_events.rs
@@ -1,17 +1,59 @@
 use axum::{
     Extension,
-    extract::{Path, State},
+    extract::{Path, Query, State},
 };
+use chrono::{DateTime, Utc};
 use ferriskey_core::domain::{
     authentication::value_objects::Identity,
-    seawatch::{SecurityEvent, ports::SecurityEventService, value_objects::FetchEventsInput},
+    seawatch::{
+        SecurityEvent, SecurityEventFilter, SecurityEventType, ports::SecurityEventService,
+        value_objects::FetchEventsInput,
+    },
 };
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
 
 use ferriskey_api_core::api_entities::api_error::{ApiError, ApiErrorResponse};
 use ferriskey_api_core::api_entities::response::Response;
 use ferriskey_api_core::app_state::AppState;
+
+/// A page of security events is capped at this many rows regardless of what
+/// the caller asks for, so a wide-open query can't be used to pull an entire
+/// realm's audit trail in one request.
+const MAX_LIMIT: u32 = 1000;
+const DEFAULT_LIMIT: u32 = 100;
+
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct GetSecurityEventsQuery {
+    pub actor_id: Option<Uuid>,
+    pub client_id: Option<Uuid>,
+    /// Comma-separated `SecurityEventType` wire values, e.g. `login_failure,session_revoked`.
+    pub event_types: Option<String>,
+    pub from_timestamp: Option<DateTime<Utc>>,
+    pub to_timestamp: Option<DateTime<Utc>>,
+    pub ip_address: Option<String>,
+    pub limit: Option<u32>,
+    pub offset: Option<u32>,
+}
+
+impl From<GetSecurityEventsQuery> for SecurityEventFilter {
+    fn from(query: GetSecurityEventsQuery) -> Self {
+        Self {
+            user_id: None,
+            client_id: query.client_id,
+            actor_id: query.actor_id,
+            event_types: query
+                .event_types
+                .map(|raw| raw.split(',').map(SecurityEventType::parse).collect()),
+            from_timestamp: query.from_timestamp,
+            to_timestamp: query.to_timestamp,
+            ip_address: query.ip_address,
+            limit: Some(query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT)),
+            offset: Some(query.offset.unwrap_or(0)),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct GetSecurityEventsResponse {
@@ -25,6 +67,7 @@ pub struct GetSecurityEventsResponse {
     tag = "seawatch",
     params(
         ("realm_name" = String, Path, description = "Realm name"),
+        GetSecurityEventsQuery,
     ),
     responses(
         (status = 200, description = "Security events retrieved successfully", body = GetSecurityEventsResponse),
@@ -37,10 +80,17 @@ pub async fn get_security_events(
     Path(realm_name): Path<String>,
     State(state): State<AppState>,
     Extension(identity): Extension<Identity>,
+    Query(query): Query<GetSecurityEventsQuery>,
 ) -> Result<Response<GetSecurityEventsResponse>, ApiError> {
     let security_events = state
         .service
-        .fetch_events(identity, FetchEventsInput { realm_name })
+        .fetch_events(
+            identity,
+            FetchEventsInput {
+                realm_name,
+                filter: query.into(),
+            },
+        )
         .await
         .map_err(ApiError::from)?;
 

--- a/libs/ferriskey-seawatch/src/entities.rs
+++ b/libs/ferriskey-seawatch/src/entities.rs
@@ -81,6 +81,49 @@ pub enum SecurityEventType {
 
     #[serde(rename = "identity_provider_link_removed")]
     IdentityProviderLinkRemoved,
+
+    /// A row whose persisted `event_type` does not match any known variant —
+    /// a typo, a variant removed in a refactor, or a row written by a newer
+    /// version. Never constructed by write-path code; the read path falls
+    /// back to this instead of guessing a variant, so a corrupt or unknown
+    /// row can never be misread as a successful login. See `parse` below.
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+impl SecurityEventType {
+    /// Parse the wire form written by `Display`. Infallible: a value that
+    /// matches no known variant becomes `Unknown` rather than being guessed
+    /// as some other variant or panicking.
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "login_success" => Self::LoginSuccess,
+            "login_failure" => Self::LoginFailure,
+            "password_reset" => Self::PasswordReset,
+            "password_reset_requested" => Self::PasswordResetRequested,
+            "password_reset_completed" => Self::PasswordResetCompleted,
+            "user_created" => Self::UserCreated,
+            "user_email_verified" => Self::UserEmailVerified,
+            "user_deleted" => Self::UserDeleted,
+            "role_assigned" => Self::RoleAssigned,
+            "role_unassigned" => Self::RoleUnassigned,
+            "role_created" => Self::RoleCreated,
+            "role_removed" => Self::RoleRemoved,
+            "client_created" => Self::ClientCreated,
+            "client_deleted" => Self::ClientDeleted,
+            "client_secret_rotated" => Self::ClientSecretRotated,
+            "client_secret_viewed" => Self::ClientSecretViewed,
+            "realm_config_changed" => Self::RealmConfigChanged,
+            "email_not_sent" => Self::EmailNotSent,
+            "email_sent" => Self::EmailSent,
+            "client_maintenance_enabled" => Self::ClientMaintenanceEnabled,
+            "client_maintenance_disabled" => Self::ClientMaintenanceDisabled,
+            "session_created" => Self::SessionCreated,
+            "session_revoked" => Self::SessionRevoked,
+            "identity_provider_link_removed" => Self::IdentityProviderLinkRemoved,
+            _ => Self::Unknown,
+        }
+    }
 }
 
 impl Display for SecurityEventType {
@@ -116,6 +159,7 @@ impl Display for SecurityEventType {
             SecurityEventType::IdentityProviderLinkRemoved => {
                 write!(f, "identity_provider_link_removed")
             }
+            SecurityEventType::Unknown => write!(f, "unknown"),
         }
     }
 }

--- a/libs/ferriskey-seawatch/src/ports.rs
+++ b/libs/ferriskey-seawatch/src/ports.rs
@@ -25,18 +25,17 @@ pub trait SecurityEventService: Send + Sync {
 
 #[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait SecurityEventRepository: Send + Sync {
-    /// Store an event that has already had its `event_hash` and `prev_hash` populated.
+    /// Store an event, atomically linking it into the realm's tamper-evident
+    /// hash chain: the implementation retrieves the current chain head under
+    /// an exclusive lock, computes `event_hash`/`prev_hash` from it, and
+    /// inserts in the same transaction so concurrent writers stay serialised.
+    /// There is deliberately only one write path — a non-chained `store_event`
+    /// invites a caller to bypass the chain and leave `event_hash`/`prev_hash`
+    /// NULL, which is exactly how the chain went unbuilt before.
     fn store_event(
         &self,
         event: SecurityEvent,
     ) -> impl Future<Output = Result<(), CoreError>> + Send;
-
-    /// Atomically retrieve the current chain head hash for `realm_id`, compute and
-    /// store the new event with correct `event_hash` / `prev_hash` fields.
-    fn store_event_chained(
-        &self,
-        event: SecurityEvent,
-    ) -> impl Future<Output = Result<SecurityEvent, CoreError>> + Send;
 
     fn get_events(
         &self,

--- a/libs/ferriskey-seawatch/src/services.rs
+++ b/libs/ferriskey-seawatch/src/services.rs
@@ -10,7 +10,7 @@ use ferriskey_domain::user::ports::{UserRepository, UserRoleRepository};
 use crate::entities::SecurityEvent;
 use crate::hashing::{VerifyResult, verify_chain};
 use crate::ports::{SecurityEventPolicy, SecurityEventRepository, SecurityEventService};
-use crate::value_objects::{FetchEventsInput, SecurityEventFilter};
+use crate::value_objects::FetchEventsInput;
 
 #[derive(Clone, Debug)]
 pub struct SecurityEventServiceImpl<R, U, C, UR, SE>
@@ -75,12 +75,7 @@ where
 
         let security_events = self
             .security_event_repository
-            .get_events(
-                realm_id,
-                SecurityEventFilter {
-                    ..Default::default()
-                },
-            )
+            .get_events(realm_id, input.filter)
             .await?;
 
         Ok(security_events)

--- a/libs/ferriskey-seawatch/src/value_objects.rs
+++ b/libs/ferriskey-seawatch/src/value_objects.rs
@@ -47,4 +47,5 @@ impl Default for SecurityEventFilter {
 
 pub struct FetchEventsInput {
     pub realm_name: String,
+    pub filter: SecurityEventFilter,
 }


### PR DESCRIPTION
## Summary

Three of the four findings from #1270 — the audit log claiming guarantees it doesn't hold:

- **Unknown event types no longer misread as a successful login.** `SecurityEventType` gets an explicit `Unknown` variant; the mapper falls back to it (with a `tracing::warn!` carrying the raw value) instead of guessing `LoginSuccess`.
- **The tamper-evident hash chain is now actually built.** `store_event`/`store_event_chained` are collapsed into one method — there's no longer a write path that skips chaining, which is exactly how the chain went unbuilt in the first place. PII redaction now runs before hashing on this merged path too.
- **`GET .../seawatch/v1/security-events` applies its own filter.** Query params (`actor_id`, `client_id`, `event_types`, `from_timestamp`, `to_timestamp`, `ip_address`, `limit` capped at 1000, `offset`) are threaded through instead of a hardcoded `SecurityEventFilter::default()`.

Finding 2 (emit `LoginSuccess`/`LoginFailure`) is deliberately out of scope here — it needs a design decision (no-actor case, enumeration risk) and touches the core auth hot path across two duplicated login flows. Tracked separately in #1304.

## Test plan

- [x] `cargo check --workspace`, `cargo clippy --tests` on touched crates — clean
- [x] `cargo test -p ferriskey-seawatch -p ferriskey-core --lib` — 384 + 20 passed
- [x] New integration tests in `api/tests/seawatch_test.rs` against a real Postgres instance (`cargo test -p ferriskey-api --test seawatch_test -- --ignored`): a stored event is linked into the hash chain, `event_types` filter excludes non-matching events, `limit` is honored

Refs #1270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering and pagination for security-event queries, including event type, actor, client, time range, IP address, limit, and offset.
  * Added support for identifying unrecognized security-event types as “Unknown.”
  * Security events are now stored with atomic tamper-evident hash-chain updates.

* **Bug Fixes**
  * Corrected handling of unknown persisted event types to prevent incorrect classification as successful logins.

* **Tests**
  * Added integration coverage for authenticated event retrieval, filtering, pagination, and hash-chain fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->