### PR TITLE
feat: list and revoke active sessions on the account page (second iteration of #995)

### DIFF
--- a/front/src/api/user.api.ts
+++ b/front/src/api/user.api.ts
@@ -60,6 +60,37 @@ export const useUpdateOwnProfile = () => {
   })
 }
 
+export const useGetUserSessions = ({ realm, userId }: GetUserQueryParams) => {
+  return useQuery({
+    ...window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/sessions', {
+      path: {
+        realm_name: realm!,
+        user_id: userId!,
+      },
+    }).queryOptions,
+    enabled: !!userId && !!realm,
+  })
+}
+
+export const useRevokeUserSession = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...window.tanstackApi.mutation(
+      'delete',
+      '/realms/{realm_name}/users/{user_id}/sessions/{session_id}'
+    ).mutationOptions,
+    onSuccess: (_res, variables) => {
+      const keys = window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/sessions', {
+        path: {
+          realm_name: variables.path.realm_name,
+          user_id: variables.path.user_id,
+        },
+      }).queryKey
+      queryClient.invalidateQueries({ queryKey: keys })
+    },
+  })
+}
+
 export const useGetUserCredentials = ({ realm, userId }: GetUserQueryParams) => {
   return useQuery({
     ...window.tanstackApi.get('/realms/{realm_name}/users/{user_id}/credentials', {

--- a/front/src/pages/account/feature/page-account-sessions-feature.tsx
+++ b/front/src/pages/account/feature/page-account-sessions-feature.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react'
+import { useParams } from 'react-router'
+import { toast } from 'sonner'
+import { useGetOwnProfile, useGetUserSessions, useRevokeUserSession } from '@/api/user.api.ts'
+import { authStore } from '@/store/auth.store'
+import { RouterParams } from '@/routes/router'
+import PageAccountSessions from '../ui/page-account-sessions'
+
+function decodeSid(token: string | null): string | null {
+  if (!token) return null
+  try {
+    const payload = token.split('.')[1]
+    if (!payload) return null
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+    const claims = JSON.parse(atob(padded)) as Record<string, unknown>
+    return typeof claims.sid === 'string' ? claims.sid : null
+  } catch {
+    return null
+  }
+}
+
+export default function PageAccountSessionsFeature() {
+  const { realm_name } = useParams<RouterParams>()
+  const { accessToken } = authStore()
+  const { data: profileResponse } = useGetOwnProfile({ realm: realm_name })
+  const userId = profileResponse?.data.id
+
+  const { data: sessionsResponse, isLoading } = useGetUserSessions({
+    realm: realm_name,
+    userId,
+  })
+  const { mutate: revokeSession } = useRevokeUserSession()
+
+  const currentSessionId = useMemo(() => decodeSid(accessToken), [accessToken])
+
+  function handleRevoke(sessionId: string) {
+    if (!realm_name || !userId) return
+    revokeSession(
+      {
+        path: { realm_name, user_id: userId, session_id: sessionId },
+      },
+      {
+        onSuccess: () => toast.success('Session revoked'),
+        onError: (error) => toast.error(error.message),
+      }
+    )
+  }
+
+  if (isLoading || !sessionsResponse) return null
+
+  return (
+    <PageAccountSessions
+      sessions={sessionsResponse.data}
+      currentSessionId={currentSessionId}
+      onRevoke={handleRevoke}
+    />
+  )
+}

--- a/front/src/pages/account/layouts/account-layout.tsx
+++ b/front/src/pages/account/layouts/account-layout.tsx
@@ -1,0 +1,48 @@
+import { Outlet, useLocation, useNavigate, useParams } from 'react-router'
+import { RouterParams } from '@/routes/router'
+
+export default function AccountLayout() {
+  const navigate = useNavigate()
+  const { realm_name } = useParams<RouterParams>()
+  const { pathname } = useLocation()
+
+  const baseUrl = `/realms/${realm_name}/account`
+
+  const tabs = [
+    { key: 'overview', label: 'Personal info', path: baseUrl },
+    { key: 'sessions', label: 'Sessions', path: `${baseUrl}/sessions` },
+  ]
+
+  return (
+    <div className='flex flex-col gap-6 p-8'>
+      <div className='-mx-8 -mt-8 px-8 pt-8 pb-4 border-b'>
+        <h1 className='text-2xl font-bold tracking-tight'>My Account</h1>
+        <p className='text-sm text-muted-foreground mt-1'>
+          Manage your own profile and active sessions.
+        </p>
+      </div>
+
+      <div className='-mx-8 px-8 pb-4 border-b flex items-center gap-2 -mt-2'>
+        {tabs.map((tab) => {
+          const isActive =
+            tab.key === 'overview' ? pathname === baseUrl : pathname.startsWith(tab.path)
+          return (
+            <button
+              key={tab.key}
+              onClick={() => navigate(tab.path)}
+              className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors border ${
+                isActive
+                  ? 'bg-primary/10 text-primary border-primary/40'
+                  : 'bg-transparent text-foreground border-border hover:bg-muted'
+              }`}
+            >
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <Outlet />
+    </div>
+  )
+}

--- a/front/src/pages/account/page-account.tsx
+++ b/front/src/pages/account/page-account.tsx
@@ -1,10 +1,15 @@
 import { Route, Routes } from 'react-router'
+import AccountLayout from './layouts/account-layout'
 import PageAccountFeature from './feature/page-account-feature'
+import PageAccountSessionsFeature from './feature/page-account-sessions-feature'
 
 export default function PageAccountModule() {
   return (
     <Routes>
-      <Route index element={<PageAccountFeature />} />
+      <Route element={<AccountLayout />}>
+        <Route index element={<PageAccountFeature />} />
+        <Route path='sessions' element={<PageAccountSessionsFeature />} />
+      </Route>
     </Routes>
   )
 }

--- a/front/src/pages/account/ui/page-account-sessions.tsx
+++ b/front/src/pages/account/ui/page-account-sessions.tsx
@@ -1,0 +1,103 @@
+import { LogOut, Monitor } from 'lucide-react'
+import { OverviewList } from '@/components/ui/overview-list'
+import { EntityAvatar } from '@/components/ui/entity-avatar'
+import { ConfirmDeleteAlert } from '@/components/confirm-delete-alert'
+import { Button } from '@/components/ui/button'
+import { useConfirmDeleteAlert } from '@/hooks/use-confirm-delete-alert.ts'
+import { Schemas } from '@/api/api.client'
+
+import UserSessionDto = Schemas.UserSessionDto
+
+export interface PageAccountSessionsProps {
+  sessions: UserSessionDto[]
+  currentSessionId: string | null
+  onRevoke: (sessionId: string) => void
+}
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function PageAccountSessions({
+  sessions,
+  currentSessionId,
+  onRevoke,
+}: PageAccountSessionsProps) {
+  const { confirm, ask, close } = useConfirmDeleteAlert()
+
+  const onRowRevoke = (session: UserSessionDto) => {
+    ask({
+      title: 'Revoke session?',
+      description: `This will immediately sign out the session on ${session.user_agent ?? 'this device'}.`,
+      onConfirm: () => {
+        onRevoke(session.id)
+        close()
+      },
+    })
+  }
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <OverviewList
+        data={sessions}
+        title={(n) => `Active sessions (${n})`}
+        emptyLabel='No active sessions.'
+        renderRow={(session) => {
+          const isCurrent = session.id === currentSessionId
+          return (
+            <div className='flex items-center justify-between px-8 py-4 border-b last:border-b-0 hover:bg-muted/40 transition-colors'>
+              <div className='flex items-center gap-4'>
+                <EntityAvatar label={session.user_agent ?? 'device'} color='#6366F1' />
+                <div>
+                  <div className='flex items-center gap-2.5'>
+                    <span className='text-base font-medium flex items-center gap-1.5'>
+                      <Monitor className='h-4 w-4 text-muted-foreground' />
+                      {session.user_agent ?? 'Unknown device'}
+                    </span>
+                    {isCurrent && (
+                      <span className='inline-flex items-center px-2.5 py-0.5 rounded-md border text-xs font-mono border-green-300 text-green-600 bg-green-50 dark:bg-green-500/10 dark:border-green-400/40'>
+                        current
+                      </span>
+                    )}
+                  </div>
+                  <div className='text-sm text-muted-foreground mt-0.5'>
+                    {session.ip_address ?? 'Unknown IP'} · last seen{' '}
+                    {session.last_seen_at ? formatDate(session.last_seen_at) : 'never'} · signed in{' '}
+                    {formatDate(session.created_at)}
+                  </div>
+                </div>
+              </div>
+              <div className='flex items-center gap-2'>
+                {!isCurrent && (
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    className='text-destructive hover:text-destructive hover:bg-destructive/10'
+                    onClick={() => onRowRevoke(session)}
+                  >
+                    <LogOut className='h-4 w-4 mr-1.5' />
+                    Revoke
+                  </Button>
+                )}
+              </div>
+            </div>
+          )
+        }}
+      />
+
+      <ConfirmDeleteAlert
+        title={confirm.title}
+        description={confirm.description}
+        open={confirm.open}
+        onConfirm={confirm.onConfirm}
+        onCancel={close}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Second iteration of #995 (self-service account management, part of epic #992), following #1311 (personal info). Adds a "Sessions" tab to the account page.

**No backend changes.** `UserSessionManagementServiceImpl::list_sessions`/`revoke_session` already bypass the permission check entirely when `actor.id == user_id` — a user has always been able to list/revoke their own sessions through the existing admin-shaped endpoints (`GET/DELETE /realms/{realm_name}/users/{user_id}/sessions[/...]`), it just had no frontend surface. `session_management_test.rs`'s `admin_can_list_own_sessions`/`admin_can_revoke_own_session` already cover this exact self-access path end to end.

- The account page now has a small tabbed layout ("Personal info" / "Sessions"), reusing the existing `OverviewList`/`EntityAvatar`/`ConfirmDeleteAlert` components already used for the admin credentials tab.
- Each session shows device (user agent), IP, last-seen and sign-in time.
- The current session is identified by decoding the access token's `sid` claim client-side and matching it against the listed session ids — it's badged "current" and has no revoke button, so a user can't accidentally sign themselves out from this list.

## Out of scope

"Revoke all except current" bulk action, left for a later iteration if wanted.

## Test plan

- [x] `pnpm exec tsc -b`, `pnpm run lint`, `pnpm run build` — clean, no new warnings
- [x] Manually verified against a locally running API + Postgres: logged in twice to create two sessions, confirmed `GET /realms/master/users/{own_id}/sessions` lists both, confirmed the access token's `sid` claim matches the corresponding session id, revoked the non-current one via `DELETE .../sessions/{id}` and confirmed it disappeared from a subsequent list — the exact sequence the new UI drives
- [x] `cargo check --workspace` — unaffected (no Rust changes)

Refs #995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Sessions section under My Account to view active sign-ins.
  * Session details include device, IP address, sign-in time, and last activity.
  * The current session is clearly identified.
  * Added the ability to revoke other active sessions with confirmation.
  * Added navigation tabs for Personal info and Sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->