### PR TITLE
fix(ci): make web_origin_test parallel-safe

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -111,8 +111,13 @@ jobs:
       - name: run cross-realm organization isolation integration tests
         run: cargo test -p ferriskey-api --test organization_cross_realm_test -- --ignored
 
+      # Every test in this file shares one realm, and the CORS origin cache
+      # (RealmOriginCache) is keyed by realm name alone — running them
+      # concurrently races on that shared cache entry. --test-threads=1
+      # keeps the shared-fixture design without touching the cache's
+      # granularity for a test-only concern.
       - name: run web origin integration tests
-        run: cargo test -p ferriskey-api --test web_origin_test -- --ignored
+        run: cargo test -p ferriskey-api --test web_origin_test -- --ignored --test-threads=1
 
       # Self-service account profile (#995, first iteration): GET/PUT /me
       # and the realm-gated username edit.


### PR DESCRIPTION
## Summary

`api/tests/web_origin_test.rs` failed on #1311's CI run, unrelated to that PR's actual diff (self-service account profile). Root cause: every test in the file shares one bootstrapped realm, but `RealmOriginCache` (`libs/ferriskey-api-core/src/cors.rs`) is keyed by realm name alone. Under the default `cargo test` parallelism, two tests mutating web origins on that shared realm race on the same cache entry — `removing_an_origin_stops_the_preflight_immediately` got back the just-deleted origin instead of `None` because a concurrent test's add-then-preflight repopulated the cache after this test's delete-then-invalidate.

Confirmed unrelated to #1311: that PR touches realm settings and user self-service endpoints, neither of which come near web origins or the CORS cache. `main` was green on the commit right before it.

## Fix

`--test-threads=1` for this one CI step. Keeps the shared-realm fixture design (spinning up a fresh schema per test would be needlessly expensive here) without narrowing the cache's granularity for what is purely a test-fixture concern.

## Test plan

- [x] Could not reproduce the race locally in 13 parallel runs (consistent with a low-probability, CI-timing-dependent flake) — the fix is justified by the structural analysis (shared cache key + concurrent mutation), not by reproduction
- [x] `cargo test -p ferriskey-api --test web_origin_test -- --ignored --test-threads=1` — 8/8 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated web origin integration tests to run serially for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->