### PR TITLE
fix(compass): make flow tracing tell the truth

### DIFF
--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -60,6 +60,7 @@ use crate::{
         },
         compass::{
             repositories::{PostgresCompassFlowRepository, PostgresCompassFlowStepRepository},
+            retention::compass_retention_task,
             writer::compass_writer_task,
         },
         db::postgres::{Postgres, PostgresConfig},
@@ -260,6 +261,9 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
         PostgresCompassFlowRepository::new(postgres.get_db()),
         PostgresCompassFlowStepRepository::new(postgres.get_db()),
     ));
+    tokio::spawn(compass_retention_task(PostgresCompassFlowRepository::new(
+        postgres.get_db(),
+    )));
     let flow_recorder = FlowRecorder::new(compass_tx);
 
     let policy = Arc::new(FerriskeyPolicy::new(

--- a/core/src/application/mod.rs
+++ b/core/src/application/mod.rs
@@ -423,6 +423,7 @@ pub async fn create_service(config: FerriskeyConfig) -> Result<ApplicationServic
             otp_enrollment.clone(),
             user_role.clone(),
             token_revocation.clone(),
+            flow_recorder.clone(),
         ),
         user_service: UserServiceImpl::new(
             realm.clone(),

--- a/core/src/domain/abyss/broker_services.rs
+++ b/core/src/domain/abyss/broker_services.rs
@@ -636,7 +636,7 @@ where
         let flow_id = self
             .flow_recorder
             .start_flow(
-                realm.id,
+                &realm,
                 Some(client.client_id.clone()),
                 format!("broker_{}", idp.alias),
                 None,
@@ -660,20 +660,20 @@ where
             input.base_url, realm.name, idp.alias
         );
 
-        let idp_params = {
-            let mut parts = Vec::new();
-            if let Some(c) = &input.code {
-                parts.push(format!("code={}", c));
-            }
-            parts.push(format!("state={}", input.state));
-            if let Some(e) = &input.error {
-                parts.push(format!("error={}", e));
-            }
-            if let Some(ed) = &input.error_description {
-                parts.push(format!("error_description={}", ed));
-            }
-            parts.join("&")
-        };
+        // Only the IdP's own error fields. The callback also carries `code` and
+        // `state`; those are credentials, not diagnostics, and the dashboard
+        // renders whatever lands in this column.
+        let idp_error = [
+            input.error.as_ref().map(|e| format!("error={e}")),
+            input
+                .error_description
+                .as_ref()
+                .map(|d| format!("error_description={d}")),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+        let idp_error = (!idp_error.is_empty()).then(|| idp_error.join("&"));
 
         let cred_start = Utc::now();
         let token_response = match self
@@ -697,7 +697,7 @@ where
                     StepStatus::Success,
                     Some(duration),
                     None,
-                    Some(idp_params.clone()),
+                    None,
                 );
                 response
             }
@@ -709,7 +709,7 @@ where
                     StepStatus::Failure,
                     Some(duration),
                     Some(format!("{:?}", e)),
-                    Some(idp_params),
+                    idp_error,
                 );
                 self.flow_recorder
                     .complete_flow(flow_id, FlowStatus::Failure, duration, None);
@@ -751,9 +751,11 @@ where
             self.auth_session_repository
                 .update_code(auth_session_id, authorization_code.clone())
                 .await?;
-            self.auth_session_repository
-                .update_compass_flow_id(auth_session_id, flow_id.0)
-                .await?;
+            if let Some(ref flow_id) = flow_id {
+                self.auth_session_repository
+                    .update_compass_flow_id(auth_session_id, flow_id.0)
+                    .await?;
+            }
         } else {
             let challenge_method = broker_session
                 .code_challenge_method
@@ -780,7 +782,7 @@ where
                 authenticated: false,
                 webauthn_challenge: None,
                 webauthn_challenge_issued_at: None,
-                compass_flow_id: Some(flow_id.0),
+                compass_flow_id: flow_id.as_ref().map(|id| id.0),
                 code_challenge: broker_session.code_challenge.clone(),
                 code_challenge_method: challenge_method,
             });

--- a/core/src/domain/authentication/services.rs
+++ b/core/src/domain/authentication/services.rs
@@ -2049,43 +2049,39 @@ where
             .await
             .map_err(|e| {
                 warn!("Failed to create JWT for authorization code grant: {:?}", e);
-                if let Some(ref fid) = flow_id {
-                    let duration = (Utc::now() - step_start).num_milliseconds();
-                    self.flow_recorder.record_step(
-                        fid.clone(),
-                        FlowStepName::TokenExchange,
-                        StepStatus::Failure,
-                        Some(duration),
-                        Some(format!("{:?}", e)),
-                        None,
-                    );
-                    self.flow_recorder.complete_flow(
-                        fid.clone(),
-                        FlowStatus::Failure,
-                        duration,
-                        Some(user_id),
-                    );
-                }
+                let duration = (Utc::now() - step_start).num_milliseconds();
+                self.flow_recorder.record_step(
+                    flow_id.clone(),
+                    FlowStepName::TokenExchange,
+                    StepStatus::Failure,
+                    Some(duration),
+                    Some(format!("{:?}", e)),
+                    None,
+                );
+                self.flow_recorder.complete_flow(
+                    flow_id.clone(),
+                    FlowStatus::Failure,
+                    duration,
+                    Some(user_id),
+                );
                 e
             })?;
 
-        if let Some(ref fid) = flow_id {
-            let duration = (Utc::now() - step_start).num_milliseconds();
-            self.flow_recorder.record_step(
-                fid.clone(),
-                FlowStepName::TokenExchange,
-                StepStatus::Success,
-                Some(duration),
-                None,
-                None,
-            );
-            self.flow_recorder.complete_flow(
-                fid.clone(),
-                FlowStatus::Success,
-                duration,
-                Some(user_id),
-            );
-        }
+        let duration = (Utc::now() - step_start).num_milliseconds();
+        self.flow_recorder.record_step(
+            flow_id.clone(),
+            FlowStepName::TokenExchange,
+            StepStatus::Success,
+            Some(duration),
+            None,
+            None,
+        );
+        self.flow_recorder.complete_flow(
+            flow_id.clone(),
+            FlowStatus::Success,
+            duration,
+            Some(user_id),
+        );
 
         self.auth_session_repository
             .update_authenticated(auth_session.id, true)
@@ -2541,31 +2537,27 @@ where
             .await
             .map_err(|e| {
                 warn!("authentication using session code error: {:?}", e);
-                if let Some(ref fid) = flow_id {
-                    let duration = (Utc::now() - step_start).num_milliseconds();
-                    self.flow_recorder.record_step(
-                        fid.clone(),
-                        FlowStepName::CredentialValidation,
-                        StepStatus::Failure,
-                        Some(duration),
-                        Some(format!("{:?}", e)),
-                        None,
-                    );
-                }
+                let duration = (Utc::now() - step_start).num_milliseconds();
+                self.flow_recorder.record_step(
+                    flow_id.clone(),
+                    FlowStepName::CredentialValidation,
+                    StepStatus::Failure,
+                    Some(duration),
+                    Some(format!("{:?}", e)),
+                    None,
+                );
                 e
             })?;
 
-        if let Some(ref fid) = flow_id {
-            let duration = (Utc::now() - step_start).num_milliseconds();
-            self.flow_recorder.record_step(
-                fid.clone(),
-                FlowStepName::CredentialValidation,
-                StepStatus::Success,
-                Some(duration),
-                None,
-                None,
-            );
-        }
+        let duration = (Utc::now() - step_start).num_milliseconds();
+        self.flow_recorder.record_step(
+            flow_id.clone(),
+            FlowStepName::CredentialValidation,
+            StepStatus::Success,
+            Some(duration),
+            None,
+            None,
+        );
 
         self.determine_next_step(auth_result, params.session_code, auth_session)
             .await
@@ -2593,16 +2585,8 @@ where
             .contains(&RequiredAction::ConfigureOtp);
 
         if has_otp_credentials && !needs_configure_otp {
-            if let Some(ref fid) = flow_id {
-                self.flow_recorder.record_step(
-                    fid.clone(),
-                    FlowStepName::MfaChallenge,
-                    StepStatus::Success,
-                    None,
-                    None,
-                    None,
-                );
-            }
+            // No step here: the challenge is only being handed to the user. Whether
+            // they pass it is decided in `challenge_otp`, which records the outcome.
             let token = auth_result.token.ok_or(CoreError::InternalServerError)?;
             let email = self
                 .user_repository
@@ -2616,6 +2600,15 @@ where
                 email,
             ));
         }
+
+        self.flow_recorder.record_step(
+            flow_id.clone(),
+            FlowStepName::MfaChallenge,
+            StepStatus::Skipped,
+            None,
+            None,
+            None,
+        );
 
         self.finalize_authentication(auth_result.user_id, session_code, auth_session)
             .await
@@ -2641,6 +2634,18 @@ where
             })?;
 
         let completion = self.build_auth_completion(&auth_session, &authorization_code)?;
+
+        // The interactive part of the login is over: the user is identified and
+        // holds an authorization code. The flow stays open until the code is
+        // exchanged for a token, which is where it is completed.
+        self.flow_recorder.record_step(
+            auth_session.compass_flow_id.map(FlowId),
+            FlowStepName::Finalize,
+            StepStatus::Success,
+            None,
+            None,
+            None,
+        );
 
         Ok(AuthenticateOutput::complete(
             user_id,
@@ -3331,7 +3336,7 @@ where
         let flow_id = self
             .flow_recorder
             .start_flow(
-                realm.id,
+                &realm,
                 Some(input.client_id.clone()),
                 "authorization_code".to_string(),
                 None,
@@ -3353,7 +3358,7 @@ where
             authenticated: false,
             webauthn_challenge: None,
             webauthn_challenge_issued_at: None,
-            compass_flow_id: Some(flow_id.0),
+            compass_flow_id: flow_id.as_ref().map(|id| id.0),
             code_challenge: input.code_challenge,
             code_challenge_method: input.code_challenge_method,
         };
@@ -3439,22 +3444,22 @@ where
                 e
             })?;
 
-        // For non-code grants, start a new compass flow (code grant uses existing flow from auth session)
+        // The code grant continues the flow the authorize step already opened.
+        // The refresh grant stays untraced for now: it fires on every token
+        // renewal and would dominate the table (see #1307).
         let is_refresh_grant = grant_type == GrantType::RefreshToken;
-        let standalone_flow_id = if !is_code_grant && !is_refresh_grant {
-            Some(
-                self.flow_recorder
-                    .start_flow(
-                        realm.id,
-                        Some(input.client_id.clone()),
-                        grant_type.to_string(),
-                        None,
-                        None,
-                    )
-                    .await,
-            )
-        } else {
+        let standalone_flow_id = if is_code_grant || is_refresh_grant {
             None
+        } else {
+            self.flow_recorder
+                .start_flow(
+                    &realm,
+                    Some(input.client_id.clone()),
+                    grant_type.to_string(),
+                    None,
+                    None,
+                )
+                .await
         };
 
         let params = GrantTypeParams {
@@ -3479,41 +3484,39 @@ where
             ))
             .await;
 
-        if let Some(ref fid) = standalone_flow_id {
-            let duration = (Utc::now() - exchange_start).num_milliseconds();
-            match &result {
-                Ok(_) => {
-                    self.flow_recorder.record_step(
-                        fid.clone(),
-                        FlowStepName::TokenExchange,
-                        StepStatus::Success,
-                        Some(duration),
-                        None,
-                        None,
-                    );
-                    self.flow_recorder.complete_flow(
-                        fid.clone(),
-                        FlowStatus::Success,
-                        duration,
-                        None,
-                    );
-                }
-                Err(error) => {
-                    self.flow_recorder.record_step(
-                        fid.clone(),
-                        FlowStepName::TokenExchange,
-                        StepStatus::Failure,
-                        Some(duration),
-                        Some(format!("{:?}", error)),
-                        None,
-                    );
-                    self.flow_recorder.complete_flow(
-                        fid.clone(),
-                        FlowStatus::Failure,
-                        duration,
-                        None,
-                    );
-                }
+        let duration = (Utc::now() - exchange_start).num_milliseconds();
+        match &result {
+            Ok(_) => {
+                self.flow_recorder.record_step(
+                    standalone_flow_id.clone(),
+                    FlowStepName::TokenExchange,
+                    StepStatus::Success,
+                    Some(duration),
+                    None,
+                    None,
+                );
+                self.flow_recorder.complete_flow(
+                    standalone_flow_id.clone(),
+                    FlowStatus::Success,
+                    duration,
+                    None,
+                );
+            }
+            Err(error) => {
+                self.flow_recorder.record_step(
+                    standalone_flow_id.clone(),
+                    FlowStepName::TokenExchange,
+                    StepStatus::Failure,
+                    Some(duration),
+                    Some(format!("{:?}", error)),
+                    None,
+                );
+                self.flow_recorder.complete_flow(
+                    standalone_flow_id.clone(),
+                    FlowStatus::Failure,
+                    duration,
+                    None,
+                );
             }
         }
 

--- a/core/src/domain/saml/services.rs
+++ b/core/src/domain/saml/services.rs
@@ -385,7 +385,7 @@ where
                 let flow_id = self
                     .flow_recorder
                     .start_flow(
-                        realm.id,
+                        &realm,
                         rejection.client_id,
                         SAML_SSO_GRANT_TYPE.to_string(),
                         None,
@@ -416,7 +416,7 @@ where
         let flow_id = self
             .flow_recorder
             .start_flow(
-                realm.id,
+                &realm,
                 Some(accepted.client.client_id.clone()),
                 SAML_SSO_GRANT_TYPE.to_string(),
                 None,
@@ -440,7 +440,7 @@ where
                 authenticated: false,
                 webauthn_challenge: None,
                 webauthn_challenge_issued_at: None,
-                compass_flow_id: Some(flow_id.0),
+                compass_flow_id: flow_id.as_ref().map(|id| id.0),
                 code_challenge: None,
                 code_challenge_method: None,
             }))
@@ -561,44 +561,34 @@ where
 
         let delivery = self.issue_assertion(&realm, auth_session, &input).await;
 
-        if let Some(flow_id) = flow_id {
-            let duration = elapsed_since(started_at);
+        let duration = elapsed_since(started_at);
 
-            match &delivery {
-                Ok(_) => {
-                    self.flow_recorder.record_step(
-                        flow_id.clone(),
-                        FlowStepName::SamlAssertion,
-                        StepStatus::Success,
-                        Some(duration),
-                        None,
-                        None,
-                    );
+        match &delivery {
+            Ok(_) => {
+                self.flow_recorder.record_step(
+                    flow_id.clone(),
+                    FlowStepName::SamlAssertion,
+                    StepStatus::Success,
+                    Some(duration),
+                    None,
+                    None,
+                );
 
-                    self.flow_recorder.complete_flow(
-                        flow_id,
-                        FlowStatus::Success,
-                        duration,
-                        user_id,
-                    );
-                }
-                Err(error) => {
-                    self.flow_recorder.record_step(
-                        flow_id.clone(),
-                        FlowStepName::SamlAssertion,
-                        StepStatus::Failure,
-                        Some(duration),
-                        Some(error_code(error)),
-                        Some(error.to_string()),
-                    );
+                self.flow_recorder
+                    .complete_flow(flow_id, FlowStatus::Success, duration, user_id);
+            }
+            Err(error) => {
+                self.flow_recorder.record_step(
+                    flow_id.clone(),
+                    FlowStepName::SamlAssertion,
+                    StepStatus::Failure,
+                    Some(duration),
+                    Some(error_code(error)),
+                    Some(error.to_string()),
+                );
 
-                    self.flow_recorder.complete_flow(
-                        flow_id,
-                        FlowStatus::Failure,
-                        duration,
-                        user_id,
-                    );
-                }
+                self.flow_recorder
+                    .complete_flow(flow_id, FlowStatus::Failure, duration, user_id);
             }
         }
 

--- a/core/src/domain/trident/services.rs
+++ b/core/src/domain/trident/services.rs
@@ -4,6 +4,10 @@ use std::{
 };
 
 use chrono::{Duration, Utc};
+use ferriskey_compass::{
+    entities::{FlowId, FlowStepName, StepStatus},
+    recorder::FlowRecorder,
+};
 use ferriskey_domain::generate_uuid_v7;
 use futures::future::try_join_all;
 use hmac::{Hmac, Mac};
@@ -268,6 +272,7 @@ pub struct TridentServiceImpl<
     pub(crate) otp_enrollment_repository: Arc<OER>,
     pub(crate) user_role_repository: Arc<URR>,
     pub(crate) token_revocation: Arc<TRV>,
+    pub(crate) flow_recorder: FlowRecorder,
 }
 
 impl<CR, RC, AS, H, URA, ML, UR, RR, ES, SC, PRT, SE, WH, ETR, TR, PPR, OER, URR, TRV>
@@ -334,6 +339,7 @@ where
         otp_enrollment_repository: Arc<OER>,
         user_role_repository: Arc<URR>,
         token_revocation: Arc<TRV>,
+        flow_recorder: FlowRecorder,
     ) -> Self {
         Self {
             credential_repository,
@@ -355,6 +361,7 @@ where
             otp_enrollment_repository,
             user_role_repository,
             token_revocation,
+            flow_recorder,
         }
     }
 
@@ -1148,6 +1155,7 @@ where
 
         let secret = TotpSecret::from_base32(&otp_credential.secret_data);
 
+        let flow_id = auth_session.compass_flow_id.map(FlowId);
         let is_valid = verify(&secret, &input.code)?;
 
         if !is_valid {
@@ -1155,10 +1163,27 @@ where
                 "invalid OTP code for user: {}",
                 user.email.as_deref().unwrap_or("")
             );
+            self.flow_recorder.record_step(
+                flow_id,
+                FlowStepName::MfaChallenge,
+                StepStatus::Failure,
+                None,
+                Some("invalid_otp_code".to_string()),
+                None,
+            );
             return Err(CoreError::TotpVerificationFailed(
                 "failed to verify OTP".to_string(),
             ));
         }
+
+        self.flow_recorder.record_step(
+            flow_id.clone(),
+            FlowStepName::MfaChallenge,
+            StepStatus::Success,
+            None,
+            None,
+            None,
+        );
 
         let required_actions = self
             .user_required_action_repository
@@ -1183,6 +1208,15 @@ where
 
         let login_url =
             login_url_from(format_auth_completion(&auth_session, &authorization_code)?)?;
+
+        self.flow_recorder.record_step(
+            flow_id,
+            FlowStepName::Finalize,
+            StepStatus::Success,
+            None,
+            None,
+            None,
+        );
 
         Ok(ChallengeOtpOutput {
             login_url: Some(login_url),
@@ -2284,6 +2318,7 @@ mod tests {
                 self.otp_enrollment_repo,
                 self.user_role_repo,
                 self.token_revocation,
+                FlowRecorder::disabled(),
             )
         }
     }

--- a/core/src/infrastructure/compass/mod.rs
+++ b/core/src/infrastructure/compass/mod.rs
@@ -1,3 +1,4 @@
 mod mapper;
 pub mod repositories;
+pub mod retention;
 pub mod writer;

--- a/core/src/infrastructure/compass/repositories/compass_flow_postgres_repository.rs
+++ b/core/src/infrastructure/compass/repositories/compass_flow_postgres_repository.rs
@@ -193,6 +193,24 @@ impl CompassFlowRepository for PostgresCompassFlowRepository {
         Ok(result.rows_affected)
     }
 
+    async fn expire_stale_flows(&self, started_before: DateTime<Utc>) -> Result<u64, CoreError> {
+        let result = compass_flows::Entity::update_many()
+            .col_expr(
+                compass_flows::Column::Status,
+                sea_orm::sea_query::Expr::value(FlowStatus::Expired.to_string()),
+            )
+            .filter(compass_flows::Column::Status.eq(FlowStatus::Pending.to_string()))
+            .filter(compass_flows::Column::StartedAt.lt(started_before.naive_utc()))
+            .exec(&self.db)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to expire stale compass flows: {}", e);
+                CoreError::InternalServerError
+            })?;
+
+        Ok(result.rows_affected)
+    }
+
     async fn get_stats(&self, realm_id: RealmId) -> Result<FlowStats, CoreError> {
         let realm_uuid: Uuid = realm_id.into();
 

--- a/core/src/infrastructure/compass/retention.rs
+++ b/core/src/infrastructure/compass/retention.rs
@@ -1,0 +1,58 @@
+use std::time::Duration as StdDuration;
+
+use chrono::{Duration, Utc};
+use ferriskey_compass::ports::CompassFlowRepository;
+
+/// How long a traced flow is kept before it is deleted.
+pub const FLOW_RETENTION_DAYS: i64 = 30;
+
+/// How long a flow may sit in `pending` before it is considered abandoned.
+///
+/// A login the user walked away from never completes, so without this every
+/// abandoned `/auth` hit would count as an in-progress login forever. Sized
+/// well above any realistic interactive login, including MFA and a detour
+/// through an external IdP.
+pub const PENDING_FLOW_TIMEOUT_HOURS: i64 = 12;
+
+const SWEEP_INTERVAL: StdDuration = StdDuration::from_secs(60 * 60);
+
+/// Applies the Compass retention window: expires abandoned flows, then deletes
+/// flows past the retention horizon.
+///
+/// Failures are logged and the loop continues — a dashboard falling behind on
+/// housekeeping must not take the process down.
+pub async fn compass_retention_task<F>(flow_repo: F)
+where
+    F: CompassFlowRepository,
+{
+    let mut ticker = tokio::time::interval(SWEEP_INTERVAL);
+    // The first tick fires immediately; on a long-running deployment that is
+    // the sweep that clears whatever accumulated while the process was down.
+    loop {
+        ticker.tick().await;
+
+        let now = Utc::now();
+
+        match flow_repo
+            .expire_stale_flows(now - Duration::hours(PENDING_FLOW_TIMEOUT_HOURS))
+            .await
+        {
+            Ok(0) => {}
+            Ok(count) => tracing::info!(count, "Compass retention: expired abandoned flows"),
+            Err(e) => tracing::error!("Compass retention: failed to expire stale flows: {e}"),
+        }
+
+        match flow_repo
+            .purge_old_flows(now - Duration::days(FLOW_RETENTION_DAYS))
+            .await
+        {
+            Ok(0) => {}
+            Ok(count) => tracing::info!(
+                count,
+                retention_days = FLOW_RETENTION_DAYS,
+                "Compass retention: purged flows past the retention window"
+            ),
+            Err(e) => tracing::error!("Compass retention: failed to purge old flows: {e}"),
+        }
+    }
+}

--- a/libs/ferriskey-compass/Cargo.toml
+++ b/libs/ferriskey-compass/Cargo.toml
@@ -15,3 +15,4 @@ uuid = { version = "1.21.0", features = ["serde"] }
 
 [dev-dependencies]
 mockall = "0.14.0"
+tokio = { version = "1", features = ["sync", "macros", "rt"] }

--- a/libs/ferriskey-compass/src/lib.rs
+++ b/libs/ferriskey-compass/src/lib.rs
@@ -1,3 +1,18 @@
+//! Compass — authentication flow tracing for the admin dashboard.
+//!
+//! # Best-effort, by design
+//!
+//! Compass answers "where do logins get stuck?", not "what happened to this
+//! account?". Events are handed to a bounded channel with `try_send` and are
+//! **dropped when the writer falls behind**, so a missing flow or step means
+//! "the server was busy", never "it did not happen". Rows are also purged on a
+//! retention window (see [`ports::CompassFlowRepository::purge_old_flows`]),
+//! and tracing is opt-out per realm via `realm_settings.compass_enabled`.
+//!
+//! None of that is acceptable for an audit trail. Anything that has to survive
+//! backpressure, retention and the toggle belongs in `ferriskey-seawatch`,
+//! which writes synchronously and chains its records.
+
 pub mod entities;
 pub mod ports;
 pub mod recorder;

--- a/libs/ferriskey-compass/src/ports.rs
+++ b/libs/ferriskey-compass/src/ports.rs
@@ -81,9 +81,24 @@ pub trait CompassFlowRepository: Send + Sync {
         filter: FlowFilter,
     ) -> impl Future<Output = Result<i64, CoreError>> + Send;
 
+    /// Deletes flows started before `older_than`, with their steps. Compass is
+    /// a dashboard, not an archive: without a retention window `compass_flows`
+    /// grows for the lifetime of the deployment.
     fn purge_old_flows(
         &self,
         older_than: DateTime<Utc>,
+    ) -> impl Future<Output = Result<u64, CoreError>> + Send;
+
+    /// Marks flows still `pending` since before `started_before` as
+    /// [`FlowStatus::Expired`].
+    ///
+    /// Every abandoned `/auth` hit leaves a flow that nothing will ever
+    /// complete. Left alone they accumulate in `pending_count` and read as
+    /// "logins currently in progress", which is how a dashboard ends up
+    /// reporting thousands of concurrent logins on an idle realm.
+    fn expire_stale_flows(
+        &self,
+        started_before: DateTime<Utc>,
     ) -> impl Future<Output = Result<u64, CoreError>> + Send;
 
     fn get_stats(

--- a/libs/ferriskey-compass/src/recorder.rs
+++ b/libs/ferriskey-compass/src/recorder.rs
@@ -1,8 +1,5 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use chrono::{DateTime, Utc};
-use ferriskey_domain::realm::RealmId;
+use ferriskey_domain::realm::Realm;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
@@ -23,39 +20,32 @@ pub enum CompassEvent {
     },
 }
 
+/// Records authentication flows for the Compass dashboard.
+///
+/// Tracing is opt-out per realm through `realm_settings.compass_enabled`. The
+/// setting is read from the [`Realm`] handed to [`FlowRecorder::start_flow`],
+/// which is the only way to obtain a [`FlowId`]: a caller cannot record steps
+/// for a realm it never started a flow on, so the toggle cannot be bypassed by
+/// reaching for the wrong method.
 #[derive(Clone, Debug)]
 pub struct FlowRecorder {
-    enabled: Arc<AtomicBool>,
     sender: Option<mpsc::Sender<CompassEvent>>,
 }
 
 impl FlowRecorder {
     pub fn new(sender: mpsc::Sender<CompassEvent>) -> Self {
         Self {
-            enabled: Arc::new(AtomicBool::new(true)),
             sender: Some(sender),
         }
     }
 
+    /// A recorder that drops everything, for deployments and tests running
+    /// without a Compass writer behind them.
     pub fn disabled() -> Self {
-        Self {
-            enabled: Arc::new(AtomicBool::new(false)),
-            sender: None,
-        }
-    }
-
-    pub fn set_enabled(&self, value: bool) {
-        self.enabled.store(value, Ordering::Relaxed);
-    }
-
-    pub fn is_enabled(&self) -> bool {
-        self.enabled.load(Ordering::Relaxed)
+        Self { sender: None }
     }
 
     fn send(&self, event: CompassEvent) {
-        if !self.enabled.load(Ordering::Relaxed) {
-            return;
-        }
         if let Some(tx) = &self.sender
             && tx.try_send(event).is_err()
         {
@@ -63,40 +53,58 @@ impl FlowRecorder {
         }
     }
 
+    /// Starts a flow, unless Compass is disabled for this realm.
+    ///
+    /// `None` means "not being traced". Every later call keyed on that `None`
+    /// is a no-op, so a disabled realm cannot emit steps referencing a flow row
+    /// that was never written.
     pub async fn start_flow(
         &self,
-        realm_id: RealmId,
+        realm: &Realm,
         client_id: Option<String>,
         grant_type: String,
         ip_address: Option<String>,
         user_agent: Option<String>,
-    ) -> FlowId {
-        let flow = CompassFlow::new(realm_id, client_id, grant_type, ip_address, user_agent);
-        let id = flow.id.clone();
-
-        if !self.enabled.load(Ordering::Relaxed) {
-            return id;
+    ) -> Option<FlowId> {
+        if !Self::is_enabled_for(realm) {
+            return None;
         }
+
+        let flow = CompassFlow::new(realm.id, client_id, grant_type, ip_address, user_agent);
+        let id = flow.id.clone();
 
         let (ack_tx, ack_rx) = oneshot::channel();
         self.send(CompassEvent::FlowStarted { flow, ack: ack_tx });
 
-        // Wait for the writer to persist the flow before returning,
-        // so that the FK constraint on auth_sessions.compass_flow_id is satisfied.
         let _ = ack_rx.await;
 
-        id
+        Some(id)
+    }
+
+    /// Realms whose settings row predates the toggle (migration
+    /// `20260306000001`) have no stored preference; Compass ships on, so the
+    /// absence of a row keeps tracing rather than silently stopping it.
+    fn is_enabled_for(realm: &Realm) -> bool {
+        realm
+            .settings
+            .as_ref()
+            .map(|settings| settings.compass_enabled)
+            .unwrap_or(true)
     }
 
     pub fn record_step(
         &self,
-        flow_id: FlowId,
+        flow_id: Option<FlowId>,
         step_name: FlowStepName,
         status: StepStatus,
         duration_ms: Option<i64>,
         error_code: Option<String>,
         error_message: Option<String>,
     ) {
+        let Some(flow_id) = flow_id else {
+            return;
+        };
+
         let step = CompassFlowStep::new(
             flow_id,
             step_name,
@@ -111,11 +119,15 @@ impl FlowRecorder {
 
     pub fn complete_flow(
         &self,
-        flow_id: FlowId,
+        flow_id: Option<FlowId>,
         status: FlowStatus,
         duration_ms: i64,
         user_id: Option<Uuid>,
     ) {
+        let Some(flow_id) = flow_id else {
+            return;
+        };
+
         self.send(CompassEvent::FlowCompleted {
             flow_id: flow_id.0,
             status,
@@ -123,5 +135,147 @@ impl FlowRecorder {
             duration_ms,
             user_id,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use ferriskey_domain::realm::{Realm, RealmId, RealmSetting};
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn realm_with_compass(enabled: Option<bool>) -> Realm {
+        let id = RealmId::from(Uuid::new_v4());
+
+        Realm {
+            id,
+            name: "master".to_string(),
+            display_name: None,
+            settings: enabled.map(|compass_enabled| {
+                let mut settings = RealmSetting::new(id, Some("RS256".to_string()));
+                settings.compass_enabled = compass_enabled;
+                settings
+            }),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    /// `start_flow` waits for the writer to acknowledge the new flow, so a test
+    /// that starts one needs something playing the writer's part. Returns the
+    /// flow the recorder emitted, or `None` if it emitted nothing.
+    fn stand_in_writer(
+        mut events: mpsc::Receiver<CompassEvent>,
+    ) -> tokio::task::JoinHandle<Option<CompassFlow>> {
+        tokio::spawn(async move {
+            match events.recv().await {
+                Some(CompassEvent::FlowStarted { flow, ack }) => {
+                    let _ = ack.send(());
+                    Some(flow)
+                }
+                _ => None,
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn a_realm_with_compass_disabled_records_nothing() {
+        let (tx, mut events) = mpsc::channel(16);
+        let recorder = FlowRecorder::new(tx);
+
+        let flow_id = recorder
+            .start_flow(
+                &realm_with_compass(Some(false)),
+                Some("account".to_string()),
+                "authorization_code".to_string(),
+                None,
+                None,
+            )
+            .await;
+
+        assert!(
+            flow_id.is_none(),
+            "a realm that switched Compass off must not open a flow"
+        );
+        assert!(
+            events.try_recv().is_err(),
+            "no event may reach the writer for a disabled realm"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_realm_with_compass_enabled_opens_a_flow() {
+        let (tx, events) = mpsc::channel(16);
+        let recorder = FlowRecorder::new(tx);
+        let realm = realm_with_compass(Some(true));
+        let writer = stand_in_writer(events);
+
+        let flow_id = recorder
+            .start_flow(
+                &realm,
+                Some("account".to_string()),
+                "authorization_code".to_string(),
+                None,
+                None,
+            )
+            .await
+            .expect("an enabled realm opens a flow");
+
+        let flow = writer
+            .await
+            .expect("writer task")
+            .expect("a FlowStarted event");
+
+        assert_eq!(flow.id, flow_id);
+        assert_eq!(flow.realm_id, realm.id);
+        assert_eq!(flow.status, FlowStatus::Pending);
+    }
+
+    /// Realms whose settings row predates migration `20260306000001` carry no
+    /// preference. Compass ships on, so tracing continues rather than silently
+    /// stopping for every realm created before the toggle existed.
+    #[tokio::test]
+    async fn a_realm_without_settings_keeps_tracing() {
+        let (tx, events) = mpsc::channel(16);
+        let recorder = FlowRecorder::new(tx);
+        let writer = stand_in_writer(events);
+
+        let flow_id = recorder
+            .start_flow(
+                &realm_with_compass(None),
+                None,
+                "password".to_string(),
+                None,
+                None,
+            )
+            .await;
+
+        assert!(flow_id.is_some());
+        assert!(writer.await.expect("writer task").is_some());
+    }
+
+    /// The disabled path must stay consistent end to end: a step keyed on a flow
+    /// that was never opened would reference a row that does not exist.
+    #[tokio::test]
+    async fn steps_and_completion_are_no_ops_without_a_flow() {
+        let (tx, mut events) = mpsc::channel(16);
+        let recorder = FlowRecorder::new(tx);
+
+        recorder.record_step(
+            None,
+            FlowStepName::Authorize,
+            StepStatus::Success,
+            None,
+            None,
+            None,
+        );
+        recorder.complete_flow(None, FlowStatus::Success, 12, None);
+
+        assert!(
+            events.try_recv().is_err(),
+            "a step without a flow must not reach the writer"
+        );
     }
 }


### PR DESCRIPTION
Closes #1271.

Compass had a per-realm on/off switch that did nothing, a table with no retention, and a set of steps that were either never recorded or recorded with the wrong meaning.

## The toggle

`realm_settings.compass_enabled` was settable through the API and reached the database, but `FlowRecorder::set_enabled` had no caller. The recorder was a single process-global `AtomicBool`, so the setting could not have been per-realm even if something had called it.

`start_flow` now takes the `&Realm` instead of a `RealmId` and reads the setting itself, returning `Option<FlowId>`. That is the only way to obtain a `FlowId`, and `record_step`/`complete_flow` no-op on `None`, so a caller cannot record steps for a realm it never opened a flow on — a disabled realm can no longer emit steps referencing a flow row that was never written.

Realms whose settings row predates migration `20260306000001` carry no preference; Compass ships on, so those keep tracing rather than silently stopping.

## Retention

`purge_old_flows` had no caller, so `compass_flows` grew for the lifetime of the deployment. Abandoned `/auth` hits made it worse: nothing completes them, so they sat at `pending` forever and inflated `pending_count` in `/compass/v1/stats`, which reads as "logins currently in progress".

Adds `expire_stale_flows` (pending for more than 12h → `FlowStatus::Expired`, a variant nothing produced until now) and runs it with `purge_old_flows` from a retention task spawned next to the writer. Retention is 30 days.

## Steps

- `FlowStepName::Finalize` was emitted by nobody. `finalize_authentication` and the OTP completion path now record it.
- `MfaChallenge` was recorded as `Success` at the point the challenge is *handed to the user*, before they answer it. That step is gone. `challenge_otp` — where the challenge is actually decided — records `Failure` on an invalid code and `Success` on a valid one, and the branch where MFA does not apply records `Skipped`.

## An authorization code in a rendered column

The IdP callback passed its query string as `record_step`'s `error_message` argument, on a `StepStatus::Success` step. That string contained `code=<authorization_code>`, so an OAuth authorization code was landing in a column the Compass dashboard displays. Only the IdP's own `error` and `error_description` are kept now, and only on failure.

## Deliberately out of scope

- `compass_flow_steps` still has no generic details column, and `ip_address`/`user_agent` are still passed as `None` at every call site. Both need a migration or reach into the HTTP layer — tracked in #1307.
- The `refresh_token` grant stays untraced. It fires on every token renewal and would dominate the table; revisiting it needs the retention indexes in #1307 first.

## Verification

`cargo test --workspace` → 1062 passed, 141 ignored. Clippy clean. Four unit tests added on the recorder covering the toggle off, the toggle on, a realm with no settings row, and the no-op path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compass authentication flow tracing now respects each realm’s Compass setting.
  * Added automatic background cleanup: abandoned flows expire after 12 hours, and older records are purged after 30 days.
  * Authentication, OTP, SAML, and broker flows now provide more complete progress and outcome tracking.

* **Privacy**
  * Authorization codes and state values are excluded from identity-provider callback diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->